### PR TITLE
Use pkg_resources to locate nginx templates

### DIFF
--- a/omero/plugins/web.py
+++ b/omero/plugins/web.py
@@ -19,6 +19,7 @@ import re
 from functools import wraps
 from omero_ext.argparse import SUPPRESS
 from path import path
+from pkg_resources import resource_string
 
 from omero.install.windows_warning import windows_warning, WINDOWS_WARNING
 from omero.install.python_warning import py27_only, PYTHON_WARNING
@@ -248,9 +249,6 @@ class WebControl(DiagnosticsControl):
     def _get_fallback_dir(self):
         return self.ctx.dir / "lib" / "fallback"
 
-    def _get_web_templates_dir(self):
-        return self.ctx.dir / "etc" / "templates" / "web"
-
     @config_required
     @assert_config_argtype
     def config(self, args, settings):
@@ -304,7 +302,7 @@ class WebControl(DiagnosticsControl):
                          "wsgi or wsgi-tcp.")
 
         template_file = "%s.conf.template" % server
-        c = file(self._get_web_templates_dir() / template_file).read()
+        c = resource_string('omeroweb', 'templates/' + template_file)
         self.ctx.out(c % d)
 
     def syncmedia(self, args):

--- a/test/unit/reference_templates/nginx-development-withoptions.conf
+++ b/test/unit/reference_templates/nginx-development-withoptions.conf
@@ -1,0 +1,69 @@
+# 
+# nginx userland template
+# this configuration is designed for running nginx as the omero user or similar
+# nginx -c etc/nginx.conf
+# for inclusion in a system-wide nginx configuration see omero web config nginx
+#
+pid /home/omero/OMERO.server/var/pid.nginx;
+error_log /home/omero/OMERO.server/var/log/nginx_error.log;
+worker_processes  5;
+working_directory /home/omero/OMERO.server/var;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    access_log    /home/omero/OMERO.server/var/log/nginx_access.log;
+    include       /home/omero/OMERO.server/etc/mime.types;
+    default_type  application/octet-stream;
+    client_body_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+
+    keepalive_timeout 65;
+
+    upstream omeroweb_test {
+        server 0.0.0.0:12345 fail_timeout=0;
+    }
+    
+    server {
+        listen 1234;
+        server_name _;
+        proxy_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+
+        sendfile on;
+        client_max_body_size 2m;
+
+        # maintenance page serve from here
+        location @maintenance_test {
+            root /home/omero/OMERO.server/etc/templates/error;
+            try_files $uri /maintainance.html =502;
+        }
+
+        # weblitz django apps serve media from here
+        location /test-static {
+            alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+        }
+
+        location @proxy_to_app_test {
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_buffering off;
+
+            proxy_pass http://omeroweb_test;
+        }
+
+        location /test {
+
+            error_page 502 @maintenance_test;
+            # checks for static file, if not found proxy to app
+            try_files $uri @proxy_to_app_test;
+        }
+
+    }
+
+}
+
+

--- a/test/unit/reference_templates/nginx-development.conf
+++ b/test/unit/reference_templates/nginx-development.conf
@@ -1,0 +1,69 @@
+# 
+# nginx userland template
+# this configuration is designed for running nginx as the omero user or similar
+# nginx -c etc/nginx.conf
+# for inclusion in a system-wide nginx configuration see omero web config nginx
+#
+pid /home/omero/OMERO.server/var/pid.nginx;
+error_log /home/omero/OMERO.server/var/log/nginx_error.log;
+worker_processes  5;
+working_directory /home/omero/OMERO.server/var;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    access_log    /home/omero/OMERO.server/var/log/nginx_access.log;
+    include       /home/omero/OMERO.server/etc/mime.types;
+    default_type  application/octet-stream;
+    client_body_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+
+    keepalive_timeout 65;
+
+    upstream omeroweb {
+        server 127.0.0.1:4080 fail_timeout=0;
+    }
+    
+    server {
+        listen 8080;
+        server_name _;
+        proxy_temp_path /home/omero/OMERO.server/var/nginx_tmp;
+
+        sendfile on;
+        client_max_body_size 0;
+
+        # maintenance page serve from here
+        location @maintenance {
+            root /home/omero/OMERO.server/etc/templates/error;
+            try_files $uri /maintainance.html =502;
+        }
+
+        # weblitz django apps serve media from here
+        location /static {
+            alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+        }
+
+        location @proxy_to_app {
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_buffering off;
+
+            proxy_pass http://omeroweb;
+        }
+
+        location / {
+
+            error_page 502 @maintenance;
+            # checks for static file, if not found proxy to app
+            try_files $uri @proxy_to_app;
+        }
+
+    }
+
+}
+
+

--- a/test/unit/reference_templates/nginx-location-withoptions.conf
+++ b/test/unit/reference_templates/nginx-location-withoptions.conf
@@ -1,0 +1,45 @@
+# These location blocks should be included in your server configuration
+# For example:
+#
+##server {
+##    listen 80;
+##    server_name $hostname;
+##
+##    # SSL configuration ...
+##
+##    sendfile on;
+##    client_max_body_size 0;
+##
+##    # Include generated file from omero web config nginx-location:
+##    include /opt/omero/web/omero-web-location.include;
+##}
+
+# maintenance page serve from here
+location @maintenance_test {
+    root /home/omero/OMERO.server/etc/templates/error;
+    try_files $uri /maintainance.html =502;
+}
+
+# weblitz django apps serve media from here
+location /test-static {
+    alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+}
+
+location @proxy_to_app_test {
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_buffering off;
+
+    proxy_pass http://0.0.0.0:12345;
+}
+
+location /test {
+
+    error_page 502 @maintenance_test;
+    # checks for static file, if not found proxy to app
+    try_files $uri @proxy_to_app_test;
+}
+
+

--- a/test/unit/reference_templates/nginx-location.conf
+++ b/test/unit/reference_templates/nginx-location.conf
@@ -1,0 +1,45 @@
+# These location blocks should be included in your server configuration
+# For example:
+#
+##server {
+##    listen 80;
+##    server_name $hostname;
+##
+##    # SSL configuration ...
+##
+##    sendfile on;
+##    client_max_body_size 0;
+##
+##    # Include generated file from omero web config nginx-location:
+##    include /opt/omero/web/omero-web-location.include;
+##}
+
+# maintenance page serve from here
+location @maintenance {
+    root /home/omero/OMERO.server/etc/templates/error;
+    try_files $uri /maintainance.html =502;
+}
+
+# weblitz django apps serve media from here
+location /static {
+    alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+}
+
+location @proxy_to_app {
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_buffering off;
+
+    proxy_pass http://127.0.0.1:4080;
+}
+
+location / {
+
+    error_page 502 @maintenance;
+    # checks for static file, if not found proxy to app
+    try_files $uri @proxy_to_app;
+}
+
+

--- a/test/unit/reference_templates/nginx-withoptions.conf
+++ b/test/unit/reference_templates/nginx-withoptions.conf
@@ -1,0 +1,42 @@
+upstream omeroweb_test {
+    server 0.0.0.0:12345 fail_timeout=0;
+}
+
+server {
+    listen 1234;
+    server_name omeroweb.host;
+
+    sendfile on;
+    client_max_body_size 2m;
+
+    # maintenance page serve from here
+    location @maintenance_test {
+        root /home/omero/OMERO.server/etc/templates/error;
+        try_files $uri /maintainance.html =502;
+    }
+
+    # weblitz django apps serve media from here
+    location /test-static {
+        alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+    }
+
+    location @proxy_to_app_test {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_buffering off;
+
+        proxy_pass http://omeroweb_test;
+    }
+
+    location /test {
+
+        error_page 502 @maintenance_test;
+        # checks for static file, if not found proxy to app
+        try_files $uri @proxy_to_app_test;
+    }
+
+}
+
+

--- a/test/unit/reference_templates/nginx.conf
+++ b/test/unit/reference_templates/nginx.conf
@@ -1,0 +1,42 @@
+upstream omeroweb {
+    server 127.0.0.1:4080 fail_timeout=0;
+}
+
+server {
+    listen 80;
+    server_name $hostname;
+
+    sendfile on;
+    client_max_body_size 0;
+
+    # maintenance page serve from here
+    location @maintenance {
+        root /home/omero/OMERO.server/etc/templates/error;
+        try_files $uri /maintainance.html =502;
+    }
+
+    # weblitz django apps serve media from here
+    location /static {
+        alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+    }
+
+    location @proxy_to_app {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_buffering off;
+
+        proxy_pass http://omeroweb;
+    }
+
+    location / {
+
+        error_page 502 @maintenance;
+        # checks for static file, if not found proxy to app
+        try_files $uri @proxy_to_app;
+    }
+
+}
+
+

--- a/test/unit/test_web.py
+++ b/test/unit/test_web.py
@@ -41,14 +41,6 @@ class TestWeb(object):
         self.cli.register("web", WebControl, "TEST")
         self.args = ["web"]
 
-    def set_templates_dir(self, monkeypatch):
-
-        dist_dir = path(__file__) / ".." / ".." / ".." / ".." / ".." / ".." /\
-            ".." / "dist"  # FIXME: should not be hard-coded
-        dist_dir = dist_dir.abspath()
-        monkeypatch.setattr(WebControl, '_get_web_templates_dir',
-                            lambda x: dist_dir / "etc" / "templates" / "web")
-
     def set_python_path(self, monkeypatch, python_path=None):
         if python_path:
             monkeypatch.setenv('PYTHONPATH', python_path)
@@ -382,7 +374,6 @@ class TestWeb(object):
             self.args += ["--servername", str(servername)]
         if max_body_size:
             self.args += ["--max-body-size", max_body_size]
-        self.set_templates_dir(monkeypatch)
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
         lines = self.clean_generated_file(o)
@@ -425,7 +416,6 @@ class TestWeb(object):
         self.mock_django_setting('STATIC_ROOT', static_root, monkeypatch)
         self.mock_django_setting('APPLICATION_SERVER', app_server, monkeypatch)
         self.args += ["config"] + server_type
-        self.set_templates_dir(monkeypatch)
         self.set_python_path(monkeypatch)
         self.cli.invoke(self.args, strict=True)
 
@@ -460,7 +450,6 @@ class TestWeb(object):
         self.add_hostport(cgihost, cgiport, monkeypatch)
 
         self.args += ["config"] + server_type
-        self.set_templates_dir(monkeypatch)
         self.set_python_path(monkeypatch)
         self.cli.invoke(self.args, strict=True)
 

--- a/test/unit/test_web.py
+++ b/test/unit/test_web.py
@@ -356,7 +356,6 @@ class TestWeb(object):
         assert startout == o.split(os.linesep)[1]
         assert 2 == len(o.split(os.linesep))-1
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize('max_body_size', [None, '0', '1m'])
     @pytest.mark.parametrize('server_type', [
         "nginx", "nginx-development"])
@@ -412,7 +411,6 @@ class TestWeb(object):
                 ], lines)
         assert not missing, 'Line not found: ' + str(missing)
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize('server_type', [
         ["nginx", 'wsgi-tcp'],
         ["nginx-development", 'wsgi-tcp'],
@@ -436,7 +434,6 @@ class TestWeb(object):
         d = self.compare_with_reference(server_type[0] + '.conf', o)
         assert not d, 'Files are different:\n' + d
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize('server_type', [
         ['nginx', '--http', '1234',
          '--servername', 'omeroweb.host',
@@ -473,7 +470,6 @@ class TestWeb(object):
             server_type[0] + '-withoptions.conf', o)
         assert not d, 'Files are different:\n' + d
 
-    @pytest.mark.xfail
     def testNginxLocationComment(self):
         """
         Check the example comment in nginx-location matches the recommended


### PR DESCRIPTION
`omero web config nginx` should now work

Removes 4 of the xfails from https://github.com/ome/omero-web/issues/18, 2 remain