### PR TITLE
Return 404 for imgData if image not found

### DIFF
--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -76,10 +76,15 @@ def get_client_ip(request):
     return ip
 
 
-def is_public_user(conn):
-    """Is the current user the same as the configured public user?"""
-    return (hasattr(settings, 'PUBLIC_USER') and
-            settings.PUBLIC_USER == conn.getUser().getOmeName())
+def is_public_user(request):
+    """
+    Is the session connector created for public user?
+
+    Returns None if no connector found
+    """
+    connector = request.session.get('connector')
+    if connector is not None:
+        return connector.is_public
 
 
 class ConnCleaningHttpResponse(StreamingHttpResponse):

--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -76,6 +76,12 @@ def get_client_ip(request):
     return ip
 
 
+def is_pubic_user(conn):
+    """Is the current user the same as the configured public user?"""
+    return (hasattr(settings, 'PUBLIC_USER') and
+            settings.PUBLIC_USER == conn.getUser().getOmeName())
+
+
 class ConnCleaningHttpResponse(StreamingHttpResponse):
     """Extension of L{HttpResponse} which closes the OMERO connection."""
 

--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -76,7 +76,7 @@ def get_client_ip(request):
     return ip
 
 
-def is_pubic_user(conn):
+def is_public_user(conn):
     """Is the current user the same as the configured public user?"""
     return (hasattr(settings, 'PUBLIC_USER') and
             settings.PUBLIC_USER == conn.getUser().getOmeName())

--- a/omeroweb/webclient/decorators.py
+++ b/omeroweb/webclient/decorators.py
@@ -127,9 +127,9 @@ class render_response(omeroweb.decorators.render_response):
         }}
 
         context.setdefault('ome', {})   # don't overwrite existing ome
-        connector = request.session.get('connector')
-        if connector is not None:
-            context['ome']['is_public_user'] = connector.is_public
+        public_user = omeroweb.decorators.is_public_user(request)
+        if public_user is not None:
+            context['ome']['is_public_user'] = public_user
         context['ome']['eventContext'] = eventContextMarshal(
             conn.getEventContext())
         context['ome']['user'] = conn.getUser

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -43,7 +43,7 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.views.generic import View
 from django.shortcuts import render
 from omeroweb.webadmin.forms import LoginForm
-from omeroweb.decorators import get_client_ip
+from omeroweb.decorators import get_client_ip, is_pubic_user
 from omeroweb.webadmin.webadmin_utils import upgradeCheck
 
 try:
@@ -1494,7 +1494,11 @@ def imageData_json(request, conn=None, _internal=False, **kwargs):
     key = kwargs.get('key', None)
     image = conn.getObject("Image", iid)
     if image is None:
-        return HttpResponseNotFound(f'Image:{iid} not found')
+        if is_pubic_user(conn):
+            # 403 - Should try logging in
+            return HttpResponseForbidden()
+        else:
+            return HttpResponseNotFound(f'Image:{iid} not found')
     if request.GET.get('getDefaults') == 'true':
         image.resetDefaults(save=False)
     rv = imageMarshal(image, key=key, request=request)

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -43,7 +43,7 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.views.generic import View
 from django.shortcuts import render
 from omeroweb.webadmin.forms import LoginForm
-from omeroweb.decorators import get_client_ip, is_pubic_user
+from omeroweb.decorators import get_client_ip, is_public_user
 from omeroweb.webadmin.webadmin_utils import upgradeCheck
 
 try:
@@ -1494,7 +1494,7 @@ def imageData_json(request, conn=None, _internal=False, **kwargs):
     key = kwargs.get('key', None)
     image = conn.getObject("Image", iid)
     if image is None:
-        if is_pubic_user(conn):
+        if is_public_user(conn):
             # 403 - Should try logging in
             return HttpResponseForbidden()
         else:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1494,7 +1494,7 @@ def imageData_json(request, conn=None, _internal=False, **kwargs):
     key = kwargs.get('key', None)
     image = conn.getObject("Image", iid)
     if image is None:
-        if is_public_user(conn):
+        if is_public_user(request):
             # 403 - Should try logging in
             return HttpResponseForbidden()
         else:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1494,7 +1494,7 @@ def imageData_json(request, conn=None, _internal=False, **kwargs):
     key = kwargs.get('key', None)
     image = conn.getObject("Image", iid)
     if image is None:
-        return HttpJavascriptResponseServerError('""')
+        return HttpResponseNotFound(f'Image:{iid} not found')
     if request.GET.get('getDefaults') == 'true':
         image.resetDefaults(save=False)
     rv = imageMarshal(image, key=key, request=request)


### PR DESCRIPTION
See https://forum.image.sc/t/opening-omero-images-through-qupath/33703/37

Previously if you access `webclient/imgData/123/` and that image is not found or you don't have permission to view it, you would get returned a 500 response.
Now we correctly return a 404.

To test:
 - go to `webclient/imgData/ID/` with an invalid ID, logged-in as a regular user and check the 404 status in browser dev-tools Console.
 - logout then (on a server with public user configured) go to the same URL and you should get a 403 response.