### PR TITLE
Delete check parent links

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -520,6 +520,29 @@ OME.truncateNames = (function(){
     return truncateNames;
 }());
 
+OME.checkForMultipleParents = function(objList, callback) {
+    // objList is list of ['image=1'] etc.
+    var url = WEBCLIENT.URLS.api_parent_links + '?' + objList.join('&');
+
+    $.getJSON(url, function(data){
+        // look for any child that has > 1 parent:
+        var multiple = false;
+        var links = {};
+        data.data.forEach(function(link){
+            var childId = link.child.type + link.child.id;
+            var parentId = link.parent.type + link.parent.id;
+            // do we already have a parent link for that child?
+            if (links[childId]) {
+                multiple = true;
+            }
+            links[childId] = parentId;
+        });
+        if (callback) {
+            callback(multiple);
+        }
+    });
+}
+
 // Handle deletion of selected objects in jsTree in containers.html
 OME.handleDelete = function(deleteUrl, filesetCheckUrl, userId) {
     var datatree = $.jstree.reference($('#dataTree'));
@@ -586,6 +609,17 @@ OME.handleDelete = function(deleteUrl, filesetCheckUrl, userId) {
         datatree.disable_node(node);
     });
 
+    // Hide warning, show it if e.g Image is in multiple groups
+    // https://forum.image.sc/t/caution-with-copy-links-in-omero/33680
+    $("#deleteCopyWarning").hide();
+    $("#delete-dialog-form").css('height', '92px');
+    OME.checkForMultipleParents(ajax_data, function(multiple){
+        if (multiple) {
+            $("#deleteCopyWarning").show();
+            $("#delete-dialog-form").css('height', '192px');
+        }
+    })
+
     if (notOwned) {
         $("#deleteOthersWarning").show();
     } else {
@@ -593,11 +627,17 @@ OME.handleDelete = function(deleteUrl, filesetCheckUrl, userId) {
     }
 
     var type_strings = [];
+    var parent_types = {image:'dataset', dataset:'project', plate:'screen'};
+    var parent_strings = [];
     for (var key in dtypes) {
+        if (parent_types[key]) {
+            parent_strings.push(parent_types[key].capitalize());
+        }
         type_strings.push(key.replace("acquisition", "Run").capitalize() + (dtypes[key]>1 && "s" || ""));
     }
     var type_str = type_strings.join(" & ");    // For delete dialog: E.g. 'Project & Datasets'
-    $("#delete_type").text(type_str);
+    $(".delete_type").text(type_str);
+    $(".delete_parent_type").text(parent_strings.join(" or "));
     if (!askDeleteContents) $("#delete_contents_form").hide();  // don't ask about deleting contents
 
     // callback when delete dialog is closed

--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -566,19 +566,6 @@ OME.handleDelete = function(deleteUrl, filesetCheckUrl, userId) {
 
     var disabledNodes = [];
 
-    function traverse(state) {
-        // Check if this state is one that we are looking for
-        var n = datatree.get_node(state);
-        disabledNodes.push(n);
-
-        if (n.children) {
-            $.each(n.children, function(index, child) {
-                 traverse(child);
-            });
-        }
-        datatree.disable_node(n);
-
-    }
     var notOwned = false;
     $.each(selected, function(index, node) {
         // What types are being deleted and how many (for pluralization)
@@ -601,11 +588,6 @@ OME.handleDelete = function(deleteUrl, filesetCheckUrl, userId) {
         // Disable the nodes marked for deletion
         // Record them so they can easily be removed/re-enabled later
         disabledNodes.push(node);
-        if (node.children) {
-            $.each(node.children, function(index, child) {
-                 traverse(child);
-            });
-        }
         datatree.disable_node(node);
     });
 

--- a/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -181,6 +181,7 @@
         WEBCLIENT.URLS.static_webgateway = "{% static 'webgateway' %}/";
         WEBCLIENT.URLS.api_tags_and_tagged = "{% url 'api_tags_and_tagged' %}";
         WEBCLIENT.URLS.fileset_check = "{% url 'fileset_check' 'delete' %}";
+        WEBCLIENT.URLS.api_parent_links = "{% url 'api_parent_links' %}";
         WEBCLIENT.URLS.deletemany = "{% url 'manage_action_containers' 'deletemany' %}";
         WEBCLIENT.URLS.copy_image_rdef_json = "{% url 'copy_image_rdef_json' %}";
         WEBCLIENT.URLS.reset_owners_rdef_json = "{% url 'reset_owners_rdef_json' %}";

--- a/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/omeroweb/webclient/templates/webclient/data/containers.html
@@ -895,7 +895,16 @@
     <p id="deleteOthersWarning" class='error' style="font-size: 120%; font-weight: bold">
         Warning: Some objects you selected are owned by other users.
     </p>
-    <p>Are you sure you want to delete the selected <span id="delete_type">Images</span>?</p>
+    <p id="deleteCopyWarning" class='error' style="font-size: 120%; font-weight: bold">
+        Warning: One or more <span class="delete_type">Images</span> are linked in multiple
+        <span class="delete_parent_type">Dataset</span>s.
+        This will DELETE them from ALL of those
+        <span class="delete_parent_type">Dataset</span>s.
+        If you only wish to remove <span class="delete_type">Images</span> from one
+        <span class="delete_parent_type">Dataset</span>, use the
+        "Cut Link" action.
+    </p>
+    <p>Are you sure you want to delete the selected <span class="delete_type">Images</span>?</p>
     <p>If yes:</p>
     <form>
     <fieldset style="border: 0px solid white">

--- a/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/omeroweb/webclient/templates/webclient/data/containers.html
@@ -896,7 +896,7 @@
         Warning: Some objects you selected are owned by other users.
     </p>
     <p id="deleteCopyWarning" class='error' style="font-size: 120%; font-weight: bold">
-        Warning: One or more <span class="delete_type">Images</span> are linked in multiple
+        Warning: One or more <span class="delete_type">Images</span> are linked to multiple
         <span class="delete_parent_type">Dataset</span>s.
         This will DELETE them from ALL of those
         <span class="delete_parent_type">Dataset</span>s.

--- a/omeroweb/webclient/urls.py
+++ b/omeroweb/webclient/urls.py
@@ -318,6 +318,10 @@ urlpatterns = [
     url(r'^api/paths_to_object/$', views.api_paths_to_object,
         name='api_paths_to_object'),
 
+    # Get parents of 1 or more objects. ?image=1,2&dataset=3
+    url(r'^api/parent_links/$', views.api_parent_links,
+        name='api_parent_links'),
+
     url(r'^api/tags/$', views.api_tags_and_tagged_list,
         name='api_tags_and_tagged'),
 


### PR DESCRIPTION
See https://forum.image.sc/t/caution-with-copy-links-in-omero/33680

We do a simple check for multiple parents and if found, show a Warning message:

![Screenshot 2020-02-11 at 15 25 19](https://user-images.githubusercontent.com/900055/74250784-0ac21480-4ce3-11ea-8247-38447bbcbdde.png)

To test:
 - Select 1 or more Images or Datasets or Plates where at least one of the selected objects has multiple Parents.
 - Click Delete.
 - Should see the warning above.
 - Also check warning is not shown when not needed.