### PR TITLE
Use sizeC in stack size to be as safe as possible

### DIFF
--- a/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1116,13 +1116,11 @@
       // on pixel type byte width
       var bytes_per_pixel = Math.ceil(
         Math.log2(viewport.loadedImg.pixel_range[1]) / 8.0);
-      var active_channel_count = viewport.loadedImg.channels
-        .filter(function(x) { return x.active }).length;
       var stack_size = sizes.width * sizes.height * sizes.z
-                       * active_channel_count * bytes_per_pixel;
+                       * sizes.c * bytes_per_pixel;
 
       // disable 'Max Intensity' projection for single-Z images or if total
-      // amount of data to be projected is > 256MiB
+      // amount of data that might be projected is > 256MiB
       var disable_intmax = (
         viewport.loadedImg.rdefs.invertAxis || sizes.z < 2
         || stack_size > 256 * 1024 * 1024


### PR DESCRIPTION
The disabling of the projection controls happens once per viewport
initialization.  If the viewport is initialized with a small number of
active channels but a the image has a large number of total channels an
unfavourable projection environment may exist.  It is safest to make the
availability check based on the total number of channels the image has.