### PR TITLE
Fix and expand "open with" plugin support

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1055,6 +1055,11 @@ $(function() {
                                     });
                                     url = v.getUrl(selJson, v.url);
                                 }
+                                if (typeof url === 'function') {
+                                    // if url is callable, call and return
+                                    url();
+                                    return;
+                                }
                                 // ...otherwise we use default handling...
                                 window.open(url, '_blank');
                             },

--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -1019,10 +1019,9 @@ OME.hideScriptList = function() {
 
 // Helper can be used by 'open with' plugins to add isEnabled()
 // handlers to the OPEN_WITH object.
-OME.setOpenWithEnabledHandler = function(label, fn) {
-    // look for label in OPEN_WITH
+OME.setOpenWithEnabledHandler = function(id, fn) {
     WEBCLIENT.OPEN_WITH.forEach(function(ow){
-        if (ow.label === label) {
+        if (ow.id === id) {
             ow.isEnabled = function() {
                 // wrap fn with try/catch, since error here will break jsTree menu
                 var args = Array.from(arguments);
@@ -1031,7 +1030,7 @@ OME.setOpenWithEnabledHandler = function(label, fn) {
                     enabled = fn.apply(this, args);
                 } catch (e) {
                     // Give user a clue as to what went wrong
-                    console.log("Open with " + label + ": " + e);
+                    console.log("Open with " + id + ": " + e);
                 }
                 return enabled;
             }


### PR DESCRIPTION
This PR fixes a bug in `OME.setOpenWithEnabledHandler` that prevented custom methods to enable/disable menu items from working.

It also adds functionality to allow plugins to not only return custom URL strings, but to return functions that can perform any action when the menu item is selected.