### PR TITLE
Fix thumbnail size from config

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1566,8 +1566,11 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
     @param w:           Thumbnail max width. 96 by default
     @return:            http response containing base64 encoded thumbnails
     """
+    server_settings = request.session.get('server_settings', {}) \
+                                     .get('browser', {})
+    defaultSize = server_settings.get('thumb_default_size', 96)
     if w is None:
-        w = 96
+        w = defaultSize
     image_ids = get_longs(request, 'id')
     image_ids = list(set(image_ids))    # remove any duplicates
     # If we only have a single ID, simply use getThumbnail()


### PR DESCRIPTION
This fixes #164 a long-standing bug: the batch JSON loading of thumbnails ignores the thumbnail size setting.

To test:

``` $ omero config set omero.client.browser.thumb_default_size 250```

Then check in browser dev tools the 'natural' size of the thumbnails in webclient.

<img width="588" alt="Screenshot 2020-04-26 at 23 05 24" src="https://user-images.githubusercontent.com/900055/80321110-7dd32580-8812-11ea-8fca-dfd51ea8c463.png">


