### PR TITLE
fix csrf reset rendering settings

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2037,7 +2037,7 @@ def reset_rdef_json(request, toOwners=False, conn=None, **kwargs):
         raise Http404("Need to specify objects in request, E.g."
                       " ?totype=dataset&toids=1&toids=2")
 
-    toids = map(lambda x: long(x), toids)
+    toids = [int(id) for id in toids]
 
     rss = conn.getRenderingSettingsService()
 


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/34/testReport/OmeroWeb.test.integration.test_csrf/TestCsrf/test_reset_rendering_settings/