### PR TITLE
Avoid parallel table.close() on the same table

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -356,6 +356,7 @@
                     {% endif %}
 
                     var showBulkAnnTooltip = function(data) {
+                        if (!data || !data.id) return;
                         var bulkAnnTooltip = "<span class='tooltip_html' style='display:none'>" +
                             "Data from tables file:<br />" +
                             "<b>File ID:</b> " + data.id + "<br />" +
@@ -391,10 +392,24 @@
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
                             {% if manager.image %}
-                                loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
-                                loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
-                                loadBulkAnnotations(projectQuery, query2, showBulkAnnTooltip);
-                                loadBulkAnnotations(datasetQuery, query2, showBulkAnnTooltip);
+                                // Try query1 and query2 in *series* (not at the same time on same OMERO.table)
+                                // to avoid the table.close() causing errors if in parallel
+                                loadBulkAnnotations(projectQuery, query, function(data) {
+                                    if (data && data.id) {
+                                        showBulkAnnTooltip(data);
+                                    } else {
+                                        // If query1 didn't work, try query2 on the same OMERO.table
+                                        loadBulkAnnotations(projectQuery, query2, showBulkAnnTooltip);
+                                    }
+                                });
+                                loadBulkAnnotations(datasetQuery, query, function(data) {
+                                    if (data && data.id) {
+                                        showBulkAnnTooltip(data);
+                                    } else {
+                                        // If query1 didn't work, try query2 on the same OMERO.table
+                                        loadBulkAnnotations(datasetQuery, query2, showBulkAnnTooltip);
+                                    }
+                                });
                             {% endif %}
                         }
                     });
@@ -408,10 +423,22 @@
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
                             {% if manager.image %}
-                                loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
-                                loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
-                                loadBulkAnnotations(projectQuery, query2, showBulkAnnTooltip);
-                                loadBulkAnnotations(datasetQuery, query2, showBulkAnnTooltip);
+                                loadBulkAnnotations(projectQuery, query, function(data) {
+                                    if (data && data.id) {
+                                        showBulkAnnTooltip(data);
+                                    } else {
+                                        // If query1 didn't work, try query2 on the same OMERO.table
+                                        loadBulkAnnotations(projectQuery, query2, showBulkAnnTooltip);
+                                    }
+                                });
+                                loadBulkAnnotations(datasetQuery, query, function(data) {
+                                    if (data && data.id) {
+                                        showBulkAnnTooltip(data);
+                                    } else {
+                                        // If query1 didn't work, try query2 on the same OMERO.table
+                                        loadBulkAnnotations(datasetQuery, query2, showBulkAnnTooltip);
+                                    }
+                                });
                             {% endif %}
                         }
                     }

--- a/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -350,9 +350,9 @@
                         return '<tr><td class="title ' + oddEvenClass + '">' + label + ':&nbsp;</td><td>' + values + '</td></tr>';
                     });
                     table.html(html.join(""));
-                    if (callback) {
-                        callback(result);
-                    }
+                }
+                if (callback) {
+                    callback(result);
                 }
         });
     };


### PR DESCRIPTION
For tables on Projects or Datasets, we try 2 queries ```image=1``` (lowercase) and ```Image=1``` on the same Table at the same time, which leads to errors. See https://github.com/ome/omero-web/issues/6

This changes the webclient right panel to make each pair of queries run in series instead of parallel.

Screenshot shows calls in Chrome dev-tools before this PR, where we try to load table data on a parent Screen, Plate, Project (x2) and Dataset (x2) all at once. 

![Screen Shot 2019-10-03 at 14 47 58](https://user-images.githubusercontent.com/900055/66132754-7a195080-e5ed-11e9-8ec4-7cab113b7ec4.png)

With this PR, we wait for the first queries on Project and Dataset to return, and if they have no data then we make another call with the alternative query:

![Screen Shot 2019-10-03 at 14 40 45](https://user-images.githubusercontent.com/900055/66132853-9d440000-e5ed-11e9-8f56-2461501f357b.png)

To test, check that table data is shown as expected with no error dialogs.

This can be tested at https://merge-ci.openmicroscopy.org/web/webclient/?show=dataset-4919 (user-3), which was the sample data originally used to replicate the error.
NB: In this data, the first call to get table data from Dataset is successful, so a second call is never made.