### PR TITLE
Allow a custom javascript tree key function

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1001,6 +1001,18 @@ CUSTOM_SETTINGS_MAPPINGS = {
             "The javascript loads data into ``$('#div_id')``."
         ),
     ],
+    "omero.web.ui.tree.sort_key_function": [
+        "TREE_SORT_KEY_FUNCTION",
+        "null",
+        str,
+        (
+            "An inline javascript function that returns a key used for "
+            "sorting the tree. Must be of the form (string) -> string, e.g. "
+            "``function(name) {return name.split('-')[1];} ``. "
+            "Warning: this is raw Javascript, errors could affect the "
+            "security of OMERO.web."
+        ),
+    ],
     # CORS
     "omero.web.cors_origin_whitelist": [
         "CORS_ORIGIN_WHITELIST",

--- a/omeroweb/webclient/decorators.py
+++ b/omeroweb/webclient/decorators.py
@@ -169,6 +169,9 @@ class render_response(omeroweb.decorators.render_response):
                     .get("tree", {})
                     .get("type_order")
                 )
+                context["ui"]["tree"][
+                    "sort_key_function"
+                ] = settings.TREE_SORT_KEY_FUNCTION
 
         self.load_settings(request, context, conn)
 

--- a/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1280,8 +1280,14 @@ $(function() {
                         return 1;
                     }
                 }
-                var name1 = node1.text.toLowerCase();
-                var name2 = node2.text.toLowerCase();
+                var name1, name2;
+                if (WEBCLIENT.UI.TREE.sort_key_function) {
+                    name1 = WEBCLIENT.UI.TREE.sort_key_function(node1.text);
+                    name2 = WEBCLIENT.UI.TREE.sort_key_function(node2.text);
+                } else {
+                    name1 = node1.text.toLowerCase();
+                    name2 = node2.text.toLowerCase();
+                }
 
                 // If names are same, sort by ID
                 if (name1 === name2) {

--- a/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -208,6 +208,7 @@
         WEBCLIENT.UI.TREE = {};
         WEBCLIENT.UI.TREE.pagination_nodes = ["experimenter", "screen", "plate", "acquisition", "project", "tagset", "image"];
         WEBCLIENT.UI.TREE.type_order = "{{ui.tree.type_order}}".toLowerCase().split(",").filter(function(e){return e});
+        WEBCLIENT.UI.TREE.sort_key_function = {{ui.tree.sort_key_function|safe}};
 
         {% if page_size %}
             var PAGE_SIZE = {{ page_size }};


### PR DESCRIPTION
The key used to sort items in the JSTree can be customised by defining a javascript function that returns the key used for sorting. This function takes the container name as a parameter, and can do anything that javascript can do.

This is an implementation of https://github.com/ome/design/issues/108#issuecomment-704141276

For example
```
config set omero.client.ui.tree.type_order false
config set omero.web.ui.tree.sort_key_function "function(s){var a=/(\w+)-.+\/\w+(\w)/.exec(s); if (a) {return a[2]+'-'+a[1];} else {return s;}}"
```
This will order first by ABCDE index (ie list all `screenA/experimentA` from any study, then list all `screenB/ExperimentB` from any study), and within `screenA/experimentA` order by idrNNNN:

![image](https://user-images.githubusercontent.com/1644105/95229317-58523b00-07f8-11eb-9858-699932f74125.png)

In case it's not obvious this is just an example to illustrate the sort of thing you can do since the dataset driving this work isn't yet live, in practice we'd want a key along the lines of `idrNNNN-[ABCDEF]`:
`"function(s){var a=/(\w+)-.+\/\w+(\w)/.exec(s); if (a) {return a[1]+'-'+a[2];} else {return s;}}"`

The `if(a)` ensures that if a container name such as `idr0038-held-kidneylightsheet` doesn't match the regex it is used as is.