### PR TITLE
download images as zip + CSS fixes

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1032,7 +1032,7 @@
         position: absolute;
         top: -5px;
         right: 15px;
-        z-index: 100;
+        z-index: 10;
     }
     .editableKeyValueTable tr.placeholder td {
         font-style: italic;

--- a/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -449,7 +449,7 @@
 			position: absolute;
 		    visibility: hidden;
 			padding: 5px 0;
-			z-index: 2;
+			z-index: 100;
 		}
 			
 			.dropdown li {

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2426,14 +2426,13 @@ def download_as(request, iid=None, conn=None, **kwargs):
             if not zipName.endswith('.zip'):
                 zipName = "%s.zip" % zipName
 
-            # get file size before it is consumed by FileWrapper
-            file_size = os.path.getsize(temp.name)
             # return the zip or single file
-            imageFile_data = FileWrapper(temp)
-            rsp = HttpResponse(imageFile_data)
-            rsp['Content-Length'] = file_size
+            rsp = ConnCleaningHttpResponse(FileWrapper(temp))
+            rsp.conn = conn
+            rsp['Content-Length'] = temp.tell()
             rsp['Content-Disposition'] = 'attachment; filename=%s' % zipName
-            # temp.seek(0)      # ValueError: I/O operation on closed file
+            temp.seek(0)
+
         except Exception:
             temp.close()
             stack = traceback.format_exc()

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2426,12 +2426,14 @@ def download_as(request, iid=None, conn=None, **kwargs):
             if not zipName.endswith('.zip'):
                 zipName = "%s.zip" % zipName
 
+            # get file size before it is consumed by FileWrapper
+            file_size = os.path.getsize(temp.name)
             # return the zip or single file
             imageFile_data = FileWrapper(temp)
             rsp = HttpResponse(imageFile_data)
-            rsp['Content-Length'] = temp.tell()
+            rsp['Content-Length'] = file_size
             rsp['Content-Disposition'] = 'attachment; filename=%s' % zipName
-            temp.seek(0)
+            # temp.seek(0)      # ValueError: I/O operation on closed file
         except Exception:
             temp.close()
             stack = traceback.format_exc()


### PR DESCRIPTION
When this is working it will fix #72 

See test at https://github.com/ome/openmicroscopy/pull/6179

To test:
 - Select multiple images
 - Download menu -> PNG
 - In dialog, choose zip to download -> should download, unzip to get PNG images

Test was previously failing at https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_download/TestDownloadAsPng/test_download_images_as_zip/

but should now be passing