### PR TITLE
disk usage percent fix

### DIFF
--- a/omeroweb/webadmin/templates/webadmin/includes/drivespaceStats.html
+++ b/omeroweb/webadmin/templates/webadmin/includes/drivespaceStats.html
@@ -34,8 +34,17 @@
 
             <div class="summary">
                 <!-- show 'Total usage' or 'Group usage' or 'User usage' -->
-                <h3><span class="totalUsage">Total</span> {% trans "usage" %}: <span id="total"></span></h3>
-                <h3>{% trans "Free space" %}: <span id="free_space"></span></h3>
+                <p>
+                    <span class="totalUsage">Total</span> {% trans "usage" %}:
+                    <span id="total" style="color:black"></span><br>
+                    {% trans "Free space" %}:
+                    <span id="free_space" style="color:black"></span>
+                </p>
+                <p>
+                    NB: Total usage is calculated as the sum of all data, including any 'in-place' imports,
+                    where the data is not on the server's drive. This may result in inaccurate percentages
+                    above when calculated against the free space on the server's drive.
+                </p>
             </div>
 
             <table id="drivespaceTable" class="tablesorter" style="display: none;">

--- a/omeroweb/webadmin/templates/webadmin/includes/drivespaceStats.js
+++ b/omeroweb/webadmin/templates/webadmin/includes/drivespaceStats.js
@@ -62,7 +62,7 @@
 
                     $('#total').text(total.filesizeformat());
                     var usagePercent = 100 * total/(total + FREE_SPACE);
-                    progressbar.progressbar( "value", parseInt(usagePercent, 10));
+                    progressbar.progressbar( "value", parseInt(Math.round(usagePercent), 10));
 
                     $("#placeholder").css('width',700).css('height',300);
                     $.plot($("#placeholder"), chart_data,


### PR DESCRIPTION
See https://forum.image.sc/t/omero-web-reports-disk-usage-incorrectly/42219

This rounds the usagePercent value before casting it to Int, to avoid strange JavaScript parseInt behaviour of ignoring exponentials for very small numbers (see example in link above).

To test: - probably not so easy to create multi-petabyte free disk space.
So might have to just check the code change against the examples in the link above.