### PR TITLE
shortening filter fix

### DIFF
--- a/omeroweb/webgateway/templatetags/common_filters.py
+++ b/omeroweb/webgateway/templatetags/common_filters.py
@@ -140,17 +140,15 @@ def shortening(value, arg):
         length = int(arg)
     except ValueError:  # invalid literal for int()
         return value  # Fail silently.
-    front = length/2-3
-    end = length/2-3
+    chunk = length//2-3
 
     if not isinstance(value, basestring):
         value = str(value)
     try:
-        length = len(value)
-        if length < length:
+        if len(value) < length:
             return value
-        elif length >= length:
-            return value[:front]+"..."+value[length-end:]
+        else:
+            return value[:chunk]+"..."+value[length-chunk:]
     except Exception:
         logger.error(traceback.format_exc())
         return value


### PR DESCRIPTION
Fixes #194 

Another python 2 > 3 fix. Use integer division to fix error from issue above.

To test:
 - Check "Companion Files" tab of https://merge-ci.openmicroscopy.org/web/webclient/?show=image-83221 (user-3)
 - Should be shortened with `start...end` (3 dots in the middle).
 - Currently, the shortening fails (and is logged) but the full name is still displayed:

![Screenshot 2020-08-05 at 15 39 31](https://user-images.githubusercontent.com/900055/89426281-e5faa700-d731-11ea-967f-6f71e1b88c99.png)
