### PR TITLE
Get table rows batch

### DIFF
--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -38,9 +38,11 @@ table_query = url(
 Query a table specified by fileid
 """
 
-table_metadata = url(r'^table/(?P<fileid>\d+)/metadata/$',
+table_metadata = url(
+    r"^table/(?P<fileid>\d+)/metadata/$",
     views.table_metadata,
-    name="webgateway_table_metadata")
+    name="webgateway_table_metadata",
+)
 """
 Get omero table metadata
 """

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -38,6 +38,13 @@ table_query = url(
 Query a table specified by fileid
 """
 
+table_metadata = url(r'^table/(?P<fileid>\d+)/metadata/$',
+    views.table_metadata,
+    name="webgateway_table_metadata")
+"""
+Get omero table metadata
+"""
+
 object_table_query = url(
     r"^table/(?P<objtype>[\w.]+)/(?P<objid>\d+)/query/$",
     views.object_table_query,
@@ -587,6 +594,7 @@ urlpatterns = [
     # bulk annotations
     annotations,
     table_query,
+    table_metadata,
     object_table_query,
     open_with_options,
 ]

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2995,7 +2995,7 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
                 "columns": [col.name for col in cols],
             },
             "meta": {
-                "rowCount": len(hits),
+                "rowCount": rows,
                 "totalCount": totalCount,
                 "limit": limit,
                 "offset": offset,

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2938,6 +2938,22 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
 
     try:
         cols = t.getHeaders()
+        col_indices = range(len(cols))
+        if col_names:
+            enumerated_columns = (
+                [(i, j) for (i, j) in enumerate(cols) if j.name in col_names]
+                if col_names
+                else [(i, j) for (i, j) in enumerate(cols)]
+            )
+            cols = []
+            col_indices = []
+            for col_name in col_names:
+                for (i, j) in enumerated_columns:
+                    if col_name == j.name:
+                        col_indices.append(i)
+                        cols.append(j)
+                        break
+
         rows = t.getNumberOfRows()
 
         offset = kwargs.get("offset", 0)
@@ -2974,9 +2990,6 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
             # hits are all consecutive rows - can load them in batches
             idx = 0
             batch = 1000
-            col_indices = range(len(cols))
-            if col_names:
-                col_indices = [i for (i, j) in enumerate(cols) if j.name in col_names]
             while idx < len(h):
                 batch = min(batch, len(h) - idx)
                 res = table.slice(col_indices, h[idx : idx + batch])

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2974,13 +2974,11 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
             # hits are all consecutive rows - can load them in batches
             idx = 0
             batch = 1000
+            col_indices = range(len(cols))
+            if col_names:
+                col_indices = [i for (i, j) in enumerate(cols) if j.name in col_names]
             while idx < len(h):
                 batch = min(batch, len(h) - idx)
-                col_indices = range(len(cols))
-                if col_names:
-                    col_indices = [
-                        i for (i, j) in enumerate(cols) if j.name in col_names
-                    ]
                 res = table.slice(col_indices, h[idx : idx + batch])
                 idx += batch
                 # yield a list of rows


### PR DESCRIPTION
Modify `table_query` to get the rows in a single batch using `slice` instead of `read`. Also, add a `table_metadata` endpoint to fetch just column information and the total number of rows in the table without any data. 