### PR TITLE
Extend sleep time for webgateway cachesettings test

### DIFF
--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -270,7 +270,7 @@ class TestWebGatewayCache(object):
                     'abcdefgh'), 'Key %d not properly cached' % i
         assert self.wcache.getThumb(self.request, 'test', uid, 5) is None, (
             'Entries limit failed')
-        time.sleep(2)
+        time.sleep(3)
         assert self.wcache.getThumb(self.request, 'test', uid, 0) is None, (
             'Time limit failed')
 


### PR DESCRIPTION
This unit test has been proven to be intermittently failing with a Time limit failed assertion (see https://travis-ci.org/ome/omero-web/builds/611736343 for an example)

In agreement with the other unit tests, this sets the sleep time to 1 second more than the timeout before testing the cache deletion.