### PR TITLE
Openwith fixes

### DIFF
--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -183,6 +183,12 @@ class BaseContainer(BaseController):
         if self.file is not None:
             return self.file
 
+    def obj_name(self):
+        if self.well:
+            return self.well.getImage().name
+        obj = self._get_object()
+        return obj is not None and obj.name or None
+
     def obj_id(self):
         obj = self._get_object()
         return obj is not None and obj.id or None

--- a/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -77,7 +77,16 @@
                     if (typeof v.isEnabled === "function") {
                         // If plugin has provided a function 'isEnabled'...
                         // prepare json of selected objects to pass to function
-                        enabled = v.isEnabled(selJson);
+                        enabled = v.isEnabled(selJson, function(enable) {
+                          // This callback allows asyn enable/disable of menu item
+                          let $a = $(`#right_panel_openwith a[data-openwithid="${v.id}"]`);
+                          $a.data('openwith_disabled', !enable);
+                          if (!enable) {
+                            $a.parent().addClass('disabled');
+                          } else {
+                            $a.parent().removeClass('disabled');
+                          }
+                        });
                     }
                     // ...Otherwise if supported_objects list is configured...
                     // v.supported_objects is ['image'] or ['dataset', 'images'] etc.
@@ -111,7 +120,8 @@
                       <li class='${ liClass }'>
                         <a title='${ tooltip }'
                           target='_blank'
-                          ${enabled ? "href = '" + url + "'" : ''}
+                          href = '${ url }'
+                          data-openwith_disabled=${ !enabled }
                           data-openwithid='${ v.id }' >
                           ${ label }
                         </a>
@@ -133,6 +143,10 @@
                 // instead of default link behaviour
                 $("#right_panel_openwith").on("click", "a", function (event) {
                   var $a = $(this);
+                  if ($a.data('openwith_disabled')) {
+                    event.preventDefault();
+                    return;
+                  }
                   if ($a.attr('href') === '#') {
                     event.preventDefault();
                     let openwith_id = $a.data('openwithid');

--- a/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -51,30 +51,29 @@
                 }
             {% endif %}
 
-
+                // if batch_annotate panel, we can use obj_labels
                 var selectedObjs = [{% for o in obj_labels %}{% if forloop.counter > 1 %},{% endif %}"{{ o.type|lower }}-{{ o.id}}"{% endfor %}];
+                var selJson = [{% for o in obj_labels %}{% if forloop.counter > 1 %}, {% endif %}{"id": {{ o.id }}, 'type': '{{ o.type|lower }}', 'name': '{{ o.name }}'  }{% endfor %}];
 
-
-                {% if manager.obj_type %}
+                // If single object selected
+              {% if manager.obj_type %}
                 selectedObjs = ["{{ manager.obj_type }}-{{ manager.obj_id }}"];
-                {% endif %}
+                selJson = [{'id': {{ manager.obj_id }},
+                           'name': '{{ manager.obj_name }}',
+                           'type': '{{ manager.obj_type }}' }]
+              {% endif %}
 
                 var selectedType = selectedObjs.reduce(function(prev, s){
                     return s.split('-')[0] + (selectedObjs.length > 1 ? "s" : "");
                 }, "undefined");
 
-                {% if not share %}
-                var openwith_html = WEBCLIENT.OPEN_WITH.map(function(v){
+              {% if not share %}
+                function getOpenwithHtml() {
+                  var openwith_html = WEBCLIENT.OPEN_WITH.map(function(v){
                     var label = v.label || v.id;
                     var enabled = false;
                     var tooltip = "Open " + selectedType + " with " + label;
 
-                    var selJson = selectedObjs.map(function(obj){
-                        var s = obj.split('-');
-                        var o = {'id': s[1],
-                                 'type': s[0]};
-                        return o;
-                    });
                     if (typeof v.isEnabled === "function") {
                         // If plugin has provided a function 'isEnabled'...
                         // prepare json of selected objects to pass to function
@@ -98,6 +97,10 @@
                     // use it to update the url...
                     if (v.getUrl) {
                         url = v.getUrl(selJson, v.url);
+                        if (typeof url === 'function') {
+                          // handle click below
+                          url = '#';
+                        }
                     }
                     var liClass = "";
                     if (!enabled) {
@@ -111,11 +114,26 @@
                         html += ">" + label + "</a></li>";
                     }
                     return html;
+                  
+                  });
+                  return openwith_html.join("");
+                }
+
+                // Only build html when we need it
+                $("#show_openwith_menu").on('click', function() {
+                  let html = getOpenwithHtml();
+                  $("#right_panel_openwith").html(html);
                 });
-                $("#right_panel_openwith").html(openwith_html.join(""));
-                {% endif %}
-            });
+
+                // Listen for clicks on Open-with menu items in case we want to handle with a function
+                // instead of default link behaviour
+                $("#right_panel_openwith tbody").on("click", "tr", function () {
+                  console.log($(this).text());
+                });
+
+              {% endif %}
             
+        });
     </script>
 
 
@@ -359,7 +377,7 @@
 
       <div class="toolbar_dropdown">
           {% if not share %}
-          <button class="btn silver btn_openwith" title="Open with..." style="height: 20px">
+          <button id="show_openwith_menu" class="btn silver btn_openwith" title="Open with..." style="height: 20px">
               <span></span>
           </button>
           <ul id="right_panel_openwith" class="dropdown dropdown_right">

--- a/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -107,12 +107,16 @@
                         liClass = "disabled";
                         tooltip = tooltip.replace("Open", "Cannot open");
                     }
-                    var html = "<li class='" + liClass + "'><a title='" + tooltip + "'";
-                    if (enabled) {
-                        html += " target='_blank' href='" + url + "'>" + label + "</a></li>";
-                    } else {
-                        html += ">" + label + "</a></li>";
-                    }
+                    var html = `
+                      <li class='${ liClass }'>
+                        <a title='${ tooltip }'
+                          target='_blank'
+                          ${enabled ? "href = '" + url + "'" : ''}
+                          data-openwithid='${ v.id }' >
+                          ${ label }
+                        </a>
+                      </li>
+                    `
                     return html;
                   
                   });
@@ -127,8 +131,19 @@
 
                 // Listen for clicks on Open-with menu items in case we want to handle with a function
                 // instead of default link behaviour
-                $("#right_panel_openwith tbody").on("click", "tr", function () {
-                  console.log($(this).text());
+                $("#right_panel_openwith").on("click", "a", function (event) {
+                  var $a = $(this);
+                  if ($a.attr('href') === '#') {
+                    event.preventDefault();
+                    let openwith_id = $a.data('openwithid');
+                    let ow = WEBCLIENT.OPEN_WITH.filter(o => o.id === openwith_id)[0];
+                    if (ow) {
+                      let fn = ow.getUrl(selJson, ow.url);
+                      if (typeof fn === 'function') {
+                        fn();
+                      }
+                    }
+                  }
                 });
 
               {% endif %}


### PR DESCRIPTION
Fixes some issues with Open-with, noticed when using https://github.com/will-moore/omero-openwith-url
When the openwith function to getUrlProvider() is called by the right panel, it includes 'name' info for selected image(s).
Previously, this was only available when the open-with was used on the jsTree.
Also, the right-panel open-with getUrl() is only called when the Open-with menu is clicked on. This means we don't call those methods unless needed, which is important if e.g. the open-with is doing an ajax call to check on enabled status.

Both the right-panel and jsTree support the passing of a callback as the second argument to `isEnabled(selected, callback)` allowing plugins to do async look-up of the enabled state and to call the callback.

To test:
 - Test https://github.com/will-moore/omero-openwith-url/pull/1 as described.
 - Also check that other open-with items are still functioning as before - Enabled/disabled as expected depending on what's selected. And open-with opens Image as expected.
