### PR TITLE
Add omero.web.nginx_server_extra_config

### DIFF
--- a/omero/plugins/web.py
+++ b/omero/plugins/web.py
@@ -276,7 +276,10 @@ class WebControl(DiagnosticsControl):
             "OMEROWEBROOT": self._get_python_dir() / "omeroweb",
             "STATIC_ROOT": settings.STATIC_ROOT,
             "STATIC_URL": settings.STATIC_URL.rstrip("/"),
-            "NOW": str(datetime.now())}
+            "NOW": str(datetime.now()),
+            "NGINX_SERVER_EXTRA_CONFIG": '\n'.join(
+                settings.NGINX_SERVER_EXTRA_CONFIG),
+        }
 
         if server in ("nginx", "nginx-development"):
             d["HTTPPORT"] = port

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -857,6 +857,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Additional Django settings as list of key-value tuples. "
           "Use this to set or override Django settings that aren't managed by "
           "OMERO.web. E.g. ``[\"CUSTOM_KEY\", \"CUSTOM_VALUE\"]``")],
+    "omero.web.nginx_server_extra_config":
+        ["NGINX_SERVER_EXTRA_CONFIG",
+         "[]",
+         json.loads,
+         ("Extra configuration lines to add to the Nginx server block. "
+          "Lines will be joined with \\n. "
+          "Remember to terminate lines with; when necessary.")],
 }
 
 DEPRECATED_SETTINGS_MAPPINGS = {

--- a/omeroweb/templates/nginx-development.conf.template
+++ b/omeroweb/templates/nginx-development.conf.template
@@ -34,6 +34,8 @@ http {
         sendfile on;
         client_max_body_size %(MAX_BODY_SIZE)s;
 
+%(NGINX_SERVER_EXTRA_CONFIG)s
+
         # maintenance page serve from here
         location @maintenance%(PREFIX_NAME)s {
             root %(ROOT)s/etc/templates/error;

--- a/omeroweb/templates/nginx.conf.template
+++ b/omeroweb/templates/nginx.conf.template
@@ -9,6 +9,8 @@ server {
     sendfile on;
     client_max_body_size %(MAX_BODY_SIZE)s;
 
+%(NGINX_SERVER_EXTRA_CONFIG)s
+
     # maintenance page serve from here
     location @maintenance%(PREFIX_NAME)s {
         root %(ROOT)s/etc/templates/error;

--- a/test/unit/reference_templates/nginx-development-withoptions.conf
+++ b/test/unit/reference_templates/nginx-development-withoptions.conf
@@ -34,6 +34,10 @@ http {
         sendfile on;
         client_max_body_size 2m;
 
+listen 443 ssl;
+ssl_certificate /dummy/fullchain.pem;
+ssl_certificate_key /dummy/private.key;
+
         # maintenance page serve from here
         location @maintenance_test {
             root /home/omero/OMERO.server/etc/templates/error;

--- a/test/unit/reference_templates/nginx-development.conf
+++ b/test/unit/reference_templates/nginx-development.conf
@@ -34,6 +34,8 @@ http {
         sendfile on;
         client_max_body_size 0;
 
+
+
         # maintenance page serve from here
         location @maintenance {
             root /home/omero/OMERO.server/etc/templates/error;

--- a/test/unit/reference_templates/nginx-withoptions.conf
+++ b/test/unit/reference_templates/nginx-withoptions.conf
@@ -9,6 +9,10 @@ server {
     sendfile on;
     client_max_body_size 2m;
 
+listen 443 ssl;
+ssl_certificate /dummy/fullchain.pem;
+ssl_certificate_key /dummy/private.key;
+
     # maintenance page serve from here
     location @maintenance_test {
         root /home/omero/OMERO.server/etc/templates/error;

--- a/test/unit/reference_templates/nginx.conf
+++ b/test/unit/reference_templates/nginx.conf
@@ -9,6 +9,8 @@ server {
     sendfile on;
     client_max_body_size 0;
 
+
+
     # maintenance page serve from here
     location @maintenance {
         root /home/omero/OMERO.server/etc/templates/error;

--- a/test/unit/test_web.py
+++ b/test/unit/test_web.py
@@ -444,8 +444,15 @@ class TestWeb(object):
         cgiport = '12345'
         app_server = server_type[-1]
         del server_type[-1]
+        nginx_server_extra = [
+            'listen 443 ssl;',
+            'ssl_certificate /dummy/fullchain.pem;',
+            'ssl_certificate_key /dummy/private.key;',
+        ]
         self.mock_django_setting('STATIC_ROOT', static_root, monkeypatch)
         self.mock_django_setting('APPLICATION_SERVER', app_server, monkeypatch)
+        self.mock_django_setting(
+            'NGINX_SERVER_EXTRA_CONFIG', nginx_server_extra, monkeypatch)
         self.add_prefix(prefix, monkeypatch)
         self.add_hostport(cgihost, cgiport, monkeypatch)
 


### PR DESCRIPTION
Closes https://github.com/ome/omero-web/issues/65

Testing:
```
omero config set omero.web.nginx_server_extra_config '["listen 443 ssl;", "ssl_certificate /dummy/fullchain.pem;", "ssl_certificate_key /dummy/private.key;"]'
omero web config nginx
```
Generated configuration should include
```
listen 443 ssl;
ssl_certificate /dummy/fullchain.pem;
ssl_certificate_key /dummy/private.key;
```