### PR TITLE
Use config.xml cached at startup in Django settings

### DIFF
--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -49,8 +49,6 @@ from omero.fs import TRANSFERS
 
 from omero.gateway import KNOWN_WRAPPERS
 
-from omero.plugins.admin import AdminControl
-
 from django.utils.encoding import smart_str
 from django.conf import settings
 
@@ -249,14 +247,11 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         Local config settings override client settings sent by the server
         """
         configmap = super(OmeroWebGateway, self).getClientSettings()
-        localcfg = AdminControl().open_config()
-        try:
-            for key in localcfg.keys():
-                if key.startswith('omero.client.'):
-                    configmap[key] = localcfg[key]
-            return configmap
-        finally:
-            localcfg.close()
+        localcfg = settings.CONFIG_XML
+        for key in localcfg.keys():
+            if key.startswith('omero.client.'):
+                configmap[key] = localcfg[key]
+        return configmap
 
     def getEmailSettings(self):
         """


### PR DESCRIPTION
Closes https://github.com/ome/omero-web/issues/75

A nicer alternative to https://github.com/openmicroscopy/openmicroscopy/pull/6053

Testing: on omero.web running separately from omero.server.
```
omero config set omero.client.ui.tree.orphans.name whatever
```

Login as the right kind of user (non-admin, non-group-leader) and `Orphaned images` should be called `whatever`