### PR TITLE
Handle bytes -> json for webgateway.get_thumbnail_json

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1611,7 +1611,8 @@ def get_thumbnail_json(request, iid, w=None, h=None, conn=None, _defcb=None,
     jpeg_data = _render_thumbnail(
         request=request, iid=iid, w=w, h=h,
         conn=conn, _defcb=_defcb, **kwargs)
-    rv = "data:image/jpeg;base64,%s" % base64.b64encode(jpeg_data)
+    rv = "data:image/jpeg;base64,%s" % \
+        base64.b64encode(jpeg_data).decode("utf-8")
     return rv
 
 


### PR DESCRIPTION
Fixes, along with https://github.com/ome/openmicroscopy/pull/6167
 - https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/40/testReport/OmeroWeb.test.integration.test_thumbnails/TestThumbnails/test_base64_thumb_None_/
 - https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/40/testReport/OmeroWeb.test.integration.test_thumbnails/TestThumbnails/test_base64_thumb_100_/
