### PR TITLE
Download table as csv

### DIFF
--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -89,6 +89,19 @@ class ConnCleaningHttpResponse(StreamingHttpResponse):
             logger.error('Failed to clean up connection.', exc_info=True)
 
 
+class TableClosingHttpResponse(ConnCleaningHttpResponse):
+    """Extension of L{HttpResponse} which closes the OMERO connection."""
+
+    def close(self):
+        try:
+            if self.table is not None:
+                self.table.close()
+        except Exception:
+            logger.error('Failed to close OMERO.table.', exc_info=True)
+        # Now call super to close conn
+        super(TableClosingHttpResponse, self).close()
+
+
 class login_required(object):
     """
     OMERO.web specific extension of the Django login_required() decorator,

--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -27,6 +27,7 @@ import logging
 import traceback
 from django.http import Http404, HttpResponse, HttpResponseRedirect, \
     JsonResponse
+from django.http.response import HttpResponseBase
 from django.shortcuts import render
 from django.http import HttpResponseForbidden, StreamingHttpResponse
 
@@ -556,7 +557,7 @@ class render_response(object):
             context = f(request, *args, **kwargs)
 
             # if we happen to have a Response, return it
-            if isinstance(context, HttpResponse):
+            if isinstance(context, HttpResponseBase):
                 return context
 
             # get template from view dict. Can be overridden from the **kwargs

--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -25,7 +25,7 @@ Decorators for use with OMERO.web applications.
 
 import logging
 import traceback
-from django.http import Http404, HttpResponse, HttpResponseRedirect, \
+from django.http import Http404, HttpResponseRedirect, \
     JsonResponse
 from django.http.response import HttpResponseBase
 from django.shortcuts import render

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3029,7 +3029,6 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
         rsp['Content-Disposition'] = ('attachment; filename=%s' % downloadName)
         return rsp
 
-
     context['data']['name'] = orig_file.name
     context['data']['path'] = orig_file.path
     context['data']['id'] = file_id

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3013,10 +3013,11 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
         table_data = context.get('data')
 
         def csv_gen():
-            csv_rows = ",".join(table_data.get('columns')) + '\n'
-            yield csv_rows
+            csv_cols = ",".join(table_data.get('columns'))
+            yield csv_cols
             for rows in table_data.get('lazy_rows'):
-                yield '\n'.join([",".join(row) for row in rows]) + '\n'
+                yield ('\n' + '\n'.join([",".join([str(d) for d in row])
+                       for row in rows]))
 
         downloadName = orig_file.name.replace(" ", "_").replace(",", ".")
         downloadName = downloadName + ".csv"

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2980,11 +2980,12 @@ def get_original_file(request, fileId, download=False, conn=None, **kwargs):
     return rsp
 
 
-@login_required()
+@login_required(doConnectionCleanup=False)
 @render_response()
 def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
     """
-    Download OMERO.table as CSV or show as HTML table
+    Download OMERO.table as CSV (streaming response) or return as HTML or json
+
     @param file_id:     OriginalFile ID
     @param mtype:       None for html table or 'csv' or 'json'
     @param conn:        BlitzGateway connection

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2804,7 +2804,8 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
     @param query:       The table query. If None, use request.GET.get('query')
                         E.g. '*' to return all rows.
                         If in the form 'colname-1', query will be (colname==1)
-    @param lazy:        If True, instead of 'rows' list, 'lazy_rows' will be generator.
+    @param lazy:        If True, instead of returning a 'rows' list,
+                        'lazy_rows' will be a generator.
                         Each gen.next() will return a list of row data
                         AND 'table' returned MUST be closed.
     @param conn:        L{omero.gateway.BlitzGateway}
@@ -2871,7 +2872,8 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
                     yield row_data
             else:
                 for hit in h:
-                    row_vals = [str(col.values[0]) for col in
+                    row_vals = [
+                        str(col.values[0]) for col in
                         table.read(range(len(cols)), hit, hit+1).columns]
                     # yield a list of rows, with only a single row
                     yield [row_vals]

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2866,7 +2866,7 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
                     for col in table.read(
                             range(len(cols)), h[idx], h[idx] + batch).columns:
                         for r in range(batch):
-                            row_data[r].append(str(col.values[r]))
+                            row_data[r].append(col.values[r])
                     idx += batch
                     # yield a list of rows
                     yield row_data

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2873,7 +2873,7 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
             else:
                 for hit in h:
                     row_vals = [
-                        str(col.values[0]) for col in
+                        col.values[0] for col in
                         table.read(range(len(cols)), hit, hit+1).columns]
                     # yield a list of rows, with only a single row
                     yield [row_vals]


### PR DESCRIPTION
NB: this is on top of #191. 

This allows downloading of much larger OMERO.table files as csv.

Currently, downloading of OMERO.tables is slow and will timeout with a reasonable sized table because:
 - we use table.read() to get 1 row at a time
 - we read all the rows in hand, then format string as csv and return as HttpResponse

This PR improves this by:
 - reading rows in batches of 1000 (when downloading ALL rows `query=*`)
 - streaming the response - download starts immediately

To test:
 - Find a large OMERO.table. - I'll create an example one on merge-ci soon...
 - Click on 'eye' to open as html table
 - Click to download as CSV, either with a query to filter rows or without query (whole table)

cc @manics
