### PR TITLE
Annotation marshal: fix Python2/3 compatibility

### DIFF
--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -22,6 +22,7 @@
 import time
 import omero
 from builtins import bytes
+from past.utils import old_div
 
 from omero.rtypes import rlong, unwrap, wrap
 from django.conf import settings
@@ -467,7 +468,7 @@ def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
 
 def _marshal_date(time):
     try:
-        d = datetime.fromtimestamp(time/1000)
+        d = datetime.fromtimestamp(old_div(time, 1000))
         return d.isoformat() + 'Z'
     except ValueError:
         return ''

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -1885,7 +1885,7 @@ def marshal_annotations(conn, project_ids=None, dataset_ids=None,
             exp = _marshal_exp_obj(ann.details.owner)
             experimenters[exp['id']] = exp
 
-    experimenters = experimenters.values()
+    experimenters = list(experimenters.values())
     # sort by id mostly for testing
     experimenters.sort(key=lambda x: x['id'])
 


### PR DESCRIPTION
Required to fix https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/31/testReport/junit/OmeroWeb.test.integration.test_tree_annotations/TestTreeAnnotation

7757875 allows to use `list.sort(key=key)`
97d7e4e  ensures the format of the timestamp returned by `datetime` is identical between Python 2 and Python 3. Without this change, `isoformat()` contains millisecond information.