### PR TITLE
Upload script only with WriteScriptRepo privileges

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -1025,7 +1025,7 @@ OME.showScriptList = function(event) {
             var html = build_ul(data);
 
             // For Admins, add a 'Upload Script' option.
-            if (WEBCLIENT.isAdmin) {
+            if (WEBCLIENT.current_admin_privileges.indexOf("WriteScriptRepo") > -1) {
                 html += "<li><a class='upload_script' href='" + WEBCLIENT.URLS.script_upload + "'>Upload Script</a></li>";
             }
             html = "<ul class='menulist'>" + html + "</ul>";

--- a/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -169,6 +169,7 @@
         WEBCLIENT.eventContext = {{ ome.eventContext|json_dumps|safe }};
         WEBCLIENT.isAdmin = {% if ome.user.isAdmin %}true{% else %}false{% endif %};
         WEBCLIENT.CAN_CREATE = {{ ome.can_create|json_dumps|safe }};
+        WEBCLIENT.current_admin_privileges = {{ current_admin_privileges|json_dumps|safe }};
 
         WEBCLIENT.URLS = {};
         WEBCLIENT.URLS.webindex = "{% url 'webindex' %}";

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -490,6 +490,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     context['page_size'] = settings.PAGE
     context['template'] = template
     context['thumbnails_batch'] = settings.THUMBNAILS_BATCH
+    context['current_admin_privileges'] = conn.getCurrentAdminPrivileges()
 
     return context
 


### PR DESCRIPTION
The Upload Script button should only be visible if current privileges include "WriteScriptRepo".

cc @jburel 