### PR TITLE
Fix Tag creation in webclient

### DIFF
--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -564,8 +564,8 @@ class BaseContainer(BaseController):
             pass
         if ann is None:
             ann = omero.model.TagAnnotationI()
-            ann.textValue = rstring(tag.encode('utf8'))
-            ann.setDescription(rstring(desc.encode('utf8')))
+            ann.textValue = rstring(tag)
+            ann.setDescription(rstring(desc))
             ann = self.conn.saveAndReturnObject(ann)
             if tag_group_id:  # Put new tag in given tag set
                 tag_group = None


### PR DESCRIPTION
Fix bug reported at:
https://docs.google.com/spreadsheets/d/1ry6vS0dmsylFQDAiIZDrPC3kXNpnHSMtK-2yj5X8jaU/edit#gid=420881033

"Add Tag fails if tag is new: Click on the plus button in Tags harmonice in RHP and try to create a new tag. This fails after clicking "Save" with no error displayed (just a blank form "Send feedback" appears). The addition of tags works if these tags are created previously via the Tags tab."