### PR TITLE
link ownership matches parent

### DIFF
--- a/omeroweb/feedback/views.py
+++ b/omeroweb/feedback/views.py
@@ -184,7 +184,7 @@ def handler500(request):
     return render(request, template, context, status=500)
 
 
-def handler404(request):
+def handler404(request, exception=None):
     logger.warning(
         'Not Found: %s' % request.path,
         extra={

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1000,21 +1000,21 @@ def _api_links_POST(conn, json_data, **kwargs):
         conn.SERVICE_OPTS.setOmeroGroup(p.details.group.id.val)
         logger.info("api_link: Saving %s links" % len(linksToSave))
 
-        # try:
-        # We try to save all at once, for speed.
-        conn.saveArray(linksToSave)
-        response['success'] = True
-        # except Exception:
-        #     logger.info("api_link: Exception on saveArray with %s links"
-        #                 % len(linksToSave))
-        #     # If this fails, e.g. ValidationException because link
-        #     # already exists, try to save individual links
-        #     for link in linksToSave:
-        #         try:
-        #             conn.saveObject(link)
-        #         except Exception:
-        #             pass
-        #     response['success'] = True
+        try:
+            # We try to save all at once, for speed.
+            conn.saveArray(linksToSave)
+            response['success'] = True
+        except Exception:
+            logger.info("api_link: Exception on saveArray with %s links"
+                        % len(linksToSave))
+            # If this fails, e.g. ValidationException because link
+            # already exists, try to save individual links
+            for link in linksToSave:
+                try:
+                    conn.saveObject(link)
+                except Exception:
+                    pass
+            response['success'] = True
 
     return JsonResponse(response)
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -970,7 +970,7 @@ def _api_links_POST(conn, json_data, **kwargs):
 
     linksToSave = []
     for parent_type, parents in json_data.items():
-        if parent_type == "orphaned":
+        if parent_type in ("orphaned", "experimenter"):
             continue
         for parent_id, children in parents.items():
             parent = conn.getObject(

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -104,7 +104,7 @@ from omero.model import AnnotationAnnotationLinkI, \
     ProjectDatasetLinkI, \
     ScreenI, \
     ScreenPlateLinkI, \
-    TagAnnotationI,
+    TagAnnotationI
 from omero import ApiUsageException, ServerError, CmdError
 from omeroweb.webgateway.views import LoginView
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1000,21 +1000,21 @@ def _api_links_POST(conn, json_data, **kwargs):
         conn.SERVICE_OPTS.setOmeroGroup(p.details.group.id.val)
         logger.info("api_link: Saving %s links" % len(linksToSave))
 
-        try:
-            # We try to save all at once, for speed.
-            conn.saveArray(linksToSave)
-            response['success'] = True
-        except Exception:
-            logger.info("api_link: Exception on saveArray with %s links"
-                        % len(linksToSave))
-            # If this fails, e.g. ValidationException because link
-            # already exists, try to save individual links
-            for link in linksToSave:
-                try:
-                    conn.saveObject(link)
-                except Exception:
-                    pass
-            response['success'] = True
+        # try:
+        # We try to save all at once, for speed.
+        conn.saveArray(linksToSave)
+        response['success'] = True
+        # except Exception:
+        #     logger.info("api_link: Exception on saveArray with %s links"
+        #                 % len(linksToSave))
+        #     # If this fails, e.g. ValidationException because link
+        #     # already exists, try to save individual links
+        #     for link in linksToSave:
+        #         try:
+        #             conn.saveObject(link)
+        #         except Exception:
+        #             pass
+        #     response['success'] = True
 
     return JsonResponse(response)
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -929,8 +929,8 @@ def set_link_owner(conn, link, parent_type, child_type):
     qs = conn.getQueryService()
     child = qs.get(child_type.title(), link.child.id.val, conn.SERVICE_OPTS)
     is_child_mine = child.details.owner.id.val == exp_id
-    if not is_child_mine:
-        # link owner should match parent owner
+    if WEBCLIENT.current_admin_privileges.indexOf('WriteOwned') > -1:
+        # If we have permissions, link owner should match parent owner
         parent = qs.get(parent_type.title(), link.parent.id.val,
                         conn.SERVICE_OPTS)
         link.details.owner = ExperimenterI(parent.details.owner.id.val, False)


### PR DESCRIPTION
Fixes #182 

Current logic (needs discussion):
 - When a user creates a link, if they don't own the child object, the link owner will be set to match the child IF user has WriteOwned privileges.

To test:
 - Login as an Admin with WriteOwned privilege.
 - Move an object you don't own (e.g. Dataset, Image, Plate) into a container you don't own.
 - The link created should belong to the owner of the Child object and be deletable by that user (can cut the object or drag it to another container)

cc @pwalczysko 