### PR TITLE
omero-py>=5.6.dev5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name="omero-web",
       packages=find_packages(exclude=("test",))+["omero.plugins"],
       install_requires=[
           # minimum requirements for `omero web start`
-          'omero-py>=5.6.dev4',  # requires Ice (use wheel for faster installs)
+          'omero-py>=5.6.dev5',  # requires Ice (use wheel for faster installs)
           'Django>=1.11,<2.0',
           'django-pipeline==1.6.14',
           'gunicorn>=19.3',


### PR DESCRIPTION
Bump omero-py to https://github.com/ome/omero-py/releases/tag/v5.6.dev5