### PR TITLE
Filter map anns number 10m m

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -6,7 +6,7 @@ function MapAnnFilter(image_ids, $element, callback, filterObjects) {
     this.moreLess = "more";
     this.filterObjects = filterObjects;
 
-    var $filter = $('<div class="imagefilter filtersearch">' +
+    var $filter = $('<div class="imagefilter filtersearch" style="width:100%">' +
         '<select class="choose_map_key">' +
         '</select>' +
         '<select class="map_more_less" style="width: 40px; display:none">' +

--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -86,8 +86,8 @@ function MapAnnFilter(image_ids, $element, callback, filterObjects) {
     $(".filter_map_value", $filter).on('input', function(event){
         var val = $(event.target).val();
         if (this.keyisNumber) {
-            // remove non-number characters
-            val = val.replace(/[a-zA-Z]/g, '');
+            // remove non-number characters. Allow . or - or 0-9
+            val = val.split("").filter(function(c){c = c.charCodeAt(); return c == 45 || c == 46 || (c > 47 && c < 58)}).join('');
             $(event.target).val(val);
             if (isNaN(val)) {
                 val = '';

--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -160,7 +160,7 @@ MapAnnFilter.prototype.isImageVisible = function(iid) {
         }.bind(this));
     } else {
         this.currentKeyValues[iid].forEach(function(v){
-            if (v.toLowerCase().indexOf(text.toLowerCase()) > -1) {
+            if (v.indexOf(text) > -1) {
                 visible = true;
             }
         });

--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -129,6 +129,7 @@ MapAnnFilter.prototype.isImageVisible = function(iid) {
     } else if (this.keyisNumber) {
         let cutoff = parseFloat(text);
         this.currentKeyValues[iid].forEach(function(v){
+            v = parseFloat(v);
             // compare: more, less, moreequal, lessequal, equal
             if (v == cutoff && this.moreLess.indexOf('equal') > -1) {
                 visible = true;
@@ -171,13 +172,10 @@ MapAnnFilter.prototype.loadAnnotations = function(callback) {
                     // If not, make sure ALL are strings
                     if (isNaN(parseFloat(val))) {
                         prev[key].type = 'string';
-                        for (i in prev[key].values) {
-                            prev[key].values[i] = prev[key].values[i].map(function(v){return v + ""});
-                        }
                     } else {
-                        val = parseFloat(val);
-                        prev[key].min = Math.min(val, prev[key].min);
-                        prev[key].max = Math.max(val, prev[key].max);
+                        var num = parseFloat(val);
+                        prev[key].min = Math.min(num, prev[key].min);
+                        prev[key].max = Math.max(num, prev[key].max);
                     }
                 }
                 if (!prev[key].values[iid]) {

--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -166,7 +166,7 @@ MapAnnFilter.prototype.loadAnnotations = function(callback) {
                 if (!prev[key]) {
                     prev[key] = {values: {}, type: 'number', min: Infinity, max: -Infinity};
                 }
-                if (isNaN(val)) {
+                if (isNaN(parseFloat(val))) {
                     prev[key].type = 'string';
                 } else {
                     val = parseFloat(val);

--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -194,20 +194,24 @@ MapAnnFilter.prototype.loadAnnotations = function(callback) {
                 }
                 // if type is NOT string, check if val is a number...
                 if (prev[key].type !== 'string') {
-                    // If 'units' are defined, value must be number+units
+                    // If 'units' are a string (not empty), value must be number+units
                     var num = undefined;
-                    if (prev[key].units != undefined) {
+                    if (prev[key].units) {
+                        // We remove units and strictly check it's a number...
                         let digits = val.replace(prev[key].units, '');
                         if (isNaN(digits) || isNaN(parseFloat(val))) {
+                            // If not - we treat data as a string
                             prev[key].type = 'string';
                             prev[key].units = undefined
                         } else {
                             num = parseFloat(val);
                         }
+                    // We haven't defined units yet... Check if NaN
                     } else if (isNaN(parseFloat(val))) {
+                        // Can't cast to a number - bail!
                         prev[key].type = 'string';
                     } else {
-                        // it is a number - need to set units
+                        // it IS a number - and we don't have any units yet...
                         num = parseFloat(val);
                         prev[key].units = val.replace(num, '').trim();   // '10 mM' -> 'mM'
                     }

--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -51,6 +51,7 @@ function MapAnnFilter(image_ids, $element, callback, filterObjects) {
             let min = this.usedKeyValues[this.currentFilterKey].min;
             let max = this.usedKeyValues[this.currentFilterKey].max;
             placeholder = min + '-' + max;
+            $(".filter_map_value", $filter).autocomplete({disabled: true})
         } else {
             var autocompVals = [];
             for (var values of Object.values(this.currentKeyValues)) {
@@ -63,6 +64,7 @@ function MapAnnFilter(image_ids, $element, callback, filterObjects) {
             autocompVals.sort();
             var self = this;
             $(".filter_map_value", $filter).autocomplete({
+                disabled: false,
                 source: autocompVals,
                 select: function( event, ui ) {
                     self.filterText = ui.item.value;

--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -84,7 +84,17 @@ function MapAnnFilter(image_ids, $element, callback, filterObjects) {
     }.bind(this));
 
     $(".filter_map_value", $filter).on('input', function(event){
-        this.filterText = $(event.target).val();
+        var val = $(event.target).val();
+        if (this.keyisNumber) {
+            // remove non-number characters
+            val = val.replace(/[a-zA-Z]/g, '');
+            $(event.target).val(val);
+            if (isNaN(val)) {
+                val = '';
+            }
+        }
+        this.filterText = val;
+
         if (callback) {
             callback();
         }

--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -166,12 +166,19 @@ MapAnnFilter.prototype.loadAnnotations = function(callback) {
                 if (!prev[key]) {
                     prev[key] = {values: {}, type: 'number', min: Infinity, max: -Infinity};
                 }
-                if (isNaN(parseFloat(val))) {
-                    prev[key].type = 'string';
-                } else {
-                    val = parseFloat(val);
-                    prev[key].min = Math.min(val, prev[key].min);
-                    prev[key].max = Math.max(val, prev[key].max);
+                // if type is NOT string, check if val is a number...
+                if (prev[key].type !== 'string') {
+                    // If not, make sure ALL are strings
+                    if (isNaN(parseFloat(val))) {
+                        prev[key].type = 'string';
+                        for (i in prev[key].values) {
+                            prev[key].values[i] = prev[key].values[i].map(function(v){return v + ""});
+                        }
+                    } else {
+                        val = parseFloat(val);
+                        prev[key].min = Math.min(val, prev[key].min);
+                        prev[key].max = Math.max(val, prev[key].max);
+                    }
                 }
                 if (!prev[key].values[iid]) {
                     prev[key].values[iid] = [val];


### PR DESCRIPTION
Bugs noticed when preparing for workshop...

When filtering by Key-Values, we test each value for being a number.
But previously, values such as ```10mM``` weren't considered numbers.
Now, we allow numbers to have 'units' (any suffix after the number) BUT ensure
that ALL the values have the same units, since we can't convert between units (see discussion below).
If various different units are found, or any value isn't a number then we revert to 'string' field.

To test:
 - Try when 1 or more values are not numbers or have different units. This should revert to normal string matching (with drop-down auto-complete menu). First screenshot.
 - Try filtering when all values ARE numbers with no units or ALL the same units, e.g. 10mM, 20mM, etc 2nd screenshot.
 - If number filter, you can only enter a number (not units)

<img width="256" alt="Screenshot 2020-03-18 at 14 56 14" src="https://user-images.githubusercontent.com/900055/76984743-2a2e0c00-6937-11ea-9d8d-769bfc6e5eb9.png">

<img width="286" alt="Screenshot 2020-03-18 at 15 50 41" src="https://user-images.githubusercontent.com/900055/76984763-2f8b5680-6937-11ea-9598-2053f877bf69.png">




