### PR TITLE
Set sign_tags to True by default in .bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,6 +2,7 @@
 current_version = 5.6.4.dev0
 commit = True
 tag = True
+sign_tags = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{build}


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/221