### PR TITLE
Use chosen plugin for script UI values

### DIFF
--- a/omeroweb/webclient/templates/webclient/scripts/script_ui.html
+++ b/omeroweb/webclient/templates/webclient/scripts/script_ui.html
@@ -3,7 +3,7 @@
 
 {% comment %}
 <!--
-  Copyright (C) 2011 University of Dundee & Open Microscopy Environment.
+  Copyright (C) 2011-2020 University of Dundee & Open Microscopy Environment.
   All rights reserved.
 
   This program is free software: you can redistribute it and/or modify
@@ -34,6 +34,8 @@
 
 
 {% block link %}
+
+    <link rel="stylesheet" href="{% static "3rdparty/jquery.chosen-1.2.0/chosen.css" %}" type="text/css" media="screen"/>
 
     <style type="text/css">
         h3 {
@@ -94,6 +96,7 @@
     {% include "webgateway/base/includes/script_src_popup.html" %}
     {% include "webgateway/base/includes/jquery-ui.html" %}
     <script type="text/javascript" src="{% static "webclient/javascript/jquery.form-3.51.js" %}"></script>
+    <script type="text/javascript" src="{% static "3rdparty/jquery.chosen-1.2.0/chosen.jquery.js" %}"></script>
     <script type="text/javascript">
 
         $(document).ready(function() {
@@ -176,6 +179,18 @@
 
             // For 'number' fields, only allow numbers input.
             $(".number").numbersOnly();
+
+            // Only use the chosen plugin if we have > 20 options
+            $("select").each(function() {
+                var limit = 20;
+                var $this = $(this);
+                if ($('option', $this).length > limit) {
+                    $this.chosen({
+                        search_contains: true,
+                        width: '300px'
+                    });
+                }
+            });
 
             // Focus first input
             $('input:visible, select:visible').first().focus();


### PR DESCRIPTION
Ported from https://github.com/ome/openmicroscopy/pull/6099

See https://forum.image.sc/t/file-browser-in-omero-script-gui/28117/16

To test:
 - Use the sample script below to generate a lot of directories to choose from in the script UI (based on use-case and code in the image.sc link above)
 - This generates > 2000 items to show in a list in the script UI
 - Without this PR, this is one select box and difficult to choose one (see screenshot)
 - With this PR you can search by typing (2nd screenshot)
 - Run the script - the chosen item appears in the output message


![Screenshot 2020-02-21 at 15 26 25](https://user-images.githubusercontent.com/900055/75047478-b840df00-54be-11ea-936c-1844e811ede7.png)


![Screenshot 2020-02-21 at 15 29 03](https://user-images.githubusercontent.com/900055/75047596-f0e0b880-54be-11ea-9d65-10aa109e8749.png)

```
import omero.scripts as scripts
from omero.rtypes import rstring
import os

dir_list = []
for d in os.listdir('/'):
    dir_list.append(d)
    try:
        for f in os.listdir('/' + d):
            dir_list.append("%s/%s" % (d, f))
    except PermissionError:
        print(d, 'PermissionError')
    except NotADirectoryError:
        print(d, 'NotADirectoryError')

dirs = [rstring(d) for d in dir_list]
print(len(dirs))

client = scripts.client(
    'Test_Big_List.py',
    """Test listing lots of dirs""",
    scripts.String("Directories", values = dirs),
)

try:
    script_params = client.getInputs(unwrap=True)
    client.setOutput("Message", rstring(script_params['Directories']))

finally:
    client.closeSession()
```