### PR TITLE
api_experimenters_groups

### DIFF
--- a/omeroweb/api/api_settings.py
+++ b/omeroweb/api/api_settings.py
@@ -57,4 +57,4 @@ report_settings(sys.modules[__name__])
 API_VERSIONS = ('0',)
 
 # Current major.minor version number
-API_VERSION = '0.2-DEV'
+API_VERSION = '0.2'

--- a/omeroweb/api/api_settings.py
+++ b/omeroweb/api/api_settings.py
@@ -57,4 +57,4 @@ report_settings(sys.modules[__name__])
 API_VERSIONS = ('0',)
 
 # Current major.minor version number
-API_VERSION = '0.1'
+API_VERSION = '0.2-DEV'

--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -300,6 +300,54 @@ api_image_rois = url(
 GET ROIs that belong to an Image, using omero-marshal to generate json
 """
 
+api_experimenters = url(r'^v(?P<api_version>%s)/m/experimenters/$' % versions,
+                        views.ExperimentersView.as_view(),
+                        name='api_experimenters')
+"""
+GET Experimenters, using omero-marshal to generate json
+"""
+
+api_experimenter = url(r'^v(?P<api_version>%s)/m/experimenters/'
+                       '(?P<object_id>[0-9]+)/$' % versions,
+                       views.ExperimenterView.as_view(),
+                       name='api_experimenter')
+"""
+GET Experimenter, using omero-marshal to generate json
+"""
+
+api_group_experimenters = url(
+    r'^v(?P<api_version>%s)/m/experimentergroups/(?P<group_id>[0-9]+)'
+    '/experimenters/$' % versions,
+    views.ExperimentersView.as_view(),
+    name='api_group_experimenters')
+"""
+GET Experimenters in a Group, using omero-marshal to generate json
+"""
+
+api_groups = url(r'^v(?P<api_version>%s)/m/experimentergroups/$' % versions,
+                 views.ExperimenterGroupsView.as_view(),
+                 name='api_groups')
+"""
+GET ExperimenterGroups, using omero-marshal to generate json
+"""
+
+api_group = url(r'^v(?P<api_version>%s)/m/experimentergroups/'
+                '(?P<object_id>[0-9]+)/$' % versions,
+                views.ExperimenterGroupView.as_view(),
+                name='api_group')
+"""
+GET ExperimenterGroup, using omero-marshal to generate json
+"""
+
+api_experimenter_groups = url(
+    r'^v(?P<api_version>%s)/m/experimenters/(?P<experimenter_id>[0-9]+)'
+    '/experimentergroups/$' % versions,
+    views.ExperimenterGroupsView.as_view(),
+    name='api_experimenter_groups')
+"""
+GET Groups that an Experimenter is in, using omero-marshal to generate json
+"""
+
 urlpatterns = [
     api_versions,
     api_base,
@@ -335,4 +383,10 @@ urlpatterns = [
     api_rois,
     api_roi,
     api_image_rois,
+    api_experimenters,
+    api_experimenter,
+    api_group_experimenters,
+    api_groups,
+    api_group,
+    api_experimenter_groups,
 ]

--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -319,14 +319,14 @@ api_group_experimenters = url(
     r'^v(?P<api_version>%s)/m/experimentergroups/(?P<group_id>[0-9]+)'
     '/experimenters/$' % versions,
     views.ExperimentersView.as_view(),
-    name='api_group_experimenters')
+    name='api_experimentergroup_experimenters')
 """
 GET Experimenters in a Group, using omero-marshal to generate json
 """
 
 api_groups = url(r'^v(?P<api_version>%s)/m/experimentergroups/$' % versions,
                  views.ExperimenterGroupsView.as_view(),
-                 name='api_groups')
+                 name='api_experimentergroups')
 """
 GET ExperimenterGroups, using omero-marshal to generate json
 """
@@ -334,7 +334,7 @@ GET ExperimenterGroups, using omero-marshal to generate json
 api_group = url(r'^v(?P<api_version>%s)/m/experimentergroups/'
                 '(?P<object_id>[0-9]+)/$' % versions,
                 views.ExperimenterGroupView.as_view(),
-                name='api_group')
+                name='api_experimentergroup')
 """
 GET ExperimenterGroup, using omero-marshal to generate json
 """
@@ -343,7 +343,7 @@ api_experimenter_groups = url(
     r'^v(?P<api_version>%s)/m/experimenters/(?P<experimenter_id>[0-9]+)'
     '/experimentergroups/$' % versions,
     views.ExperimenterGroupsView.as_view(),
-    name='api_experimenter_groups')
+    name='api_experimenter_experimentergroups')
 """
 GET Groups that an Experimenter is in, using omero-marshal to generate json
 """

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -79,7 +79,8 @@ def api_base(request, api_version=None, **kwargs):
     """Base url of the webgateway json api for a specified version."""
     v = api_version
     rv = {'url:experimenters': build_url(request, 'api_experimenters', v),
-          'url:experimentergroups': build_url(request, 'api_experimentergroups', v),
+          'url:experimentergroups': build_url(request,
+                                              'api_experimentergroups', v),
           'url:projects': build_url(request, 'api_projects', v),
           'url:datasets': build_url(request, 'api_datasets', v),
           'url:images': build_url(request, 'api_images', v),
@@ -390,8 +391,10 @@ class ExperimenterView(ObjectView):
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
-        'url:experimentergroups': {'name': 'api_experimenter_experimentergroups',
-                                   'kwargs': {'experimenter_id': 'OBJECT_ID'}},
+        'url:experimentergroups': {
+            'name': 'api_experimenter_experimentergroups',
+            'kwargs': {'experimenter_id': 'OBJECT_ID'}
+        },
     }
 
 
@@ -743,8 +746,10 @@ class ExperimentersView(ObjectsView):
     urls = {
         'url:experimenter': {'name': 'api_experimenter',
                              'kwargs': {'object_id': 'OBJECT_ID'}},
-        'url:experimentergroups': {'name': 'api_experimenter_experimentergroups',
-                                   'kwargs': {'experimenter_id': 'OBJECT_ID'}},
+        'url:experimentergroups': {
+            'name': 'api_experimenter_experimentergroups',
+            'kwargs': {'experimenter_id': 'OBJECT_ID'}
+        },
     }
 
     def get_opts(self, request, **kwargs):

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -755,8 +755,8 @@ class ExperimentersView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(ExperimentersView, self).get_opts(request, **kwargs)
-        # Default 'load_groups' is True for 5.3.x, but we don't need groups
-        opts['load_groups'] = False
+        # Default 'load_experimentergroups' is True, but we don't need groups
+        opts['load_experimentergroups'] = False
         # order_by lastName, firstName
         opts['order_by'] = 'lower(obj.lastName), lower(obj.firstName)'
 
@@ -788,7 +788,7 @@ class ExperimenterGroupsView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(ExperimenterGroupsView, self).get_opts(request, **kwargs)
-        # Default 'load_experimenters' = True for 5.3.x, but we don't want them
+        # Default 'load_experimenters' = True, but we don't want them
         opts['load_experimenters'] = False
         # order_by group name
         opts['order_by'] = 'lower(obj.name)'

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -78,7 +78,9 @@ def api_versions(request, **kwargs):
 def api_base(request, api_version=None, **kwargs):
     """Base url of the webgateway json api for a specified version."""
     v = api_version
-    rv = {'url:projects': build_url(request, 'api_projects', v),
+    rv = {'url:experimenters': build_url(request, 'api_experimenters', v),
+          'url:experimentergroups': build_url(request, 'api_groups', v),
+          'url:projects': build_url(request, 'api_projects', v),
           'url:datasets': build_url(request, 'api_datasets', v),
           'url:images': build_url(request, 'api_images', v),
           'url:screens': build_url(request, 'api_screens', v),
@@ -378,6 +380,32 @@ class RoiView(ObjectView):
         opts = super(RoiView, self).get_opts(request, **kwargs)
         opts['load_shapes'] = True
         return opts
+
+
+class ExperimenterView(ObjectView):
+
+    OMERO_TYPE = 'Experimenter'
+
+    CAN_DELETE = False
+
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'url:experimentergroups': {'name': 'api_experimenter_groups',
+                                   'kwargs': {'experimenter_id': 'OBJECT_ID'}},
+    }
+
+
+class ExperimenterGroupView(ObjectView):
+
+    OMERO_TYPE = 'ExperimenterGroup'
+
+    CAN_DELETE = False
+
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'url:experimenters': {'name': 'api_group_experimenters',
+                              'kwargs': {'group_id': 'OBJECT_ID'}},
+    }
 
 
 class ObjectsView(ApiView):
@@ -702,6 +730,72 @@ class RoisView(ObjectsView):
             image = getIntOrDefault(request, 'image', None)
             if image is not None:
                 opts['image'] = image
+
+        return opts
+
+
+class ExperimentersView(ObjectsView):
+    """Handles GET for /experimenters/ to list Experimenters."""
+
+    OMERO_TYPE = 'Experimenter'
+
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'url:experimenter': {'name': 'api_experimenter',
+                             'kwargs': {'object_id': 'OBJECT_ID'}},
+        'url:experimentergroups': {'name': 'api_experimenter_groups',
+                                   'kwargs': {'experimenter_id': 'OBJECT_ID'}},
+    }
+
+    def get_opts(self, request, **kwargs):
+        """Add extra parameters to the opts dict."""
+        opts = super(ExperimentersView, self).get_opts(request, **kwargs)
+        # Default 'load_groups' is True for 5.3.x, but we don't need groups
+        opts['load_groups'] = False
+        # order_by lastName, firstName
+        opts['order_by'] = 'lower(obj.lastName), lower(obj.firstName)'
+
+        # at /groups/:group_id/experimenters/ we have 'group_id' in kwargs
+        if 'group_id' in kwargs:
+            opts['group'] = int(kwargs['group_id'])
+        else:
+            # filter by query /experimenters/?group=:id
+            group = getIntOrDefault(request, 'group', None)
+            if group is not None:
+                opts['group'] = group
+
+        return opts
+
+
+class ExperimenterGroupsView(ObjectsView):
+    """Handles GET for /groups/ to list ExperimenterGroups."""
+
+    OMERO_TYPE = 'ExperimenterGroup'
+
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'url:experimentergroup': {'name': 'api_group',
+                                  'kwargs': {'object_id': 'OBJECT_ID'}},
+        'url:experimenters': {'name': 'api_group_experimenters',
+                              'kwargs': {'group_id': 'OBJECT_ID'}},
+    }
+
+    def get_opts(self, request, **kwargs):
+        """Add extra parameters to the opts dict."""
+        opts = super(ExperimenterGroupsView, self).get_opts(request, **kwargs)
+        # Default 'load_experimenters' = True for 5.3.x, but we don't want them
+        opts['load_experimenters'] = False
+        # order_by group name
+        opts['order_by'] = 'lower(obj.name)'
+
+        # handle /experimenters/:experimenter_id/groups/
+        if 'experimenter_id' in kwargs:
+            opts['experimenter'] = int(kwargs['experimenter_id'])
+        else:
+            # filter by query /groups/?experimenter=:id
+            group = getIntOrDefault(request, 'experimenter', None)
+            if group is not None:
+                opts['experimenter'] = group
 
         return opts
 

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -803,11 +803,11 @@ class ExperimenterGroupsView(ObjectsView):
         # order_by group name
         opts['order_by'] = 'lower(obj.name)'
 
-        # handle /experimenters/:experimenter_id/groups/
+        # handle /experimenters/:experimenter_id/experimentergroups/
         if 'experimenter_id' in kwargs:
             opts['experimenter'] = int(kwargs['experimenter_id'])
         else:
-            # filter by query /groups/?experimenter=:id
+            # filter by query /experimentergroups/?experimenter=:id
             group = getIntOrDefault(request, 'experimenter', None)
             if group is not None:
                 opts['experimenter'] = group

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -753,7 +753,12 @@ class ExperimentersView(ObjectsView):
     }
 
     def get_opts(self, request, **kwargs):
-        """Add extra parameters to the opts dict."""
+        """
+        Add extra parameters to the opts dict for GET /experimenters/.
+
+        Query will order by lastName, firstName
+        Includes option to filter by group
+        """
         opts = super(ExperimentersView, self).get_opts(request, **kwargs)
         # Default 'load_experimentergroups' is True, but we don't need groups
         opts['load_experimentergroups'] = False
@@ -787,7 +792,11 @@ class ExperimenterGroupsView(ObjectsView):
     }
 
     def get_opts(self, request, **kwargs):
-        """Add extra parameters to the opts dict."""
+        """
+        Add extra parameters to the opts dict.
+
+        Query will order Groups by name
+        """
         opts = super(ExperimenterGroupsView, self).get_opts(request, **kwargs)
         # Default 'load_experimenters' = True, but we don't want them
         opts['load_experimenters'] = False

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -760,14 +760,15 @@ class ExperimentersView(ObjectsView):
         # order_by lastName, firstName
         opts['order_by'] = 'lower(obj.lastName), lower(obj.firstName)'
 
-        # at /groups/:group_id/experimenters/ we have 'group_id' in kwargs
+        # at /experimentergroups/:group_id/experimenters/
+        # we have 'group_id' in kwargs
         if 'group_id' in kwargs:
-            opts['group'] = int(kwargs['group_id'])
+            opts['experimentergroup'] = int(kwargs['group_id'])
         else:
-            # filter by query /experimenters/?group=:id
-            group = getIntOrDefault(request, 'group', None)
+            # filter by query /experimenters/?experimentergroup=:id
+            group = getIntOrDefault(request, 'experimentergroup', None)
             if group is not None:
-                opts['group'] = group
+                opts['experimentergroup'] = group
 
         return opts
 

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -437,7 +437,7 @@ class ObjectsView(ApiView):
     def get(self, request, conn=None, **kwargs):
         """GET a list of Projects, filtering by various request parameters."""
         opts = self.get_opts(request, **kwargs)
-        group = getIntOrDefault(request, 'experimentergroup', -1)
+        group = getIntOrDefault(request, 'group', -1)
         normalize = request.GET.get('normalize', False) == 'true'
         # Get the data
         marshalled = query_objects(conn, self.OMERO_TYPE, group,

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -79,7 +79,7 @@ def api_base(request, api_version=None, **kwargs):
     """Base url of the webgateway json api for a specified version."""
     v = api_version
     rv = {'url:experimenters': build_url(request, 'api_experimenters', v),
-          'url:experimentergroups': build_url(request, 'api_groups', v),
+          'url:experimentergroups': build_url(request, 'api_experimentergroups', v),
           'url:projects': build_url(request, 'api_projects', v),
           'url:datasets': build_url(request, 'api_datasets', v),
           'url:images': build_url(request, 'api_images', v),
@@ -390,7 +390,7 @@ class ExperimenterView(ObjectView):
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
-        'url:experimentergroups': {'name': 'api_experimenter_groups',
+        'url:experimentergroups': {'name': 'api_experimenter_experimentergroups',
                                    'kwargs': {'experimenter_id': 'OBJECT_ID'}},
     }
 
@@ -403,7 +403,7 @@ class ExperimenterGroupView(ObjectView):
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
-        'url:experimenters': {'name': 'api_group_experimenters',
+        'url:experimenters': {'name': 'api_experimentergroup_experimenters',
                               'kwargs': {'group_id': 'OBJECT_ID'}},
     }
 
@@ -434,7 +434,7 @@ class ObjectsView(ApiView):
     def get(self, request, conn=None, **kwargs):
         """GET a list of Projects, filtering by various request parameters."""
         opts = self.get_opts(request, **kwargs)
-        group = getIntOrDefault(request, 'group', -1)
+        group = getIntOrDefault(request, 'experimentergroup', -1)
         normalize = request.GET.get('normalize', False) == 'true'
         # Get the data
         marshalled = query_objects(conn, self.OMERO_TYPE, group,
@@ -743,7 +743,7 @@ class ExperimentersView(ObjectsView):
     urls = {
         'url:experimenter': {'name': 'api_experimenter',
                              'kwargs': {'object_id': 'OBJECT_ID'}},
-        'url:experimentergroups': {'name': 'api_experimenter_groups',
+        'url:experimentergroups': {'name': 'api_experimenter_experimentergroups',
                                    'kwargs': {'experimenter_id': 'OBJECT_ID'}},
     }
 
@@ -768,15 +768,15 @@ class ExperimentersView(ObjectsView):
 
 
 class ExperimenterGroupsView(ObjectsView):
-    """Handles GET for /groups/ to list ExperimenterGroups."""
+    """Handles GET for /experimentergroups/ to list ExperimenterGroups."""
 
     OMERO_TYPE = 'ExperimenterGroup'
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
-        'url:experimentergroup': {'name': 'api_group',
+        'url:experimentergroup': {'name': 'api_experimentergroup',
                                   'kwargs': {'object_id': 'OBJECT_ID'}},
-        'url:experimenters': {'name': 'api_group_experimenters',
+        'url:experimenters': {'name': 'api_experimentergroup_experimenters',
                               'kwargs': {'group_id': 'OBJECT_ID'}},
     }
 

--- a/omeroweb/webadmin/views.py
+++ b/omeroweb/webadmin/views.py
@@ -101,7 +101,7 @@ def prepare_experimenter(conn, eid=None):
     if eid is None:
         eid = conn.getEventContext().userId
     experimenter = conn.getObject("Experimenter", eid,
-                                  opts={'load_groups': True})
+                                  opts={'load_experimentergroups': True})
     defaultGroup = experimenter.getDefaultGroup()
     otherGroups = list(experimenter.getOtherGroups())
     hasAvatar = conn.hasExperimenterPhoto()
@@ -393,7 +393,7 @@ def experimenters(request, conn=None, **kwargs):
     template = "webadmin/experimenters.html"
 
     experimenterList = list(conn.getObjects("Experimenter",
-                                            opts={'load_groups': True}))
+                                            opts={'load_experimentergroups': True}))
     can_modify_user = 'ModifyUser' in conn.getCurrentAdminPrivileges()
 
     context = {'experimenterList': experimenterList,

--- a/omeroweb/webadmin/views.py
+++ b/omeroweb/webadmin/views.py
@@ -392,8 +392,8 @@ def logout(request, **kwargs):
 def experimenters(request, conn=None, **kwargs):
     template = "webadmin/experimenters.html"
 
-    experimenterList = list(conn.getObjects("Experimenter",
-                                            opts={'load_experimentergroups': True}))
+    experimenterList = list(conn.getObjects(
+        "Experimenter", opts={'load_experimentergroups': True}))
     can_modify_user = 'ModifyUser' in conn.getCurrentAdminPrivileges()
 
     context = {'experimenterList': experimenterList,

--- a/omeroweb/webadmin/views.py
+++ b/omeroweb/webadmin/views.py
@@ -3,7 +3,7 @@
 #
 #
 #
-# Copyright (c) 2008-2018 University of Dundee.
+# Copyright (c) 2008-2020 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -100,7 +100,8 @@ class render_response_admin(omeroweb.webclient.decorators.render_response):
 def prepare_experimenter(conn, eid=None):
     if eid is None:
         eid = conn.getEventContext().userId
-    experimenter = conn.getObject("Experimenter", eid)
+    experimenter = conn.getObject("Experimenter", eid,
+                                  opts={'load_groups': True})
     defaultGroup = experimenter.getDefaultGroup()
     otherGroups = list(experimenter.getOtherGroups())
     hasAvatar = conn.hasExperimenterPhoto()
@@ -391,7 +392,8 @@ def logout(request, **kwargs):
 def experimenters(request, conn=None, **kwargs):
     template = "webadmin/experimenters.html"
 
-    experimenterList = list(conn.getObjects("Experimenter"))
+    experimenterList = list(conn.getObjects("Experimenter",
+                                            opts={'load_groups': True}))
     can_modify_user = 'ModifyUser' in conn.getCurrentAdminPrivileges()
 
     context = {'experimenterList': experimenterList,

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -518,8 +518,9 @@ def group_user_content(request, url=None, conn=None, **kwargs):
         system_groups = [
             conn.getAdminService().getSecurityRoles().userGroupId,
             conn.getAdminService().getSecurityRoles().guestGroupId]
-        groups = [g for g in conn.getObjects("ExperimenterGroup")
-                  if g.getId() not in system_groups]
+        groups = conn.getObjects("ExperimenterGroup",
+                                 opts={'load_experimenters': True})
+        groups = [g for g in groups if g.getId() not in system_groups]
         groups.sort(key=lambda x: x.getName().lower())
     else:
         groups = myGroups
@@ -1382,7 +1383,8 @@ def load_chgrp_groups(request, conn=None, **kwargs):
     # In case we were passed no objects or they weren't found
     if len(ownerIds) == 0:
         ownerIds = [conn.getUserId()]
-    for owner in conn.getObjects("Experimenter", ownerIds):
+    for owner in conn.getObjects("Experimenter", ownerIds,
+                                 opts={'load_groups': True}):
         # Each owner has a set of groups
         gids = []
         owners[owner.id] = owner.getFullName()

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1384,7 +1384,7 @@ def load_chgrp_groups(request, conn=None, **kwargs):
     if len(ownerIds) == 0:
         ownerIds = [conn.getUserId()]
     for owner in conn.getObjects("Experimenter", ownerIds,
-                                 opts={'load_groups': True}):
+                                 opts={'load_experimentergroups': True}):
         # Each owner has a set of groups
         gids = []
         owners[owner.id] = owner.getFullName()

--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -1412,23 +1412,23 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             if e.id in rm_exps:
                 # removing user from their default group #9193
                 # if e.getDefaultGroup().id != group.id:
-                to_remove.append(e._obj)
+                to_remove.append(e)
             if e.id in add_exps:
-                to_add.append(e._obj)
+                to_add.append(e)
 
         admin_serv = self.getAdminService()
         userGid = admin_serv.getSecurityRoles().userGroupId
         failures = []
         for e in to_add:
-            admin_serv.addGroups(e, [group._obj])
+            admin_serv.addGroups(e._obj, [group._obj])
         for e in to_remove:
             # Experimenter needs to stay in at least 1 non-user group
-            gs = [l.parent.id.val for l in e.copyGroupExperimenterMap()
+            gs = [l.parent.id for l in e.copyGroupExperimenterMap()
                   if l.parent.id.val != userGid]
             if len(gs) == 1:
-                failures.append(ExperimenterWrapper(self, e))
+                failures.append(ExperimenterWrapper(self, e._obj))
                 continue
-            admin_serv.removeGroups(e, [group._obj])
+            admin_serv.removeGroups(e._obj, [group._obj])
         return failures
 
     def setOwnersOfGroup(self, group, owners):

--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -2373,7 +2373,7 @@ class ExperimenterGroupWrapper(OmeroWebObjectWrapper,
                 yield ExperimenterWrapper(self._conn, gem.child)
 
     def getOwnersNames(self):
-        warnings.warn("getOwnersNames() deprecated in 5.6.3",
+        warnings.warn("getOwnersNames() deprecated in 5.7.0",
                       DeprecationWarning)
         owners = list()
         for e in self.getOwners():

--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -1380,6 +1380,10 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         @rtype                  List of L{ExperimenterWrapper}
         """
 
+        # Make sure we've loaded experimenters
+        group = self.getObject("ExperimenterGroup", group.id,
+                               opts={'load_experimenters': True})
+
         experimenters = list(self.getObjects("Experimenter"))
 
         new_membersIds = [nm.id for nm in new_members]
@@ -1387,11 +1391,10 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         old_members = group.getMembers()
         old_membersIds = [om.id for om in old_members]
 
-        old_available = list()
+        old_availableIds = []
         for e in experimenters:
             if e.id not in old_membersIds:
-                old_available.append(e)
-        old_availableIds = [oa.id for oa in old_available]
+                old_availableIds.append(e.id)
 
         new_available = list()
         for e in experimenters:
@@ -2366,6 +2369,8 @@ class ExperimenterGroupWrapper(OmeroWebObjectWrapper,
                 yield ExperimenterWrapper(self._conn, gem.child)
 
     def getOwnersNames(self):
+        warnings.warn("getOwnersNames() deprecated in 5.6.3",
+                      DeprecationWarning)
         owners = list()
         for e in self.getOwners():
             owners.append(e.getFullName())

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(name="omero-web",
       python_requires='>=3',
       install_requires=[
           # requires Ice (use wheel for faster installs)
-          'omero-py',
+          'omero-py>=5.7.0',
           # minimum requirements for `omero web start`
           'Django>=1.11,<2.0',
           'django-pipeline==1.6.14',


### PR DESCRIPTION
Ported from PR https://github.com/ome/openmicroscopy/pull/5315/

This is needed for #149 .

This requires https://github.com/ome/omero-py/pull/196 (merged - required as omero-py 5.7.0)

To test:
 - Browse to ```/api/v0/m/experimenters/``` to list all.
 - filter with ```?experimentergroup=3``` or with ```/api/v0/m/experimentergroups/3/experimenters```
 - Browse to ```/api/v0/m/experimentergroups/``` to list all.
 - filter groups with ```?experimenter=3``` or with ```/api/v0/m/experimenters/3/experimentergroups```
 - Follow links to see single experimenter or group: ```/api/v0/m/experimenters/3/``` or ```/api/v0/m/experimentergroups/3/```

NB: elsewhere we use ```?group=1``` to filter objects by permissions.
But experimenters don't have permissions and we are filtering by links, so we use ```?experimentergroup=3``` in the same way as we do ```/images/?dataset=3```.
Hopefully not *too* confusing, but I think that is logically correct.
