### PR TITLE
Always marshal tile metadata on presence of pyramid

### DIFF
--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -168,11 +168,11 @@ def imageMarshal(image, key=None, request=None):
         return rv       # Return what we have already, in case it's useful
 
     # big images
-    tiles = image._re.requiresPixelsPyramid()
+    levels = image._re.getResolutionLevels()
+    tiles = levels > 1
     rv['tiles'] = tiles
-    if (tiles):
+    if tiles:
         width, height = image._re.getTileSize()
-        levels = image._re.getResolutionLevels()
         zoomLevelScaling = image.getZoomLevelScaling()
 
         rv.update({'tile_size': {'width': width,


### PR DESCRIPTION
It is possible, in particular for floating point data, that a pyramid is
present even if the server thinks a pyramid is not required.  The
condition for tile metadata being available is now pyramid presence.

See:

 * ome/omero-romio#24

/cc @kkoz, @melissalinkert, @knabar 