### PR TITLE
paths to object ROI

### DIFF
--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -452,7 +452,7 @@ def get_image_ids(conn, datasetId=None, groupId=-1, ownerId=None):
 def paths_to_object(conn, experimenter_id=None, project_id=None,
                     dataset_id=None, image_id=None, screen_id=None,
                     plate_id=None, acquisition_id=None, well_id=None,
-                    group_id=None, page_size=None):
+                    group_id=None, page_size=None, roi_id=None):
     """
     Retrieves the parents of an object (E.g. P/D/I for image) as a list
     of paths.
@@ -501,6 +501,10 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
     if dataset_id is not None:
         params.add('did', rlong(dataset_id))
         lowest_type = 'dataset'
+    if roi_id is not None:
+        roi = conn.getObject('Roi', roi_id)
+        if roi is not None:
+            image_id = roi.image.id
     if image_id is not None:
         params.add('iid', rlong(image_id))
         lowest_type = 'image'
@@ -628,6 +632,11 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
                     'type': 'image',
                     'id': imageId
                 })
+                if roi_id is not None:
+                    path.append({
+                        'type': 'roi',
+                        'id': roi_id
+                    })
                 paths.append(path)
 
     elif lowest_type == 'dataset':

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1089,6 +1089,7 @@ def api_paths_to_object(request, conn=None, **kwargs):
         well_id = request.GET.get('well', None)
         tag_id = get_long_or_default(request, 'tag', None)
         tagset_id = get_long_or_default(request, 'tagset', None)
+        roi_id = get_long_or_default(request, 'roi', None)
         group_id = get_long_or_default(request, 'group', None)
         page_size = get_long_or_default(request, 'page_size', settings.PAGE)
     except ValueError:
@@ -1101,7 +1102,7 @@ def api_paths_to_object(request, conn=None, **kwargs):
         paths = paths_to_object(conn, experimenter_id, project_id,
                                 dataset_id, image_id, screen_id, plate_id,
                                 acquisition_id, well_id, group_id,
-                                page_size=page_size)
+                                page_size, roi_id)
     return JsonResponse({'paths': paths})
 
 


### PR DESCRIPTION
Required for iviewer https://github.com/ome/omero-iviewer/pull/311

To test:
 - Test added at https://github.com/ome/openmicroscopy/pull/6228
 - Find an ROI ID and go to ```/webclient/api/paths_to_object/?roi=1```
 - Should see JSON path to the ROI:
 - See empty list if ROI ID is not found
```
{
    "paths": [
        [
            {
                "type": "experimenter",
                "id": 2
            },
            {
                "type": "project",
                "id": 152
            },
            {
                "type": "dataset",
                "id": 151,
                "childCount": 33
            },
            {
                "type": "image",
                "id": 838
            },
            {
                "type": "roi",
                "id": 179711
            }
        ]
    ]
}
```