### PR TITLE
Fix handling of exceptions in process_custom_settings

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1036,7 +1036,7 @@ def process_custom_settings(
         except ValueError as e:
             raise ValueError(
                 "Invalid %s (%s = %r). %s. %s" %
-                (global_name, key, global_value, e.message, description))
+                (global_name, key, global_value, e.args[0], description))
         except ImportError as e:
             raise ImportError(
                 "ImportError: %s. %s (%s = %r).\n%s" %


### PR DESCRIPTION
See https://github.com/ome/omero-mapr/pull/57#issuecomment-560472871

To test:
 - set some invalid JSON
 - should see a useful error message on web start (not sure where the Error printing text is coming from, but I saw the same in web-install testing earlier).

```
$ omero config set omero.web.server_list '[["some", "invalid JSON]'
$ omero web start
Error printing text
Invalid SERVER_LIST (omero.web.server_list = '[["some", "invalid JSON]'). Unterminated string starting at: line 1 column 11 (char 10). A list of servers the Web client can connect to.
```

NB: I seem to remember that ```omero config set``` would fail with invalid JSON before? cc @manics