### PR TITLE
Handle lookupLdapAuthExperimenter exception

### DIFF
--- a/omeroweb/webadmin/views.py
+++ b/omeroweb/webadmin/views.py
@@ -53,6 +53,7 @@ from forms import UploadPhotoForm, EmailForm
 from omeroweb.http import HttpJPEGResponse
 from omeroweb.webclient.decorators import login_required, render_response
 from omeroweb.connector import Connector
+from omero import ApiUsageException
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,12 @@ def prepare_experimenter(conn, eid=None):
     defaultGroup = experimenter.getDefaultGroup()
     otherGroups = list(experimenter.getOtherGroups())
     hasAvatar = conn.hasExperimenterPhoto()
-    isLdapUser = experimenter.isLdapUser()
+    try:
+        isLdapUser = experimenter.isLdapUser()
+    except ApiUsageException as x:
+        # e.g. "Cannot find unique user DistinguishedName: found=0"
+        logger.error(traceback.format_exc())
+        isLdapUser = x.message
     return experimenter, defaultGroup, otherGroups, isLdapUser, hasAvatar
 
 

--- a/omeroweb/webadmin/views.py
+++ b/omeroweb/webadmin/views.py
@@ -109,7 +109,7 @@ def prepare_experimenter(conn, eid=None):
         isLdapUser = experimenter.isLdapUser()
     except ApiUsageException as x:
         # e.g. "Cannot find unique user DistinguishedName: found=0"
-        logger.error(traceback.format_exc())
+        logger.info(traceback.format_exc())
         isLdapUser = x.message
     return experimenter, defaultGroup, otherGroups, isLdapUser, hasAvatar
 


### PR DESCRIPTION
See https://github.com/ome/omero-web/issues/23

E.g. for experimenter/edit/id this would still allow the page to load and show message in place of LDAP info:

![Screen Shot 2019-10-03 at 11 05 03](https://user-images.githubusercontent.com/900055/66118912-737be080-e5cf-11e9-894b-c58c5bc2df74.png)

NB: screenshot was created by manually manipulating the code, not via real LDAP testing.
To test: need to fail to look up LDAP user.