### PR TITLE
Cap pytest-xdist to avoid psutil failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ deps =
     PyYAML
     py27: tables < 3.6.0
     py36: tables
-    pytest-xdist
+    # https://github.com/pytest-dev/pytest-xdist/issues/585
+    pytest-xdist < 2
     restructuredtext-lint
     py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl


### PR DESCRIPTION
See pytest-dev/pytest-xdist#585 for the rationale

This should fix Travis CI which is currently failing while trying to install `psutil`