### PR TITLE
Map ann parent ID

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -31,6 +31,11 @@
                       <% print (ann.permissions.canEdit && clientMapAnn ? 'editing' : 'viewing') %>
                       <b><%= ann.parentNames.length %></b> identical Key-Value annotations:
                     <% } %>
+                    <% if (!ann.parentNames) { %>
+                        <!-- If single object show e.g. Image ID: (slice ImageI -> Image) -->
+                        <b><%= ann.link.parent.class.slice(0, ann.link.parent.class.length-1) %>
+                            ID:</b> <%= ann.link.parent.id %><br />
+                    <% } %>
                     <b>Annotation ID<% if (ann.parentNames) { %>s<% } %>:</b> <%= ann.id %><br />
                     <% if (ann.parentNames) { %>
                         <b>Linked to:</b><br>

--- a/omeroweb/webgateway/static/3rdparty/jquery.jstree-3.0.8/jstree.js
+++ b/omeroweb/webgateway/static/3rdparty/jquery.jstree-3.0.8/jstree.js
@@ -7045,6 +7045,8 @@
 
 
 (function ($) {
+	// NB: document.registerElement is deprecated - see https://github.com/vakata/jstree/issues/2094
+	// But seems this is not used by OMERO.web currently - see https://github.com/ome/omero-web/pull/119
 	if(document.registerElement && Object && Object.create) {
 		var proto = Object.create(HTMLElement.prototype);
 		proto.createdCallback = function () {

--- a/omeroweb/webgateway/static/3rdparty/jquery.jstree-3.0.8/jstree.js
+++ b/omeroweb/webgateway/static/3rdparty/jquery.jstree-3.0.8/jstree.js
@@ -7066,7 +7066,7 @@
 		};
 		// proto.attributeChangedCallback = function (name, previous, value) { };
 		try {
-			document.registerElement("vakata-jstree", { prototype: proto });
+			window.customElements.define("vakata-jstree", { prototype: proto });
 		} catch(ignore) { }
 	}
 }(jQuery));


### PR DESCRIPTION
I recently found I needed this:

With multiple objects e.g. Images selected, map annotations are shown for all of them. We currently display the Name of the object that each map annotation is linked to, but names can be hard to recognise. This adds the Object ID to the tooltip.
To test, select a few Objects that have some map annotations:
 - Tooltip on each map annotation should show e.g. Image ID: 1

<img width="342" alt="Screenshot 2020-02-01 at 23 17 16" src="https://user-images.githubusercontent.com/900055/73600519-0eb69f80-4549-11ea-9979-0e5e634b7760.png">
