### PR TITLE
Quick fix of the show downloads regex

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -269,7 +269,8 @@ class WebclientLoginView(LoginView):
         if settings.SHOW_CLIENT_DOWNLOADS:
             ver = re.match((r'(?P<major>\d+)\.'
                             r'(?P<minor>\d+)\.'
-                            r'(?P<patch>(dev|a|b|rc)\d+).*'),
+                            r'(?P<patch>\d+\.)?'
+                            r'(?P<dev>(dev|a|b|rc)\d+)?.*'),
                            omero_version)
             client_download_tag_re = '^v%s\\.%s\\.[^-]+$' % (
                 ver.group('major'), ver.group('minor'))

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -269,7 +269,7 @@ class WebclientLoginView(LoginView):
         if settings.SHOW_CLIENT_DOWNLOADS:
             ver = re.match((r'(?P<major>\d+)\.'
                             r'(?P<minor>\d+)\.'
-                            r'(?P<patch>\d+\.)?'
+                            r'(?P<patch>\d+\.?)?'
                             r'(?P<dev>(dev|a|b|rc)\d+)?.*'),
                            omero_version)
             client_download_tag_re = '^v%s\\.%s\\.[^-]+$' % (


### PR DESCRIPTION
The 5.6.0 version is broken for non-dev version strings.
This should handle 5.6.0, 5.6.dev1, and 5.6.0.dev1 style
version strings. Ultimately, this method should either be
refactored out to a util method so we can write unit tests
or removed in favor of a more complete solution a la
https://github.com/ome/design/issues/103