### PR TITLE
Urls import handling

### DIFF
--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -24,7 +24,7 @@
 #
 
 import logging
-import importlib
+import pkgutil
 from django.conf import settings
 from django.apps import AppConfig
 from django.conf.urls import url, include
@@ -85,7 +85,7 @@ for app in settings.ADDITIONAL_APPS:
         urlmodule = '%s.urls' % app
 
     # Try to import module.urls.py if it exists (not for corsheaders etc)
-    urls_found = importlib.util.find_spec(urlmodule)
+    urls_found = pkgutil.find_loader(urlmodule)
     if urls_found is not None:
         # We don't try/except here since import failure means app won't run
         __import__(urlmodule)

--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -87,10 +87,15 @@ for app in settings.ADDITIONAL_APPS:
     # Try to import module.urls.py if it exists (not for corsheaders etc)
     urls_found = pkgutil.find_loader(urlmodule)
     if urls_found is not None:
-        # We don't try/except here since import failure means app won't run
-        __import__(urlmodule)
-        regex = '^(?i)%s/' % label
-        urlpatterns.append(url(regex, include(urlmodule)))
+        try:
+            __import__(urlmodule)
+            regex = '^(?i)%s/' % label
+            urlpatterns.append(url(regex, include(urlmodule)))
+        except ImportError:
+            print("""Failed to import %s
+Please check if the app is  installed and the versions of the app and OMERO.web are compatible
+            """ % urlmodule)
+            raise
     else:
         logger.debug('Module not found: %s' % urlmodule)
 

--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -93,7 +93,8 @@ for app in settings.ADDITIONAL_APPS:
             urlpatterns.append(url(regex, include(urlmodule)))
         except ImportError:
             print("""Failed to import %s
-Please check if the app is  installed and the versions of the app and OMERO.web are compatible
+Please check if the app is installed and the versions of the app and
+OMERO.web are compatible
             """ % urlmodule)
             raise
     else:


### PR DESCRIPTION
This change means that failure to import ```module.urls.py``` for OMERO.web apps results in a failure of OMERO.web to run. Failure to import the ```module``` itself has always resulted in a failure of OMERO.web to run, but before this PR, import of ```module.urls.py``` fails silently.
This has meant that an app could be "installed" and OMERO.web appear to run OK, but all of the app's URLS are 404 or that ```reverse(url_name)``` fails.

This PR implements the behaviour that I manually applied each time I was working to port an OMERO.web app to python3 where I needed to see import failures at start-time, and not silently result in 404s.
Hopefully this will also help fixing failure of ```reverse("mapr_config")``` etc in integration tests at https://github.com/ome/omero-mapr/pull/54 by causing a failure at an earlier point.

To test, run OMERO.web locally, install an app (e.g figure, iviewer etc) then add an error that causes an ```ImportError```, either in the ```urls.py``` or ```views.py``` and check that OMERO.web fails with ```ImportError```. Could also use a pre-python3 version of figure or iviewer etc.