### PR TITLE
Prevent large zip files for archived files from being created

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -598,7 +598,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
          1024 ** 3,
          int,
          "Prevent multiple files with total aggregate size greater than this "
-         " value in bytes from being downloaded as a zip archive."],
+         "value in bytes from being downloaded as a zip archive."],
 
     # VIEWER
     "omero.web.viewer.view":

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -593,6 +593,12 @@ CUSTOM_SETTINGS_MAPPINGS = {
          "Size, in bytes, of the “chunk”"],
     "omero.web.webgateway_cache":
         ["WEBGATEWAY_CACHE", None, leave_none_unset, None],
+    "omero.web.maximum_multifile_download_size":
+        ["MAXIMUM_MULTIFILE_DOWNLOAD_ZIP_SIZE",
+         1024 ** 3,
+         int,
+         "Prevent multiple files with total aggregate size greater than this "
+         " value in bytes from being downloaded as a zip archive."],
 
     # VIEWER
     "omero.web.viewer.view":

--- a/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -101,6 +101,17 @@ Download files
     <p>Create and download a zip file which will contain these
         {% if fileLists %} files{% else %} images{% endif %}:</p>
 
+    {% if downloadTooLarge %}
+
+    <p class="error">
+        Not available:
+        Total size of files {{ filesTotalSize|filesizeformat }}
+        is larger than {{ downloadTooLarge|filesizeformat }}.
+        Try requesting fewer files.
+    </p>
+
+    {% else %}
+
     <div style="padding: 15px; float: right">
         <input type="submit" value="Create Zip"/>
     </div>
@@ -109,6 +120,7 @@ Download files
         Zip file name:
         <input id="zipName" value="{{ defaultName }}.zip"/>
     </p>
+    {% endif %}
 
     <div style="clear:both"></div>
 

--- a/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -107,7 +107,6 @@ Download files
         Not available:
         Total size of files {{ filesTotalSize|filesizeformat }}
         is larger than {{ downloadTooLarge|filesizeformat }}.
-        Try requesting fewer files.
     </p>
 
     {% else %}

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3144,6 +3144,7 @@ def download_placeholder(request, conn=None, **kwargs):
 
     fileLists = []
     fileCount = 0
+    filesTotalSize = 0
     # If we're downloading originals, list original files so user can
     # download individual files.
     if format is None:
@@ -3182,6 +3183,7 @@ def download_placeholder(request, conn=None, **kwargs):
                 fList.append({'id': f.id,
                               'name': f.name,
                               'size': f.getSize()})
+                filesTotalSize += f.getSize()
             if len(fList) > 0:
                 fileLists.append(fList)
         fileCount = sum([len(fList) for fList in fileLists])
@@ -3200,8 +3202,12 @@ def download_placeholder(request, conn=None, **kwargs):
         'url': download_url,
         'defaultName': defaultName,
         'fileLists': fileLists,
-        'fileCount': fileCount
-        }
+        'fileCount': fileCount,
+        'filesTotalSize': filesTotalSize,
+    }
+    if filesTotalSize > settings.MAXIMUM_MULTIFILE_DOWNLOAD_ZIP_SIZE:
+        context['downloadTooLarge'] = \
+            settings.MAXIMUM_MULTIFILE_DOWNLOAD_ZIP_SIZE
     return context
 
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2552,6 +2552,16 @@ def archived_files(request, iid=None, conn=None, **kwargs):
         fname = orig_file.getName().replace(" ", "_").replace(",", ".")
         rsp['Content-Disposition'] = 'attachment; filename=%s' % (fname)
     else:
+        total_size = sum(f.size for f in files)
+        if total_size > settings.MAXIMUM_MULTIFILE_DOWNLOAD_ZIP_SIZE:
+            message = ('Total size of files %d is larger than %d. '
+                       'Try requesting fewer files.' % (
+                           total_size,
+                           settings.MAXIMUM_MULTIFILE_DOWNLOAD_ZIP_SIZE))
+            logger.warn(message)
+            rsp = ConnCleaningHttpResponse(StringIO(message), status=403)
+            rsp.conn = conn
+            return rsp
 
         temp = tempfile.NamedTemporaryFile(suffix='.archive')
         zipName = request.GET.get('zipname', image.getName())


### PR DESCRIPTION
This prevents too many large files being zipped up which can lead to excessive use of disk space, either on the node creating the zip or due to buffering in a proxy.

Closes https://github.com/ome/omero-web/issues/118 (at least it closes the particular URL that's causing problems, it's quite likely other URLs could cause problems too).

Testing:
1. Optionally set the maximum size limit to something small to make testing easier, e.g. 1MB: `omero config set omero.web.maximum_multifile_download_size 1048576`.
2. Find some images for which you can download the original archived files
3. Select enough images to take you over the limit you set in step 1. If you didn't set a limit the default is 1GB (should it be larger? Or unlimited?).
4. Attempt to download them. Instead of a zip link you should see an error message:

![image](https://user-images.githubusercontent.com/1644105/88945082-71cd8880-d285-11ea-868f-e3487abe8739.png)
