### PR TITLE
omero.web.root_application: override / handler

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -748,7 +748,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
          json.loads,
          ("Add additional Django applications. For example, see"
           " :doc:`/developers/Web/CreateApp`")],
-    "omero.web.apps.root_application":
+    "omero.web.root_application":
         ["OMEROWEB_ROOT_APPLICATION",
          '',
          str,

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -748,6 +748,15 @@ CUSTOM_SETTINGS_MAPPINGS = {
          json.loads,
          ("Add additional Django applications. For example, see"
           " :doc:`/developers/Web/CreateApp`")],
+    "omero.web.apps.root_application":
+        ["OMEROWEB_ROOT_APPLICATION",
+         '',
+         str,
+         ("Override the root application label that handles ``/``. "
+          "**Warning** you must ensure the application's URLs do not conflict "
+          "with other applications. "
+          "omero-gallery is an example of an application that can be used for "
+          "this (set to ``gallery``)")],
     "omero.web.databases":
         ["DATABASES", '{}', json.loads, None],
     "omero.web.page_size":

--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -89,7 +89,11 @@ for app in settings.ADDITIONAL_APPS:
     if urls_found is not None:
         try:
             __import__(urlmodule)
-            regex = '^(?i)%s/' % label
+            # https://stackoverflow.com/questions/7580220/django-urls-how-to-map-root-to-app
+            if label == settings.OMEROWEB_ROOT_APPLICATION:
+                regex = r'^'
+            else:
+                regex = '^(?i)%s/' % label
             urlpatterns.append(url(regex, include(urlmodule)))
         except ImportError:
             print("""Failed to import %s


### PR DESCRIPTION
Allows the root handler in OMERO.web (`/`) to be overridden.
The default is for `/` to redirect to `/webclient`. This can be used to make omero-gallery appear as `/`, and should mean the IDR no-longer needs a custom patch https://github.com/IDR/deployment/pull/211/commits/60f2161ac7f6882be826788bc3b59b6ddc285e00
```
omero config set omero.web.root_application gallery
```