### PR TITLE
fix webadmin search firefox

### DIFF
--- a/omeroweb/webadmin/templates/webadmin/experimenters.html
+++ b/omeroweb/webadmin/templates/webadmin/experimenters.html
@@ -72,8 +72,8 @@
     </div>
     {% endif %}
 
-    <form class="search filtersearch" id="filtersearch" action="#" style="width: 160px">
-        <input type="text" id="id_search">
+    <form class="search filtersearch" id="filtersearch" action="#" style="margin-left:20px; width: 160px">
+        <input type="text" id="id_search" style="width: 100%">
         <input type="submit" value="Go" />
         <span class="loading">
             <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">

--- a/omeroweb/webadmin/templates/webadmin/groups.html
+++ b/omeroweb/webadmin/templates/webadmin/groups.html
@@ -70,9 +70,9 @@
         </div>
     {% endif %}
 
-    <form class="search filtersearch" id="filtersearch" action="#" style="width:160px">
-        <input type="text" id="id_search">
-        <input type="submit" value="Go" />
+    <form class="search filtersearch" id="filtersearch" action="#" style="margin-left: 20px; width:160px">
+        <input type="text" id="id_search" style="width: 100%">
+        <input type="submit" value="Go"/>
         <span class="loading">
             <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
         </span>


### PR DESCRIPTION
Fixes layout of the search field on Groups and Experimenters webadmin pages on firefox.
To test:
 - Search field should not be obscured behind the edge of the table header.