### PR TITLE
Add note about pip install editable omero-py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,7 @@ For a development installation we recommend creating a virtualenv with the follo
 
 This will install OMERO.web into your virtualenv as an editable package, so any edits to source files should be reflected in your installation.
 
-Note you should not install multiple omero modules in editable mode.
-For example do not ``pip install -e`` omero-py and omero-web in the same virtualenv.
+Note some omero-web tests may not run when this module and/or omero-py are installed in editable mode.
 
 Running tests
 -------------

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,9 @@ For a development installation we recommend creating a virtualenv with the follo
     pip install -e .
 
 This will install OMERO.web into your virtualenv as an editable package, so any edits to source files should be reflected in your installation.
-Note that if you add or remove files you must rerun the last step.
+
+Note you should not install multiple omero modules in editable mode.
+For example do not ``pip install -e`` omero-py and omero-web in the same virtualenv.
 
 Running tests
 -------------


### PR DESCRIPTION
If you `pip install e .` in omero-py and/or omero-web some omero-web tests may fail due to `omero.plugins.web` not being found