### PR TITLE
list(myColleagues.values()) in webclient search page

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -466,7 +466,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
             g.loadLeadersAndMembers()
             for c in g.leaders + g.colleagues:
                 myColleagues[c.id] = c
-        myColleagues = myColleagues.values()
+        myColleagues = list(myColleagues.values())
         myColleagues.sort(key=lambda x: x.getLastName().lower())
 
     context = {


### PR DESCRIPTION
Fixes webclient search results page - bug reported in https://docs.google.com/spreadsheets/d/1ry6vS0dmsylFQDAiIZDrPC3kXNpnHSMtK-2yj5X8jaU/edit#gid=420881033

"Top right search box is broken. On ihtting <enter>: "AttributeError: 'dict_values' object has no attribute 'sort'"