### PR TITLE
Be defensive and return default value for scripts_to_ignore

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3678,8 +3678,8 @@ def list_scripts(request, conn=None, **kwargs):
 
     # group scripts into 'folders' (path), named by parent folder name
     scriptMenu = {}
-    scripts_to_ignore = request.session.get('server_settings') \
-                                       .get('scripts_to_ignore').split(",")
+    scripts_to_ignore = request.session.get('server_settings', {}) \
+        .get('scripts_to_ignore', "").split(",")
     for s in scripts:
         scriptId = s.id.val
         path = s.path.val


### PR DESCRIPTION
Reported in a QA feedback, under some condition there might be no `scripts_to_ignore` key in the `server-settings` dictionary leading to an `AttributeError`.

This change fixes this issue by returning a default value as done elsewhere in the code e.g.

https://github.com/ome/omero-web/blob/9284f6a5a6f335a1a2708c74f2ebd825142ca2ae/omeroweb/webgateway/marshal.py#L190-L191