### PR TITLE
Fix edit of shares

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2716,6 +2716,8 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
 
     elif action == 'edit':
         # form for editing Shares only
+        if o_id is None:
+            raise Http404("No share ID")
         if o_type == "share" and int(o_id) > 0:
             template = "webclient/public/share_form.html"
             manager.getMembers(o_id)

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2716,7 +2716,7 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
 
     elif action == 'edit':
         # form for editing Shares only
-        if o_type == "share" and o_id > 0:
+        if o_type == "share" and int(o_id) > 0:
             template = "webclient/public/share_form.html"
             manager.getMembers(o_id)
             manager.getComments(o_id)


### PR DESCRIPTION
Fix bug with editing of shares, reported at https://www.openmicroscopy.org/qa2/qa/feedback/29218/

```
File "/opt/omero/web/venv3/lib/python3.7/site-packages/omeroweb/webclient/views.py", line 2719, in manage_action_containers
if o_type == "share" and o_id > 0:
TypeError: '>' not supported between instances of 'str' and 'int'
```

To test:
 - Select some Images and create a 'share' in the webclient
 - Under 'Public' tab, select the Share then click the 'Edit' (green pen) in the right panel
 - Should see no error - can make a change and save it.
 - /webclient/action/edit/share/ should return a 404 (not an exception)