### PR TITLE
Fix activities clear list

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3499,7 +3499,8 @@ def activities_update(request, action, **kwargs):
                 rv['removed'] = False
             return JsonResponse(rv)
         else:
-            for key, data in request.session['callback'].items():
+            jobs = list(request.session['callback'].items())
+            for key, data in jobs:
                 if data['status'] != "in progress":
                     del request.session['callback'][key]
     return HttpResponse("OK")


### PR DESCRIPTION
Previously this was failing because we were modifying the list while iterating
through it.

To test:
 - Run some scripts or delete something etc to get some items in the Activities dialog
 - Click the "Clear List" button - should see no error.
 - Refresh the page and confirm that the Activities list is empty