### PR TITLE
Export as png

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -55,6 +55,7 @@ except ImportError:
     long = int
 
 from io import StringIO
+from io import BytesIO
 import tempfile
 
 from omero import ApiUsageException
@@ -1024,22 +1025,26 @@ def render_image(request, iid, z=None, t=None, conn=None, **kwargs):
     if 'download' in kwargs and kwargs['download']:
         if format == 'png':
             # convert jpeg data to png...
-            i = Image.open(StringIO(jpeg_data))
-            output = StringIO()
+            i = Image.open(BytesIO(jpeg_data))
+            output = BytesIO()
             i.save(output, 'png')
             jpeg_data = output.getvalue()
             output.close()
             rsp = HttpResponse(jpeg_data, content_type='image/png')
         elif format == 'tif':
             # convert jpeg data to TIFF
-            i = Image.open(StringIO(jpeg_data))
-            output = StringIO()
+            i = Image.open(BytesIO(jpeg_data))
+            output = BytesIO()
             i.save(output, 'tiff')
             jpeg_data = output.getvalue()
             output.close()
             rsp = HttpResponse(jpeg_data, content_type='image/tiff')
-        fileName = img.getName().decode('utf8').replace(" ", "_")
-        fileName = fileName.replace(",", ".")
+        fileName = img.getName()
+        try:
+            fileName = fileName.decode('utf8')
+        except AttributeError:
+            pass    # python 3
+        fileName = fileName.replace(",", ".").replace(" ", "_")
         rsp['Content-Type'] = 'application/force-download'
         rsp['Content-Length'] = len(jpeg_data)
         rsp['Content-Disposition'] = (

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1090,7 +1090,6 @@ def render_ome_tiff(request, ctx, cid, conn=None, **kwargs):
         imgs.extend(list(obj.listChildren()))
         selection = list(filter(None, request.GET.get(
             'selection', '').split(',')))
-        print(selection)
         if len(selection) > 0:
             logger.debug(selection)
             logger.debug(imgs)

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1088,7 +1088,8 @@ def render_ome_tiff(request, ctx, cid, conn=None, **kwargs):
         if obj is None:
             raise Http404
         imgs.extend(list(obj.listChildren()))
-        selection = list(filter(None, request.GET.get('selection', '').split(',')))
+        selection = list(filter(None, request.GET.get(
+            'selection', '').split(',')))
         print(selection)
         if len(selection) > 0:
             logger.debug(selection)


### PR DESCRIPTION
Fixes: #66 

Also noticed that `render_ome_tiff` was using StringIO and updated this to BytesIO and fixed other issues. I think this is a Glencoe feature that is not exposed in webclient.

To test:
 - download as PNG for single image (multiple images not fixed in this PR)
 - Test OME-TIFF download for Dataset ```/webgateway/render_ome_tiff/d/3753/``` or Image ```/i/``` or Project ```/p/```