### PR TITLE
Handle no 'callback' in request.session

### DIFF
--- a/omeroweb/webclient/webclient_utils.py
+++ b/omeroweb/webclient/webclient_utils.py
@@ -66,7 +66,7 @@ def _formatReport(callback):
 
 def _purgeCallback(request):
 
-    callbacks = request.session.get('callback').keys()
+    callbacks = request.session.get('callback', {}).keys()
     if len(callbacks) > 200:
         for (cbString, count) in zip(request.session.get('callback').keys(),
                                      range(0, len(callbacks)-200)):


### PR DESCRIPTION
Avoids error reported at https://www.openmicroscopy.org/qa2/qa/feedback/29405/
where no 'callback' dict in the session. Now returns `{}` instead of None.

```
File "/home/omero/OMERO.server/lib/python/omeroweb/webclient/views.py", line 3134, in activities
_purgeCallback(request)
File "/home/omero/OMERO.server/lib/python/omeroweb/webclient/webclient_utils.py", line 62, in _purgeCallback
AttributeError: 'NoneType' object has no attribute 'keys'
path:/webclient/activities/,
```

Don't know how to reproduce the error - can't happen very often since I've not seen this error much.

Could get this into `omero-web 5.7.0`