### PR TITLE
public user workflow crash

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -50,7 +50,7 @@ from omero.gateway.utils import toBoolean
 from django.conf import settings
 from django.template import loader as template_loader
 from django.http import Http404, HttpResponse, HttpResponseRedirect, \
-    JsonResponse
+    JsonResponse, HttpResponseForbidden
 from django.http import HttpResponseServerError, HttpResponseBadRequest
 from django.utils.http import urlencode
 from django.core.urlresolvers import reverse
@@ -629,6 +629,9 @@ def api_container_list(request, conn=None, **kwargs):
     # parents), screens and plates (without parents). This is fine for
     # the first page, but the second page may not be what is expected.
 
+    if not conn.isValidGroup(group_id):
+        return HttpResponseForbidden("Not a member of Group: %s" % group_id)
+
     r = dict()
     try:
         # Get the projects
@@ -704,6 +707,9 @@ def api_dataset_list(request, conn=None, **kwargs):
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
+    if not conn.isValidGroup(group_id):
+        return HttpResponseForbidden("Not a member of Group: %s" % group_id)
+
     try:
         # Get the datasets
         datasets = tree.marshal_datasets(conn=conn,
@@ -747,6 +753,9 @@ def api_image_list(request, conn=None, **kwargs):
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
+    if not conn.isValidGroup(group_id):
+        return HttpResponseForbidden("Not a member of Group: %s" % group_id)
+
     # Share ID is in kwargs from api/share_images/<id>/ which will create
     # a share connection in @login_required.
     # We don't support ?share_id in query string since this would allow a
@@ -786,6 +795,9 @@ def api_plate_list(request, conn=None, **kwargs):
         screen_id = get_long_or_default(request, 'id', None)
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
+
+    if not conn.isValidGroup(group_id):
+        return HttpResponseForbidden("Not a member of Group: %s" % group_id)
 
     try:
         # Get the plates

--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -149,8 +149,8 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         return self._shareId
 
     def isValidGroup(self, group_id):
-        group_ids = self.getEventContext().memberOfGroups
-        return group_id == -1 or group_id in group_ids
+        ec = self.getEventContext()
+        return ec.isAdmin or group_id == -1 or group_id in ec.memberOfGroups
 
     ##############################################
     #    Session methods                         #

--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -148,6 +148,10 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
                 self._shareId = self.getEventContext().shareId
         return self._shareId
 
+    def isValidGroup(self, group_id):
+        group_ids = self.getEventContext().memberOfGroups
+        return group_id == -1 or group_id in group_ids
+
     ##############################################
     #    Session methods                         #
 


### PR DESCRIPTION
Fixes https://trello.com/c/sBdAN4L6/375-bug-public-user-workflow-crash

Several URLs load data to the jsTree and include ```?group=ID``` to load data for the correct group. This causes ```SecurityViolation``` if you are not a member of that group.
A common cause of this is your session has timed-out, but when you try to connect, you are logged-in as public user (who is not a member of your group).

This PR checks for invalid group when loading 'containers', Datasets, Images, Plates in the jsTree and returns a 403 (as if you were logged out) which causes the webclient to refresh.

To test:
 - you need to log into webclient as non-public user, browse to a group that Public User is not a member of.
 - Wait for session to time out (e.g. close laptop to stop the webclient pinging keep-alive) or use @mtbc's handy command (from trello card) to kill it. E.g. if you can ```psql omero``` then:
```
for s in `echo "select uuid from session where useragent = 'OMERO.web' and closed is null" | psql omero | grep '[[:digit:]]'-` ; do omero sessions timeout --session $s 1 ; done
```
 - Then try to refresh the tree (refresh button) or expand Project, Dataset or Screen.
 - The webclient page should refresh to show that you are now logged-in as public user.

NB: If the public user IS a member of the group that you're in, then you won't see the refresh. Data will be loaded (if not a private group) but you'll be viewing it as pubic user, so you won't be able to edit etc. This is not ideal but has been the behaviour for a long time. It doesn't cause any errors and simply needs a manual refresh of the webclient page to 'fix'.