### PR TITLE
omero.web.secure defaults to true

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -448,7 +448,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "sessions/#using-cached-sessions>` for more details.")],
     "omero.web.secure":
         ["SECURE",
-         "false",
+         "true",
          parse_boolean,
          ("Force all backend OMERO.server connections to use SSL.")],
     "omero.web.session_cookie_age":


### PR DESCRIPTION
# What this PR does

Python BlitzGateway and OMERO.web default to using secure connections.

Previously the defaults for secure/insecure were confusing: https://trello.com/c/pJuzsmKU/441-bug-blitzgateway-connconnect

This makes both default to secure. The main advantage is you can connect to any OMERO.server with just the standard 4064 port exposed or forwarded, you no-longer need to remember to set secure.

# Testing this PR

Everything should continue to just work. You should be able to connect to servers from the BlitzGateway and OMERO.web with or without 4063 exposed with no change in configuration, previously the default configuration would have failed if 4063 was blocked.

Ported from https://github.com/ome/openmicroscopy/pull/5946