### PR TITLE
OMERO.web use client (browser) timezone

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -237,6 +237,18 @@ def identity(x):
     return x
 
 
+def json_or_plain_str(s):
+    """
+    Most omero.web properties are JSON objects but some are plain strings.
+    Use this to allow both JSON objects/strings and plain strings. Obviously
+    this can only be used when the plain string can't also be a JSON object.
+    """
+    try:
+        return json.loads(s)
+    except ValueError:
+        return s
+
+
 def str_slash(s):
     if s is not None:
         s = str(s)
@@ -850,6 +862,15 @@ CUSTOM_SETTINGS_MAPPINGS = {
          "Whether to allow OMERO.web to be loaded in a frame."
          ],
 
+    "omero.web.timezone":
+        ["TIME_ZONE",
+         "UTC",
+         json_or_plain_str,
+         ("Local time zone for this installation. Choices can be found here: "
+          "http://www.postgresql.org/docs/8.1/static/datetime-keywords.html"
+          "#DATETIME-TIMEZONE-SET-TABLE although not all variations may be "
+          "possible on all operating systems. Default ``\"UTC\"``")],
+
     "omero.web.django_additional_settings":
         ["DJANGO_ADDITIONAL_SETTINGS",
          "[]",
@@ -1086,10 +1107,6 @@ report_settings(sys.modules[__name__])
 
 SITE_ID = 1
 
-# Local time zone for this installation. Choices can be found here:
-# http://www.postgresql.org/docs/8.1/static/datetime-keywords.html#DATETIME-TIMEZONE-SET-TABLE
-# although not all variations may be possible on all operating systems.
-TIME_ZONE = 'Europe/London'
 FIRST_DAY_OF_WEEK = 0     # 0-Monday, ... 6-Sunday
 
 # LANGUAGE_CODE: A string representing the language code for this

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -862,7 +862,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
          "Whether to allow OMERO.web to be loaded in a frame."
          ],
 
-    "omero.web.timezone":
+    "omero.web.time_zone":
         ["TIME_ZONE",
          "UTC",
          json_or_plain_str,

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -866,10 +866,10 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["TIME_ZONE",
          "UTC",
          json_or_plain_str,
-         ("Local time zone for this installation. Choices can be found here: "
-          "http://www.postgresql.org/docs/8.1/static/datetime-keywords.html"
-          "#DATETIME-TIMEZONE-SET-TABLE although not all variations may be "
-          "possible on all operating systems. Default ``\"UTC\"``")],
+         ("Time zone for this installation. Choices can be found in the "
+          "``TZ database name`` column of: "
+          "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones "
+          "Default ``\"UTC\"``")],
 
     "omero.web.django_additional_settings":
         ["DJANGO_ADDITIONAL_SETTINGS",

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -871,6 +871,15 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones "
           "Default ``\"UTC\"``")],
 
+    "omero.web.server_returns_utc":
+        ["OMERO_SERVER_RETURNS_UTC",
+         "true",
+         parse_boolean,
+         ("Should OMERO.server date-times be treated as UTC. If ``true`` "
+          "attempt to do client side local time-zone conversion, If "
+          "``false`` assumes date-times returned by OMERO.server are already "
+          "in localtime.")],
+
     "omero.web.django_additional_settings":
         ["DJANGO_ADDITIONAL_SETTINGS",
          "[]",

--- a/omeroweb/webclient/decorators.py
+++ b/omeroweb/webclient/decorators.py
@@ -219,3 +219,8 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['center_plugins'] = c_plugins
 
         context['ome']['user_dropdown'] = settings.USER_DROPDOWN
+
+        if settings.OMERO_SERVER_RETURNS_UTC:
+            context['ome']['datetime_suffix'] = 'Z'
+        else:
+            context['ome']['datetime_suffix'] = ''

--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -717,13 +717,9 @@ OME.formatDate = function formatDate(date) {
         }
         return n;
     }
-    // For consistency with the datetimes in metadata_general.html we have to
-    // assume dates should not be converted using the local timezone. This is
-    // because the datetime returned by OMERO may already be in "localtime",
-    // treating it as UTC ensures no local timezone adjustment is made.
     var d = new Date(date),
-        dt = [d.getUTCFullYear(), padZero(d.getUTCMonth()+1), padZero(d.getUTCDate())].join("-"),
-        tm = [padZero(d.getUTCHours()), padZero(d.getUTCMinutes()), padZero(d.getUTCSeconds())].join(":");
+        dt = [d.getFullYear(), padZero(d.getMonth()+1), padZero(d.getDate())].join("-"),
+        tm = [padZero(d.getHours()), padZero(d.getMinutes()), padZero(d.getSeconds())].join(":");
     return dt + " " + tm;
 };
 

--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -717,7 +717,8 @@ OME.formatDate = function formatDate(date) {
         }
         return n;
     }
-    var d = new Date(date),
+    // OMERO_DATETIME_SUFFIX: "Z" for UTC, "" for localtime
+    var d = new Date(date + OMERO_DATETIME_SUFFIX),
         dt = [d.getFullYear(), padZero(d.getMonth()+1), padZero(d.getDate())].join("-"),
         tm = [padZero(d.getHours()), padZero(d.getMinutes()), padZero(d.getSeconds())].join(":");
     return dt + " " + tm;

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -444,6 +444,12 @@
                     }
 
                 {% endif %}
+
+
+                $('[data-isodate]').each(function() {
+                    $(this).text(OME.formatDate($(this).data('isodate')));
+                });
+
             });
             
     </script>
@@ -519,8 +525,8 @@
                 <table>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date'>{{ manager.dataset.getDate|date:"Y-m-d H:i:s" }}</td>
-                    </tr>                    
+                        <td id='creation_date' data-isodate='{{ manager.dataset.getDate|date:"c" }}Z'></td>
+                    </tr>
                 </table>
                 </div>
             {% else %}
@@ -546,7 +552,7 @@
                     <table>
                         <tr>
                             <th>Creation Date:</th>
-                            <td id='creation_date'>{{ manager.project.getDate|date:"Y-m-d H:i:s" }}</td>
+                            <td id='creation_date' data-isodate='{{ manager.project.getDate|date:"c" }}Z'></td>
                         </tr>
                     </table>
                     </div>
@@ -587,15 +593,15 @@
                 <table>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date'>{{ manager.acquisition.getDate|date:"Y-m-d H:i:s" }}</td>
+                        <td id='creation_date' data-isodate='{{ manager.acquisition.getDate|date:"c" }}Z'></td>
                     </tr>
                     <tr>
                         <th>Start Time:</th>
-                        <td>{{ manager.acquisition.getStartTime|date:"Y-m-d H:i:s" }}</td>
+                        <td data-isodate='{{ manager.acquisition.getStartTime|date:"c" }}Z'></td>
                     </tr>
                     <tr>
                         <th>End Time:</th>
-                        <td>{{ manager.acquisition.getEndTime|date:"Y-m-d H:i:s" }}</td>
+                        <td data-isodate='{{ manager.acquisition.getEndTime|date:"c" }}Z'></td>
                     </tr>
                 </table>
                 </div>
@@ -624,7 +630,7 @@
                     <table>
                         <tr>
                             <th>Creation Date:</th>
-                            <td id='creation_date'>{{ manager.plate.getDate|date:"Y-m-d H:i:s" }}</td>
+                            <td id='creation_date' data-isodate='{{ manager.plate.getDate|date:"c" }}Z'></td>
                         </tr>
                         <!--{% comment %}
                         <tr>
@@ -658,8 +664,8 @@
                         <table>
                             <tr>
                                 <th>Creation Date:</th>
-                                <td id='creation_date'>{{ manager.screen.getDate|date:"Y-m-d H:i:s" }}</td>
-                            </tr>                    
+                                <td id='creation_date' data-isodate='{{ manager.screen.getDate|date:"c" }}Z'></td>
+                            </tr>
                             <tr>
                                 <th>Plate Count:</th>
                                 <td id='child_count'>{{ manager.screen.countChildren }} {% plural manager.screen.countChildren 'plate' 'plates' %}</td>
@@ -726,7 +732,7 @@
                     </tr>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date'>{{ manager.tag.getDate|date:"Y-m-d H:i:s" }}</td>
+                        <td id='creation_date' data-isodate='{{ manager.tag.getDate|date:"c" }}Z'></td>
                     </tr>
                     <tr>
                         <th>Image Count:</th>

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -525,7 +525,7 @@
                 <table>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date' data-isodate='{{ manager.dataset.getDate|date:"c" }}Z'></td>
+                        <td id='creation_date' data-isodate='{{ manager.dataset.getDate|date:"c" }}'></td>
                     </tr>
                 </table>
                 </div>
@@ -552,7 +552,7 @@
                     <table>
                         <tr>
                             <th>Creation Date:</th>
-                            <td id='creation_date' data-isodate='{{ manager.project.getDate|date:"c" }}Z'></td>
+                            <td id='creation_date' data-isodate='{{ manager.project.getDate|date:"c" }}'></td>
                         </tr>
                     </table>
                     </div>
@@ -593,15 +593,15 @@
                 <table>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date' data-isodate='{{ manager.acquisition.getDate|date:"c" }}Z'></td>
+                        <td id='creation_date' data-isodate='{{ manager.acquisition.getDate|date:"c" }}'></td>
                     </tr>
                     <tr>
                         <th>Start Time:</th>
-                        <td data-isodate='{{ manager.acquisition.getStartTime|date:"c" }}Z'></td>
+                        <td data-isodate='{{ manager.acquisition.getStartTime|date:"c" }}'></td>
                     </tr>
                     <tr>
                         <th>End Time:</th>
-                        <td data-isodate='{{ manager.acquisition.getEndTime|date:"c" }}Z'></td>
+                        <td data-isodate='{{ manager.acquisition.getEndTime|date:"c" }}'></td>
                     </tr>
                 </table>
                 </div>
@@ -630,7 +630,7 @@
                     <table>
                         <tr>
                             <th>Creation Date:</th>
-                            <td id='creation_date' data-isodate='{{ manager.plate.getDate|date:"c" }}Z'></td>
+                            <td id='creation_date' data-isodate='{{ manager.plate.getDate|date:"c" }}'></td>
                         </tr>
                         <!--{% comment %}
                         <tr>
@@ -664,7 +664,7 @@
                         <table>
                             <tr>
                                 <th>Creation Date:</th>
-                                <td id='creation_date' data-isodate='{{ manager.screen.getDate|date:"c" }}Z'></td>
+                                <td id='creation_date' data-isodate='{{ manager.screen.getDate|date:"c" }}'></td>
                             </tr>
                             <tr>
                                 <th>Plate Count:</th>
@@ -732,7 +732,7 @@
                     </tr>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date' data-isodate='{{ manager.tag.getDate|date:"c" }}Z'></td>
+                        <td id='creation_date' data-isodate='{{ manager.tag.getDate|date:"c" }}'></td>
                     </tr>
                     <tr>
                         <th>Image Count:</th>

--- a/omeroweb/webclient/templates/webclient/base/base.html
+++ b/omeroweb/webclient/templates/webclient/base/base.html
@@ -30,6 +30,11 @@
     <!-- required for the script_launch html below -->
     {% include "webclient/base/includes/script_launch_head.html" %}
 
+    <!-- Required for client-side javascript timezone calculations -->
+    <script type="text/javascript">
+        var OMERO_DATETIME_SUFFIX = "{{ ome.datetime_suffix }}";
+    </script>
+
     <script type="text/javascript" src="{% static "webclient/javascript/ome.webclient.actions.js"|add:url_suffix %}"></script>
 
     <!-- The following are required by the right-hand panel, E.g. annotations/metadata_general.html -->

--- a/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -49,6 +49,11 @@
     <!-- required for the script_launch html below -->
     {% include "webclient/base/includes/script_launch_head.html" %}
 
+    <!-- Required for client-side javascript timezone calculations -->
+    <script type="text/javascript">
+        var OMERO_DATETIME_SUFFIX = "{{ ome.datetime_suffix }}";
+    </script>
+
     <script type="text/javascript" src="{% static "webclient/javascript/ome.webclient.actions.js"|add:url_suffix %}"></script>
     <script src="{% static 'webclient/javascript/jquery.infieldlabel-0.1.js' %}" type="text/javascript"></script>
 

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -469,7 +469,7 @@ def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
 def _marshal_date(time):
     try:
         d = datetime.fromtimestamp(old_div(time, 1000))
-        return d.isoformat() + 'Z'
+        return d.isoformat()
     except ValueError:
         return ''
 


### PR DESCRIPTION
Just testing a possible way of porting PRs:
`curl -sSL https://github.com/ome/openmicroscopy/pull/6010.patch | sed 's%/components/tools/OmeroWeb/%/%g' | git am`

Ported from https://github.com/ome/openmicroscopy/pull/6010

----

# What this PR does

This is an alternative solution to https://github.com/openmicroscopy/openmicroscopy/pull/5786 (and it reverts https://github.com/openmicroscopy/openmicroscopy/pull/6009)
@pwalczysko @will-moore 

This PR moves all OMERO.web datetime processing to the client browser using Javascript, which can optionally take account of the client's timezone. In cases where the timestamps were previously rendered with Django they are now stored as a `data-isodate` HTML attribute, and are automatically converted for display by `OME.formatDate`.

# Two configurations should be tested

## 1. All timestamps are UTC

The assumption is that the backend OMERO.server stores all timestamps in UTC. The timestamps are then converted to the client browsers local timezone for display. This is done client-side using Javascript, the OMERO.web server does not need to care about the client's locality, and this should therefore work for clients in multiple timezones.

OMERO.web configuration (this is the default in this PR):
```
omero config set omero.web.server_returns_utc true
```

### Current timezone
Open a browser. Create objects (e.g. projects, annotations) in OMERO.web. Check that the displayed timestamps are as expected. If they are not please verify that OMERO.server really is using UTC by requesting the timestamps using the OMERO API (e.g. Python BlitzGateway) and checking the raw timestamps.

### Different timezone
Fly to Australia, if you are using a Mac your laptop may auto-configure itself for the new timezone, otherwise update it in system preferences. If this is not possible you may be able to simulate a different timezone, e.g. On OS X with Chrome:
```
mkdir $HOME/chrome-profile
TZ='Australia/ACT' open -na "Google Chrome" --args "--user-data-dir=$HOME/chrome-profile"
```
Look at the objects created in the previous step, the timestamps should be adjusted to the new timezone. Note you can only have one instance of chrome using this custom profile directory.


## 2. Timestamps are localtime

The assumption is that the backend OMERO.server stores all timestamps in the client's timezone. Therefore no conversion is done when it is displayed in the browser. Obviously if you have clients in multiple timezones, of if the server timezone is not the same as the clients, they will all see the wrong time.

OMERO.web configuration:
```
omero config set omero.web.server_returns_utc false
```

As before open a browser in your current and different timezones. You should see that the displayed timestamps are always the same.

# Other notes
This PR changes the default OMERO.web timezone to `UTC` since nothing else really makes sense. I'm not sure if it makes sense for it to be configurable, but I guess there's no harm.

# Background

- https://github.com/openmicroscopy/openmicroscopy/pull/5786#issuecomment-484155143
- https://trello.com/c/HEXZNdSC/227-omeroweb-default-timezone-is-different-from-omeroserver
