### PR TITLE
Shape thumbnail float points

### DIFF
--- a/omeroweb/webgateway/util.py
+++ b/omeroweb/webgateway/util.py
@@ -196,3 +196,45 @@ def zip_archived_files(images, temp, zipName, buf=2621440):
         shutil.rmtree(temp_zip_dir, ignore_errors=True)
 
     return zipName
+
+
+def xy_list_to_bbox(xyList):
+    """
+    Returns a bounding box (x,y,w,h) that will contain the shape
+    represented by the XY points list
+    """
+    xList, yList = [], []
+    for xy in xyList:
+        x, y = xy
+        xList.append(x)
+        yList.append(y)
+    return (min(xList), min(yList), max(xList)-min(xList),
+            max(yList)-min(yList))
+
+
+def points_string_to_XY_list(string):
+    """
+    Method for converting the string returned from
+    omero.model.ShapeI.getPoints() into list of (x,y) points.
+    E.g: "points[309,427, 366,503, 190,491] points1[309,427, 366,503,
+    190,491] points2[309,427, 366,503, 190,491]"
+    or the new format: "309,427 366,503 190,491"
+    OR with extra ,  : "309,427, 366,503, 190,491"
+    """
+    pointLists = string.strip().split("points")
+    if len(pointLists) < 2:
+        if len(pointLists) == 1 and pointLists[0]:
+            xys = pointLists[0].split(" ")
+            xyList = [tuple(map(float, xy.strip(',').split(',')))
+                      for xy in xys if len(xy) > 0]
+            return xyList
+
+        msg = "Unrecognised ROI shape 'points' string: %s" % string
+        raise ValueError(msg)
+
+    firstList = pointLists[1]
+    xyList = []
+    for xy in firstList.strip(" []").split(", "):
+        x, y = xy.split(",")
+        xyList.append((float(x.strip()), float(y.strip())))
+    return xyList

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -33,7 +33,7 @@ from django.conf import settings
 from wsgiref.util import FileWrapper
 from omero.rtypes import rlong, unwrap
 from omero.constants.namespaces import NSBULKANNOTATIONS
-from omero.util.ROI_utils import pointsStringToXYlist, xyListToBbox
+from .util import points_string_to_XY_list, xy_list_to_bbox
 from .plategrid import PlateGrid
 from omeroweb.version import omeroweb_buildyear as build_year
 from .marshal import imageMarshal, shapeMarshal, rgb_int2rgba
@@ -531,8 +531,8 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
                 2*shape['radiusX'], 2*shape['radiusY'])
     elif type(s) == omero.model.PolylineI:
         shape['type'] = 'PolyLine'
-        shape['xyList'] = pointsStringToXYlist(s.getPoints().getValue())
-        bBox = xyListToBbox(shape['xyList'])
+        shape['xyList'] = points_string_to_XY_list(s.getPoints().getValue())
+        bBox = xy_list_to_bbox(shape['xyList'])
     elif type(s) == omero.model.LineI:
         shape['type'] = 'Line'
         shape['x1'] = int(s.getX1().getValue())
@@ -550,8 +550,8 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
         bBox = (shape['x']-50, shape['y']-50, 100, 100)
     elif type(s) == omero.model.PolygonI:
         shape['type'] = 'Polygon'
-        shape['xyList'] = pointsStringToXYlist(s.getPoints().getValue())
-        bBox = xyListToBbox(shape['xyList'])
+        shape['xyList'] = points_string_to_XY_list(s.getPoints().getValue())
+        bBox = xy_list_to_bbox(shape['xyList'])
     elif type(s) == omero.model.LabelI:
         shape['type'] = 'Label'
         shape['x'] = s.getX().getValue()

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -636,7 +636,7 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
 
     # we have our full-sized region. Need to resize to thumbnail.
     current_w, current_h = img.size
-    factor = float(MAX_WIDTH) // current_w
+    factor = float(MAX_WIDTH) / current_w
     resizeH = int(current_h * factor)
     img = img.resize((MAX_WIDTH, resizeH))
 


### PR DESCRIPTION
Fix shape thumbnails for Polygons / Polylines with floating-point coordinates (e.g from iviewer).

Fixes error: 
```
  File "/home/omero/workspace/OMERO-web/.venv3/lib64/python3.6/site-packages/omeroweb/webgateway/views.py", line 553, in get_shape_thumbnail
    shape['xyList'] = pointsStringToXYlist(s.getPoints().getValue())

  File "/home/omero/workspace/OMERO-web/.venv3/lib64/python3.6/site-packages/omero/util/ROI_utils.py", line 80, in pointsStringToXYlist
    xyList = [tuple(map(int, xy.split(','))) for xy in xys]

ValueError: invalid literal for int() with base 10: '952.60546875'
```

To fix this in omero-web, I have stopped using the ```omero-py util/ROI_utils.py``` function ```pointsStringToXYlist()``` which has been deprecated since OMERO 5.3.

I also found another bug from #137 with incorrect Integer division.