### PR TITLE
Rating post only

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2194,6 +2194,8 @@ def annotate_rating(request, conn=None, **kwargs):
     """
     Handle adding Rating to one or more objects
     """
+    if request.method != 'POST':
+        raise Http404("Only POST supported")
     rating = getIntOrDefault(request, 'rating', 0)
     oids = getObjects(request, conn)
 


### PR DESCRIPTION
I noticed the missing "POST" check when adding a deliberate error to test feedback fix: #131. 

To test "POST" is required for rating, try to rate e.g. a Project by going to /webclient/annotate_rating/?project=52&rating=2 in the browser (a "GET" request). This should not change the rating (will see a 404 instead).

Editing of rating in the webclient UI should work as normal.
