### PR TITLE
Fix script results failures

### DIFF
--- a/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
@@ -32,7 +32,8 @@
     }
 
     // this is called by the setInterval loop below
-    OME.activitiesUpdate = function(i) {
+    OME.activitiesUpdate = function() {
+        var i = OME.activitiesInteval;
         $.get("{% url 'activities' %}", function(data) {
             $('#activities_spinner').hide();
             var inprogress = $("#inprogress", data).text();
@@ -42,12 +43,16 @@
             // if we've got no jobs still running, stop checking
             if ((typeof inprogress == 'undefined') || (inprogress.length == 0)) {
                 if (i) clearInterval(i);
+                OME.activitiesInteval = undefined;
                 showJobCount(0);
                 //return;
             }
             inprogress = parseInt( inprogress );
             if (inprogress==0) {
-                if (i != undefined) clearInterval(i);
+                if (i != undefined) {
+                    clearInterval(i);
+                    OME.activitiesInteval = undefined;
+                }
             }
             
             // display what we recieved, bind events etc
@@ -120,10 +125,14 @@
     }
 
     OME.refreshActivities = function() {
-        var i = setInterval(function (){
-                OME.activitiesUpdate(i);
+        console.log("refreshActivities", OME.activitiesInteval);
+        if (OME.activitiesInteval) {
+            return;
+        }
+        OME.activitiesInteval = setInterval(function (){
+                OME.activitiesUpdate();
         }, 5000);
-        OME.activitiesUpdate(i);
+        OME.activitiesUpdate();
     }
     $(document).ready(function() {
         OME.displayStatus(-1);  // reset new_results

--- a/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/activities_info.html
@@ -33,7 +33,7 @@
 
     // this is called by the setInterval loop below
     OME.activitiesUpdate = function() {
-        var i = OME.activitiesInteval;
+        var i = OME.activitiesInterval;
         $.get("{% url 'activities' %}", function(data) {
             $('#activities_spinner').hide();
             var inprogress = $("#inprogress", data).text();
@@ -43,7 +43,7 @@
             // if we've got no jobs still running, stop checking
             if ((typeof inprogress == 'undefined') || (inprogress.length == 0)) {
                 if (i) clearInterval(i);
-                OME.activitiesInteval = undefined;
+                OME.activitiesInterval = undefined;
                 showJobCount(0);
                 //return;
             }
@@ -51,7 +51,7 @@
             if (inprogress==0) {
                 if (i != undefined) {
                     clearInterval(i);
-                    OME.activitiesInteval = undefined;
+                    OME.activitiesInterval = undefined;
                 }
             }
             
@@ -125,11 +125,10 @@
     }
 
     OME.refreshActivities = function() {
-        console.log("refreshActivities", OME.activitiesInteval);
-        if (OME.activitiesInteval) {
+        if (OME.activitiesInterval) {
             return;
         }
-        OME.activitiesInteval = setInterval(function (){
+        OME.activitiesInterval = setInterval(function (){
                 OME.activitiesUpdate();
         }, 5000);
         OME.activitiesUpdate();


### PR DESCRIPTION
This prevents multiple timeouts running at the same time, which allows several simultaneous calls
to get script results, causing race conditions.

See https://forum.image.sc/t/omero-scripts-producing-failed-to-get-results/31601

To test:
 - Run multiple scripts at once. E.g. Open lots of "Batch Image Export" script dialogs and then hit Run on all of them at once.
 - Should get all results returned as expected. No "Failed to get results" as described on forum.
 - Looking at the console Network tab, you should see that we only ping the server once every 5 secs. Previously, each script started it's own 5-second ping. So we were had multiple simultaneous calls to getResults(). Only the first call succeeded, but the Django ```request.session``` containing the results was over-written by the other request. E.g. as described at https://stackoverflow.com/questions/13748166/django-session-race-condition