### PR TITLE
preserve whitespace for comments

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1167,17 +1167,10 @@
 					font-weight: bold;
 					color:#333;
 				}
-			
-			.commentText p{
-                -webkit-border-radius:2px;
-				display:block;
-				border:solid 1px transparent;
-				-webkit-border-radius:2px; /* Saf3+, Chrome */
-				   -moz-border-radius:2px; /* FF1+ */
-				        border-radius:2px; /* Opera 10.5, IE 9 */ 
-                line-height:1.4em;
-			}
-	
+
+            .commentText {
+                white-space: pre-wrap
+            }
 	
 			.removeComment {
 				float:right;

--- a/omeroweb/webclient/templates/webclient/annotations/comments_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/comments_underscore.html
@@ -23,9 +23,7 @@
                 title="Delete comment"/>
         <% } %>
 
-        <div class='commentText'>
-            <%= ann.textValue %>
-        </div>
+        <div class='commentText'><%= ann.textValue %></div>
     </div>
 
     <% if (ann.ns || ann.description) { %>

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     PyYAML
     py27: tables < 3.6.0
     py36: tables
-    pytest-sugar
     pytest-xdist
     restructuredtext-lint
     py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl


### PR DESCRIPTION
See https://forum.image.sc/t/structuring-of-comment-annotation-in-omero-web/34925

To test:
 - Add comments with new-lines etc.
 - Check that these are preserved in the displayed comments

<img width="374" alt="Screenshot 2020-03-12 at 21 02 40" src="https://user-images.githubusercontent.com/900055/76566959-beb2ed00-64a5-11ea-824d-fe1b59fe24fb.png">

<img width="366" alt="Screenshot 2020-03-12 at 21 02 55" src="https://user-images.githubusercontent.com/900055/76566981-c4a8ce00-64a5-11ea-9c40-79d01bdc0aec.png">
