### PR TITLE
Run tox in travis instead of Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 *.egg-info/
 *.pyc
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - python setup.py sdist
   - pip install dist/omero-web*gz
   - python -c "import omeroweb.version as owv; print(owv.omeroweb_version)"
-  - tox
+  - tox -e travis
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - docker
 
 before_install:
-  - pip install -U pip
+  - pip install -U pip tox
   - pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
   # https://github.com/ome/openmicroscopy/blob/v5.5.1/Dockerfile#L32
   - python -c "import Ice; print(Ice.stringVersion())"
@@ -19,8 +19,7 @@ script:
   - python setup.py sdist
   - pip install dist/omero-web*gz
   - python -c "import omeroweb.version as owv; print(owv.omeroweb_version)"
-  - docker build -t test .
-  - docker run --rm -ti test
+  - tox
 
 deploy:
   provider: pypi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
+# Default tox environment when run without `-e`
 envlist = py36
+# Use `-e travis` to speed up travis by installing a pre-built ice wheel
+
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel
 requires = pip >= 19.0.0
@@ -12,12 +15,13 @@ deps =
     numpy>=1.9
     pytest
     PyYAML
-    py27: tables < 3.6.0
-    py36: tables
+    tables
     # https://github.com/pytest-dev/pytest-xdist/issues/585
     pytest-xdist < 2
     restructuredtext-lint
-    py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
+    py36: zeroc-ice >3.6,<3.7
+    travis: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
+
 
 setenv =
     OMERODIR = {toxinidir}
@@ -32,5 +36,5 @@ commands =
     pip install .
     pytest {posargs:-rf}
 
-[testenv:py36]
+[testenv:travis]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps =
     # https://github.com/pytest-dev/pytest-xdist/issues/585
     pytest-xdist < 2
     restructuredtext-lint
-    py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
 
 setenv =
@@ -34,5 +33,4 @@ commands =
     pytest {posargs:-rf}
 
 [testenv:py36]
-basepython =
-    /opt/rh/rh-python36/root/usr/bin/python3.6
+basepython = python3.6


### PR DESCRIPTION
Are there any advantages to running the tests with tox and Docker? To me it seems to make things more difficult, especially if we want to start testing multiple Python versions.

Extracted from https://github.com/ome/omero-web/pull/218