### PR TITLE
Close sessions where user is anonymous but is_valid_public_url is false

### DIFF
--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -337,6 +337,9 @@ class login_required(object):
             is_anonymous = connection.isAnonymous()
             logger.debug('Is anonymous? %s' % is_anonymous)
             if is_anonymous and not is_valid_public_url:
+                if connection.c is not None:
+                    logger.debug("Closing anonymous connection")
+                    connection.close(hard=False)
                 return None
         return connection
 


### PR DESCRIPTION
Previously, if a request is made where is_valid_public_url is false but is_anonymous is true, a connection would be created but would never be closed. This PR closes those connections to prevent resource leaks.

# Testing this PR

1. required setup
- Install this version of omeroweb
- You need a public user (to make `is_anonymous` True)
- Need to have `omero.web.public.url_filter` configured without `webclient/keepalive_ping` (to make `is_valid_public_url` False for `webclient/keepalive_ping` requests)

2. actions to perform
- Navigate to a public page (e.g. a pathviewer image) which uses a keepalive ping.
- Open several tabs like this.

3. expected observations
- The thread count used by omeroweb or gunicorn should not increase over time, even as keepalive requests are made by these pages.
- Without this PR, the number of threads in use (e.g. result of `ps -Fw -u omero Hh |grep gunicorn |wc -l`) will increase over time. 