### PR TITLE
Ignore OMERO_HOME in omeroweb/settings.py

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -56,13 +56,13 @@ if 'OMERO_HOME' in os.environ:
     logger.warn("OMERO_HOME usage is deprecated in OMERO.web")
 
 if 'OMERODIR' in os.environ:
-    OMERO_HOME = os.environ.get('OMERODIR')
+    OMERODIR = os.environ.get('OMERODIR')
 else:
-    OMERO_HOME = os.path.join(os.path.dirname(__file__), '..', '..', '..')
-    OMERO_HOME = os.path.normpath(OMERO_HOME)
+    OMERODIR = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+    OMERODIR = os.path.normpath(OMERODIR)
 
 # Logging
-LOGDIR = os.path.join(OMERO_HOME, 'var', 'log').replace('\\', '/')
+LOGDIR = os.path.join(OMERODIR, 'var', 'log').replace('\\', '/')
 
 if not os.path.isdir(LOGDIR):
     try:
@@ -161,7 +161,7 @@ LOGGING = {
 }
 
 
-CONFIG_XML = os.path.join(OMERO_HOME, 'etc', 'grid', 'config.xml')
+CONFIG_XML = os.path.join(OMERODIR, 'etc', 'grid', 'config.xml')
 count = 10
 event = get_event("websettings")
 
@@ -417,7 +417,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " must end in a slash if set to a non-empty value.")],
     "omero.web.static_root":
         ["STATIC_ROOT",
-         os.path.join(OMERO_HOME, 'var', 'static'),
+         os.path.join(OMERODIR, 'var', 'static'),
          os.path.normpath,
          ("The absolute path to the directory where collectstatic will"
           " collect static files for deployment. If the staticfiles contrib"
@@ -1104,7 +1104,7 @@ LANGUAGE_CODE = 'en-gb'
 try:
     SECRET_KEY
 except NameError:
-    secret_path = os.path.join(OMERO_HOME, 'var',
+    secret_path = os.path.join(OMERODIR, 'var',
                                'django_secret_key').replace('\\', '/')
     if not os.path.isfile(secret_path):
         try:

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 # A boolean that turns on/off debug mode.
 # handler404 and handler500 works only when False
 if 'OMERO_HOME' in os.environ:
-    logger.warn("OMERO_HOME usage is deprecated in OMERO.web")
+    logger.warn("OMERO_HOME usage is ignored in OMERO.web")
 
 if 'OMERODIR' in os.environ:
     OMERODIR = os.environ.get('OMERODIR')

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -53,8 +53,9 @@ logger = logging.getLogger(__name__)
 # A boolean that turns on/off debug mode.
 # handler404 and handler500 works only when False
 if 'OMERO_HOME' in os.environ:
-    OMERO_HOME = os.environ.get('OMERO_HOME')
-elif 'OMERODIR' in os.environ:
+    logger.warn("OMERO_HOME usage is deprecated in OMERO.web")
+
+if 'OMERODIR' in os.environ:
     OMERO_HOME = os.environ.get('OMERODIR')
 else:
     OMERO_HOME = os.path.join(os.path.dirname(__file__), '..', '..', '..')

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
 
 setenv =
-    OMERO_HOME = {toxinidir}
+    OMERODIR = {toxinidir}
     DJANGO_SETTINGS_MODULE = omeroweb.settings
     PYTHONPATH = {toxinidir}
 passenv =


### PR DESCRIPTION
See https://forum.image.sc/t/omero-python-3-5-6-milestone-for-upgrade-testing/32120/3

If ``OMERO_HOME`` is set, we should ignore it and show warning:
Same as in ``omero-py``: https://github.com/ome/omero-py/pull/148

To test, setting OMERO_HOME should not break ``omero web start``:
```
$ export OMERO_HOME=/path/to/somewhere
$ omero web start
...
```
