### PR TITLE
Use BytesIO for default thumbnail

### DIFF
--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -86,7 +86,7 @@ def defaultThumbnail(size=(120, 120)):
         size = (size[0], size[0])
     img = Image.open(settings.DEFAULT_IMG)
     img.thumbnail(size, Image.ANTIALIAS)
-    f = StringIO()
+    f = BytesIO()
     img.save(f, "PNG")
     f.seek(0)
     return f.read()


### PR DESCRIPTION
To test, visit ```/webclient/render_thumbnail/{ID}/``` where ```{ID}``` is a random number that is not a valid image ID (not found).

Should see the default thumbnail:

<img width="524" alt="Screen Shot 2020-01-02 at 15 12 24" src="https://user-images.githubusercontent.com/900055/71674140-65766100-2d72-11ea-8214-ec3b859d67fe.png">
