### PR TITLE
Tox improvements (flake8) and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,22 @@
+---
 sudo: required
-
 language: python
-
-python:
-  - "2.7"
 
 services:
   - docker
 
 before_install:
   - pip install -U pip
-  - pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.0.10/zeroc_ice-3.6.4-cp27-cp27mu-manylinux2010_x86_64.whl
+  - pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
   # https://github.com/ome/openmicroscopy/blob/v5.5.1/Dockerfile#L32
   - pip install flake8==2.4.0
-  - python -c "import Ice; print Ice.stringVersion()"
+  - python -c "import Ice; print(Ice.stringVersion())"
 
 script:
   - flake8
   - python setup.py sdist
   - pip install dist/omero-web*gz
-  - python -c "import omeroweb.version as owv; print owv.omeroweb_version"
+  - python -c "import omeroweb.version as owv; print(owv.omeroweb_version)"
   - docker build -t test .
   - docker run --rm -ti test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ before_install:
   - pip install -U pip
   - pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
   # https://github.com/ome/openmicroscopy/blob/v5.5.1/Dockerfile#L32
-  - pip install flake8==2.4.0
   - python -c "import Ice; print(Ice.stringVersion())"
 
 script:
-  - flake8
   - python setup.py sdist
   - pip install dist/omero-web*gz
   - python -c "import omeroweb.version as owv; print(owv.omeroweb_version)"

--- a/omeroweb/webclient/controller/search.py
+++ b/omeroweb/webclient/controller/search.py
@@ -23,6 +23,7 @@
 # Version: 1.0
 #
 
+from past.builtins import long
 import time
 import omero
 import logging

--- a/omeroweb/webclient/controller/share.py
+++ b/omeroweb/webclient/controller/share.py
@@ -25,6 +25,7 @@
 
 import datetime
 import time
+from past.builtins import long
 
 from omero.rtypes import rtime
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -33,6 +33,7 @@ import json
 import re
 import sys
 import warnings
+from past.builtins import unicode
 
 from io import StringIO
 from time import time

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -20,6 +20,7 @@ import warnings
 from functools import wraps
 import omero
 import omero.clients
+from past.builtins import unicode
 
 from django.http import HttpResponse, HttpResponseBadRequest, \
     HttpResponseServerError, JsonResponse

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,7 @@ requires = pip >= 19.0.0
 deps =
     flake8==2.4.0
     future
-    Django>=1.8,<1.9
     numpy>=1.9
-    Pillow
     pytest
     PyYAML
     py27: tables < 3.6.0
@@ -19,8 +17,6 @@ deps =
     pytest-sugar
     pytest-xdist
     restructuredtext-lint
-    https://github.com/snoopycrimecop/omero-marshal/archive/py3_ci.zip
-    https://github.com/snoopycrimecop/omero-py/archive/py3_ci.zip
     py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ requires = pip >= 19.0.0
 
 [testenv]
 deps =
+    flake8==2.4.0
     future
     Django>=1.8,<1.9
     numpy>=1.9

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ passenv =
     ICE_CONFIG
     PIP_CACHE_DIR
 commands =
+    flake8 .
     rst-lint README.rst
     python setup.py install
     pytest {posargs:-n1 -x -m "not broken" -rf}


### PR DESCRIPTION
While reviewing https://github.com/ome/omero-web/pull/38, I was surprised that the missing imports were not picked up via a minimal check. Executing the `flake8` on Python 3 suffices to flag additional `long` and `unicode` imports which are probably not covered by integration tests.

This PR makes the following changes:

- adds `flake8` to the tox environment defined by `tox.ini` for execution under `py27` and `py36`
-  fixes a few Python 3 flake8 errors by importing the relevant `past.builtins` methods
- cleans up dependencies declared in `tox.ini` redundant with `setup.py`
- uncaps Travis CI to run on Python 3 and removes flake8 (now executed via `tox` under multiple Python environment)