### PR TITLE
test_web: add 'config parse' test

### DIFF
--- a/test/unit/test_web.py
+++ b/test/unit/test_web.py
@@ -23,6 +23,7 @@ import pytest
 from difflib import unified_diff
 import re
 import os
+import sys
 try:
     from omero_ext.path import path
 except ImportError:
@@ -513,6 +514,7 @@ class TestParse(object):
         self.cli.register("config", PrefsControl, "TEST")
         self.args = ["config"]
 
+    @pytest.mark.xfail(sys.version_info < (3, 0), reason="py2 unicode issue")
     def test_parse(self):
         self.args += ["parse", "--rst"]
         self.cli.invoke(self.args, strict=True)

--- a/test/unit/test_web.py
+++ b/test/unit/test_web.py
@@ -31,6 +31,9 @@ except ImportError:
 import getpass
 import Ice
 import omero.cli
+from omero.plugins.prefs import (
+    PrefsControl
+)
 from omero.plugins.web import (
     APACHE_MOD_WSGI_ERR,
     WebControl
@@ -501,3 +504,15 @@ class TestWeb(object):
             '-proxy_pass http://omeroweb;',
             '+proxy_pass http://127.0.0.1:4080;'
         ]
+
+
+class TestParse(object):
+
+    def setup_method(self, method):
+        self.cli = omero.cli.CLI()
+        self.cli.register("config", PrefsControl, "TEST")
+        self.args = ["config"]
+
+    def test_parse(self):
+        self.args += ["parse", "--rst"]
+        self.cli.invoke(self.args, strict=True)

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,8 @@ passenv =
 commands =
     flake8 .
     rst-lint README.rst
-    python setup.py install
-    pytest {posargs:-n1 -m "not broken" -rf}
+    pip install .
+    pytest {posargs:-rf}
 
 [testenv:py36]
 basepython =


### PR DESCRIPTION
see: https://github.com/ome/omero-py/pull/130#pullrequestreview-323596133

`config parse` requires web settings to be present. Adding a test to this repo. This test will fail if the UTF-8 settings of the docker are removed:

```
git diff Dockerfile
diff --git a/Dockerfile b/Dockerfile
index 30b1ea494..740db5a77 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos7
-RUN localedef -i en_US -f UTF-8 en_US.UTF-8
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+#RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+#ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
```

or if the environment variables are removed in tox:

```
git diff tox.ini
diff --git a/tox.ini b/tox.ini
index 1b8e87453..ef20fa3e6 100644
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py36-{utf8,c}
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel
 requires = pip >= 19.0.0
@@ -24,6 +25,8 @@ setenv =
     OMERO_HOME = {toxinidir}
     DJANGO_SETTINGS_MODULE = omeroweb.settings
     PYTHONPATH = {toxinidir}
+    c: LANG=c
+    c: LC_ALL=c
 passenv =
     ICE_CONFIG
     PIP_CACHE_DIR
```