### PR TITLE
Render roi thumbnail fixes

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -705,8 +705,11 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
 
     rv = BytesIO()
     compression = 0.9
-    img.save(rv, 'jpeg', quality=int(compression*100))
-    jpeg = rv.getvalue()
+    try:
+        img.save(rv, 'jpeg', quality=int(compression*100))
+        jpeg = rv.getvalue()
+    finally:
+        rv.close()
     return HttpResponse(jpeg, content_type='image/jpeg')
 
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -443,7 +443,7 @@ def render_roi_thumbnail(request, roiId, w=None, h=None, conn=None, **kwargs):
         default_z = image.getDefaultZ()
         # find shapes on default Z/T plane
         def_shapes = [s for s in shapes if unwrap(s.getTheT()) is None
-                  or unwrap(s.getTheT()) == default_t]
+                      or unwrap(s.getTheT()) == default_t]
         if len(def_shapes) == 1:
             shape = def_shapes[0]
         else:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -508,8 +508,10 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
 
     bBox = None   # bounding box: (x, y, w, h)
     shape = {}
-    theT = s.getTheT() is not None and s.getTheT().getValue() or 0
-    theZ = s.getTheZ() is not None and s.getTheZ().getValue() or 0
+    theT = unwrap(s.getTheT())
+    theT = theT if theT is not None else image.getDefaultT()
+    theZ = unwrap(s.getTheZ())
+    theZ = theZ if theZ is not None else image.getDefaultZ()
     if type(s) == omero.model.RectangleI:
         shape['type'] = 'Rectangle'
         shape['x'] = s.getX().getValue()

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -416,42 +416,46 @@ def render_roi_thumbnail(request, roiId, w=None, h=None, conn=None, **kwargs):
     server_id = request.session['connector'].server_id
 
     # need to find the z indices of the first shape in T
-    roiResult = conn.getRoiService().findByRoi(
+    result = conn.getRoiService().findByRoi(
         long(roiId), None, conn.SERVICE_OPTS)
-    if roiResult is None or roiResult.rois is None:
+    if result is None or result.rois is None or len(result.rois) == 0:
         raise Http404
-    zz = set()
-    minT = None
-    shapes = {}
-    for roi in roiResult.rois:
+
+    for roi in result.rois:
         imageId = roi.image.id.val
-        for s in roi.copyShapes():
-            if s is None:   # seems possible in some situations
-                continue
-            t = unwrap(s.getTheT())
-            z = unwrap(s.getTheZ())
-            shapes[(z, t)] = s
-            if minT is None:
-                minT = t
-            if t < minT:
-                zz = set([z])
-                minT = t
-            elif minT == t:
-                zz.add(z)
-    zList = list(zz)
-    if len(zList) == 0:
+        shapes = roi.copyShapes()
+    shapes = [s for s in shapes if s is not None]
+
+    if len(shapes) == 0:
         raise Http404("No Shapes found for ROI %s" % roiId)
-    zList.sort()
-    midZ = zList[len(zList)/2]
-    s = shapes[(midZ, minT)]
 
     pi = _get_prepared_image(request, imageId, server_id=server_id, conn=conn)
-
     if pi is None:
         raise Http404
     image, compress_quality = pi
 
-    return get_shape_thumbnail(request, conn, image, s, compress_quality)
+    shape = None
+    # if only single shape, use it...
+    if len(shapes) == 1:
+        shape = shapes[0]
+    else:
+        default_t = image.getDefaultT()
+        default_z = image.getDefaultZ()
+        # find shapes on default Z/T plane
+        def_shapes = [s for s in shapes if unwrap(s.getTheT()) is None
+                  or unwrap(s.getTheT()) == default_t]
+        if len(def_shapes) == 1:
+            shape = def_shapes[0]
+        else:
+            def_shapes = [s for s in def_shapes if unwrap(s.getTheZ()) is None
+                          or unwrap(s.getTheZ()) == default_z]
+            if len(def_shapes) > 0:
+                shape = def_shapes[0]
+        # otherwise pick first shape
+        if shape is None and len(shapes) > 0:
+            shape = shapes[0]
+
+    return get_shape_thumbnail(request, conn, image, shape, compress_quality)
 
 
 @login_required()


### PR DESCRIPTION
Found bug in ```render_roi_thumbnail``` as part of the iviewer work at https://github.com/ome/omero-iviewer/pull/311
We don't use ```render_roi_thumbnail``` in any of our clients (old webgateway viewer uses Shapes thumbnails, not ROIs).

Added tests at https://github.com/ome/openmicroscopy/pull/6235

To test:
 - For an ROI with a single shape where Z & T are not set, try ```/webgateway/render_roi_thumbnail/{ROI_ID}/```