### PR TITLE
omero-web-docker release process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,11 @@ specifying ``major``, ``minor`` or ``patch`` depending on whether the developmen
 
 Remember to ``git push`` all commits and tags.
 
+omero-web-docker
+^^^^^^^^^^^^^^^^
+
+Following ``omero-web`` release, need to update and release ``omero-web-docker``.
+
 License
 -------
 


### PR DESCRIPTION
Adds ```omero-web-docker``` to Release Process on README:

Preview at:
https://github.com/will-moore/omero-web/tree/omero-web-docker_release_process

If this is OK, I can do the same for ```omero-py```