### PR TITLE
paths_to_object supports ?shape=1

### DIFF
--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -449,8 +449,8 @@ def get_image_ids(conn, datasetId=None, groupId=-1, ownerId=None):
     return iids
 
 
-def get_image_id_for_shape(conn, shape_id):
-    """Find ROI ID and Image ID from a shape ID."""
+def get_image_roi_id_for_shape(conn, shape_id):
+    """Returns (Image_ID, ROI_ID) from a shape ID."""
     params = omero.sys.ParametersI()
     params.addId(shape_id)
     query = """select roi from Roi roi
@@ -460,7 +460,7 @@ def get_image_id_for_shape(conn, shape_id):
     result = query_service.findByQuery(query, params, conn.SERVICE_OPTS)
     if result:
         roi = result
-        return (roi.id.val, roi.image.id.val)
+        return (roi.image.id.val, roi.id.val)
     return (None, None)
 
 
@@ -522,7 +522,7 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
         if roi is not None:
             image_id = roi.image.id
     if shape_id is not None:
-        roi_id, image_id = get_image_id_for_shape(conn, shape_id)
+        image_id, roi_id = get_image_roi_id_for_shape(conn, shape_id)
     if image_id is not None:
         params.add('iid', rlong(image_id))
         lowest_type = 'image'

--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -461,6 +461,7 @@ def get_image_id_for_shape(conn, shape_id):
     if result:
         roi = result
         return (roi.id.val, roi.image.id.val)
+    return (None, None)
 
 
 def paths_to_object(conn, experimenter_id=None, project_id=None,

--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -650,17 +650,19 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
                     'type': 'image',
                     'id': imageId
                 })
-                if roi_id is not None:
-                    path.append({
-                        'type': 'roi',
-                        'id': roi_id
-                    })
-                if shape_id is not None:
-                    path.append({
-                        'type': 'shape',
-                        'id': shape_id
-                    })
                 paths.append(path)
+        # Any roi/shape info to paths
+        for path in paths:
+            if roi_id is not None:
+                path.append({
+                    'type': 'roi',
+                    'id': roi_id
+                })
+            if shape_id is not None:
+                path.append({
+                    'type': 'shape',
+                    'id': shape_id
+                })
 
     elif lowest_type == 'dataset':
         q = '''

--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -897,7 +897,8 @@ def paths_to_well_image(conn, params, well_id=None, image_id=None,
                slink.parent.id,
                plate.id,
                acquisition.id,
-               well.id
+               well.id,
+               wellsample.id
         from WellSample wellsample
         join wellsample.details.owner wsowner
         left outer join wellsample.plateAcquisition acquisition
@@ -960,6 +961,18 @@ def paths_to_well_image(conn, params, well_id=None, image_id=None,
             path.append({
                 'type': 'well',
                 'id': e[4].val
+            })
+
+        # Include WellSampe if path is to image
+        if e[5] is not None and orphanedImage:
+            path.append({
+                'type': 'wellsample',
+                'id': e[5].val
+            })
+        if image_id is not None:
+            path.append({
+                'type': 'image',
+                'id': image_id
             })
 
         paths.append(path)

--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -453,7 +453,9 @@ def get_image_id_for_shape(conn, shape_id):
     """Find ROI ID and Image ID from a shape ID."""
     params = omero.sys.ParametersI()
     params.addId(shape_id)
-    query = "select roi from Roi roi left outer join roi.shapes as shape where shape.id=:id"
+    query = """select roi from Roi roi
+        left outer join roi.shapes as shape
+        where shape.id=:id"""
     query_service = conn.getQueryService()
     result = query_service.findByQuery(query, params, conn.SERVICE_OPTS)
     if result:

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1107,6 +1107,7 @@ def api_paths_to_object(request, conn=None, **kwargs):
         tag_id = get_long_or_default(request, 'tag', None)
         tagset_id = get_long_or_default(request, 'tagset', None)
         roi_id = get_long_or_default(request, 'roi', None)
+        shape_id = get_long_or_default(request, 'shape', None)
         group_id = get_long_or_default(request, 'group', None)
         page_size = get_long_or_default(request, 'page_size', settings.PAGE)
     except ValueError:
@@ -1119,7 +1120,7 @@ def api_paths_to_object(request, conn=None, **kwargs):
         paths = paths_to_object(conn, experimenter_id, project_id,
                                 dataset_id, image_id, screen_id, plate_id,
                                 acquisition_id, well_id, group_id,
-                                page_size, roi_id)
+                                page_size, roi_id, shape_id)
     return JsonResponse({'paths': paths})
 
 


### PR DESCRIPTION
This adds `?shape=1` support to paths_to_objects. (Similar to #159 for ROIs).
Required to support ?shape=1 in iviewer.

Test added in https://github.com/ome/openmicroscopy/pull/6239

To test:
 - With a shape ID: go to `/webclient/api/paths_to_object/?shape=2`
 - Should see a 'path' of objects, including image, roi and shape.
 - Using an invalid Shape ID should return empty JSON list.