### PR TITLE
Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# 5.6.dev2 (October 2019)
+
+
+# 5.6.dev1 (October 2019)
+
+
+# 5.5.dev2 (August 2019)
+
+
+# 5.5.dev1 (August 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## API Changes
+
+ - OMERO.web now uses Django 1.11, upgraded from Django 1.8.
+
+ - Urls must be referenced by ```name``` not path.to.view.method (previously some webgateway URLS lacked a name). For example, instead of ```{% url 'webgateway.views.render_image' image_id theZ theT %}```, use ```{% url 'webgateway_render_image' image_id theZ theT %}```.
+
 # 5.6.dev2 (October 2019)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,27 @@
+# 5.6.dev2 (October 2019)
 
 ## API Changes
 
  - OMERO.web now uses Django 1.11, upgraded from Django 1.8.
-
- - Urls must be referenced by ```name``` not path.to.view.method (previously some webgateway URLS lacked a name). For example, instead of ```{% url 'webgateway.views.render_image' image_id theZ theT %}```, use ```{% url 'webgateway_render_image' image_id theZ theT %}```.
-
-# 5.6.dev2 (October 2019)
-
+ - URLs must be referenced by `name` not path.to.view.method (previously
+   some webgateway URLS lacked a name). For example, instead of
+   `{% url 'webgateway.views.render_image' image_id theZ theT %}`, use
+   `{% url 'webgateway_render_image' image_id theZ theT %}`.
 
 # 5.6.dev1 (October 2019)
 
+- First version of python3 support
+- Focus on getting unit tests passing
+- Instructions for dev installation
 
 # 5.5.dev2 (August 2019)
 
+- Improve README
+- Add omeroweb.version
+- Move templates to omeroweb/
+- Bump to omero-py 5.5.1.dev1
 
 # 5.5.dev1 (August 2019)
+
+- Extract code from ome/openmicroscopy
+- Make minimal changes for a functioning `python setup.py` (#1)


### PR DESCRIPTION
On top of https://github.com/ome/omero-web/pull/31

Do we want to remove the various empty ```.dev``` headers instead of trying to retrospectively fill them out?