### PR TITLE
filter KV show auto-complete

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.center_plugin_filter.js
@@ -65,6 +65,7 @@ function MapAnnFilter(image_ids, $element, callback, filterObjects) {
             var self = this;
             $(".filter_map_value", $filter).autocomplete({
                 disabled: false,
+                minLength: 0,
                 source: autocompVals,
                 select: function( event, ui ) {
                     self.filterText = ui.item.value;
@@ -73,6 +74,14 @@ function MapAnnFilter(image_ids, $element, callback, filterObjects) {
                     }
                 }
             });
+            // When user clicks on auto-complete, show ALL options (search: "")
+            $(".filter_map_value", $filter)
+            .on('click', function (event) {
+                $(this).autocomplete("search", "");
+            })
+            .focus()    // immediately focus and 'click' to show auto-complete
+            .click();
+
         }
         $('.filter_map_value', $filter).attr('placeholder', placeholder)
             .attr('title', placeholder)


### PR DESCRIPTION
Fixes #247

This improves the usability of filtering Images by Key-Value pairs.
To test:

 - Filter by Key-Value and choose a Key...
 - This should immediately show the auto-complete options, without having to start typing
 - When you choose an option, filtering should happen as before.
 - Then you can click again on the auto-complete input, ALL the options should be shown, allowing you to pick another without having to delete the text from the one you chose before.
 - So the input acts more like a drop-down chooser, as well as allowing you to enter any text (e.g. partial text to filter for many different values)