### PR TITLE
Ship AGPL with the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ recursive-include omeroweb/webclient/templates *
 recursive-include omeroweb/webgateway/static *
 recursive-include omeroweb/webgateway/templates *
 recursive-include omeroweb/templates *
+include omeroweb/license/agpl-3.0.txt


### PR DESCRIPTION
When comparing the current dev2 on pypi in decouple-python to the state of https://github.com/joshmoore/omero.dist/tree/5.5 (latest 5.5.1 release), then the only significant missing file is this license:

```
build@0326ff289264:/src/dist$ git --git-dir=/dist/.git status | grep -v IPython | grep -v pyc | grep -v modified
HEAD detached at origin/5.5
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	deleted:    .gitmodules
	deleted:    lib/python/omeroweb/.gitignore
	deleted:    lib/python/omeroweb/license/agpl-3.0.txt
```