### PR TITLE
Confine projections to no more than 256MiB of raw data

### DIFF
--- a/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1116,7 +1116,10 @@
       // on pixel type byte width
       var bytes_per_pixel = Math.ceil(
         Math.log2(viewport.loadedImg.pixel_range[1]) / 8.0);
-      var stack_size = sizes.width * sizes.height * sizes.z * sizez.c * bytes_per_pixel;
+      var active_channel_count = viewport.loadedImg.channels
+        .filter(function(x) { return x.active }).length;
+      var stack_size = sizes.width * sizes.height * sizes.z
+                       * active_channel_count * bytes_per_pixel;
 
       // disable 'Max Intensity' projection for single-Z images or if total
       // amount of data to be projected is > 256MiB

--- a/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1111,8 +1111,19 @@
         $("#rdef-fullrange-btn").attr("disabled", "disabled").addClass("button-disabled");
       }
 
-      // disable 'Max Intensity' projection for single-Z images
-      var disable_intmax = (viewport.loadedImg.rdefs.invertAxis || viewport.getSizes().z < 2);
+      var sizes = viewport.getSizes();
+      // Currently relies on `pixel_range` coming from the server being based
+      // on pixel type byte width
+      var bytes_per_pixel = Math.ceil(
+        Math.log2(viewport.loadedImg.pixel_range[1]) / 8.0);
+      var stack_size = sizes.width * sizes.height * sizes.z * sizez.c * bytes_per_pixel;
+
+      // disable 'Max Intensity' projection for single-Z images or if total
+      // amount of data to be projected is > 256MiB
+      var disable_intmax = (
+        viewport.loadedImg.rdefs.invertAxis || sizes.z < 2
+        || stack_size > 256 * 1024 * 1024
+      );
       $('[name="wblitz-proj"][value=intmax]').prop('disabled', disable_intmax);
     });
 


### PR DESCRIPTION
# What this PR does

Projections from the OMERO.web default viewer are currently not confined. In 2019 the stack sizes across all active channels can easily be 1-2 GiB which will, on a reasonable machine, result in projection times > minute. The stack size can also be > Java maxint which will result in integer overflows and HTTP 500s.

This PR confines the maximum projection size as 256MiB of raw data, disabling the "Maximum Intensity" viewing option of the viewer if this condition is met.

# Testing this PR

1. Find an image where the projection size as defined as `sizeX * sizeY * sizeZ * activeChannelCount * bytesPerPixel` is greater than 256MiB as well as one that is not

2. Open the viewer

3. Ensure that the "Maximum Intensity" viewing option is disabled or enabled accordingly
