### PR TITLE
chgrp owner not in group

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1399,7 +1399,9 @@ def load_chgrp_groups(request, conn=None, **kwargs):
     # if all the Objects are in a single group, exclude it from the target
     # groups
     if len(currentGroups) == 1:
-        targetGroupIds.remove(currentGroups.pop())
+        curr_grp = currentGroups.pop()
+        if curr_grp in targetGroupIds:
+            targetGroupIds.remove(curr_grp)
 
     def getPerms(group):
         p = group.getDetails().permissions


### PR DESCRIPTION
Error reported at https://www.openmicroscopy.org/qa2/qa/feedback/29521/

We previously assumed that the owner of the data we're chgrp-ing is a member of the
group that the data starts in. But this may not be true (see workflow described on QA link).

To test:
 - Choose some data (P/D/I etc) that you want to move to a new user and group, where the user is not a member of the starting group.
 - Use `$ omero chown username Dataset:1` to change the ownership
 - Login to webclient as an Admin, browse to the group showing data from "All Members"
 - Select the object(s) - see that the ownership has been switched to the target user (that isn't a member of the current group)
 - Choose `chgrp`...
 - You should see a list of the groups that the data owner is a member of (this failed before)
 - choose one, and move the data to that group as normal.
