### PR TITLE
Bump omero-web OME dependencies

### DIFF
--- a/omeroweb/webadmin/views.py
+++ b/omeroweb/webadmin/views.py
@@ -33,7 +33,6 @@ import traceback
 import logging
 import datetime
 
-from past.builtins import long
 import omeroweb.webclient.views
 
 from omeroweb.version import omeroweb_buildyear as build_year

--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,11 @@ setup(name="omero-web",
       packages=find_packages(exclude=("test",))+["omero.plugins"],
       install_requires=[
           # minimum requirements for `omero web start`
-          'omero-py>=5.6.dev1',  # requires Ice (use wheel for faster installs)
+          'omero-py>=5.6.dev2',  # requires Ice (use wheel for faster installs)
           'Django>=1.11,<2.0',
           'django-pipeline==1.6.14',
           'gunicorn>=19.3',
-          'omero-marshal>=0.6.1',
+          'omero-marshal>=0.6.3',
           'Pillow',
       ],
       include_package_data=True,


### PR DESCRIPTION
Increment the minimal versions of the omero-py and omero-marshal packages to include the Python 3 fixes