### PR TITLE
webgateway: use list comprehension instead of map (fix for Python 3)

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1991,9 +1991,7 @@ def search_json(request, conn=None, **kwargs):
                     logger.debug("(iid %i) ignoring Server Error: %s" % (e.id, str(x)))
             return rv
         else:
-            return [
-                x.simpleMarshal(xtra=xtra, parents=opts["parents"]) for x in sr
-            ]
+            return [x.simpleMarshal(xtra=xtra, parents=opts["parents"]) for x in sr]
 
     rv = timeit(marshal)()
     logger.debug(rv)

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1723,7 +1723,7 @@ def listImages_json(request, did, conn=None, **kwargs):
         "thumbUrlPrefix": kwargs.get("urlprefix", urlprefix),
         "tiled": request.GET.get("tiled", False),
     }
-    return map(lambda x: x.simpleMarshal(xtra=xtra), dataset.listChildren())
+    return [x.simpleMarshal(xtra=xtra) for x in dataset.listChildren()]
 
 
 @login_required()
@@ -1991,9 +1991,9 @@ def search_json(request, conn=None, **kwargs):
                     logger.debug("(iid %i) ignoring Server Error: %s" % (e.id, str(x)))
             return rv
         else:
-            return map(
-                lambda x: x.simpleMarshal(xtra=xtra, parents=opts["parents"]), sr
-            )
+            return [
+                x.simpleMarshal(xtra=xtra, parents=opts["parents"]) for x in sr
+            ]
 
     rv = timeit(marshal)()
     logger.debug(rv)


### PR DESCRIPTION
to fix JSON serialization,
as map() is an iterator in Python 3 now:
https://docs.python.org/3/library/functions.html#map

The fixed error is:
```
{"message": "Object of type 'map' is not JSON serializable", "stacktrace": "Traceback (most recent call last):\n  File \"/opt/omero/web/venv3/lib/python3.6/site-packages/omeroweb/webgateway/views.py\", line 1448, in wrap\n    return JsonResponse(rv, safe=safe)\n  File \"/opt/omero/web/venv3/lib/python3.6/site-packages/django/http/response.py\", line 530, in __init__\n    data = json.dumps(data, cls=encoder, **json_dumps_params)\n  File \"/usr/lib/python3.6/json/__init__.py\", line 238, in dumps\n    **kw).encode(obj)\n  File \"/usr/lib/python3.6/json/encoder.py\", line 199, in encode\n    chunks = self.iterencode(o, _one_shot=True)\n  File \"/usr/lib/python3.6/json/encoder.py\", line 257, in iterencode\n    return _iterencode(o, 0)\n  File \"/opt/omero/web/venv3/lib/python3.6/site-packages/django/core/serializers/json.py\", line 124, in default\n    return super(DjangoJSONEncoder, self).default(o)\n  File \"/usr/lib/python3.6/json/encoder.py\", line 180, in default\n    o.__class__.__name__)\nTypeError: Objec* Connection #0 to host 192.168.56.125 left intact
t of type 'map' is not JSON serializable\n"}
```
for example on a request like this:
```/webgateway/dataset/1024/children/```

It would also be possible to just wrap a ```list()``` around, but list comprehension is less complex and also used in other parts of the same file.