### PR TITLE
annotations api limit

### DIFF
--- a/omeroweb/feedback/views.py
+++ b/omeroweb/feedback/views.py
@@ -200,8 +200,7 @@ def handler404(request, exception=None):
         "Not Found: %s" % request.path, extra={"status_code": 404, "request": request}
     )
     if request.is_ajax():
-        msg = traceback.format_exception(*sys.exc_info())[-1]
-        return HttpResponseNotFound(msg)
+        return HttpResponseNotFound()
 
     return page_not_found(request, "404.html")
 

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_tags_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_tags_pane.js
@@ -125,8 +125,6 @@ var TagPane = function TagPane($element, opts) {
             request = request.join("&");
 
             var annsUrl = WEBCLIENT.URLS.webindex + "api/annotations/?type=tag&" + request
-            // set high limit on number of results (default is 200)
-            annsUrl += '&limit=10000'
             $.getJSON(annsUrl, function(data){
 
                 // manipulate data...

--- a/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -22,7 +22,13 @@
             <% if (ann.id) { %>
                 Added by: <%= ann.owner.firstName %> <%= ann.owner.lastName %>
                 <% if (showParent && ann.link.parent.name){ %>
-                  <br>To: <%= ann.parentNames ? (ann.parentNames.length + " objects") : ann.link.parent.name %>
+                  <br>
+                  <% if (ann.parentNames) { %>
+                    <%= ann.parentNames.length %> Annotations linked to:
+                  <% } else { %>
+                    To:
+                  <% } %>
+                  <%= ann.parentNames ? (ann.parentNames.length + " objects") : ann.link.parent.name %>
                 <% } %>
 
                 <span class="tooltip_html" style='display:none'>

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1307,7 +1307,7 @@ def api_annotations(request, conn=None, **kwargs):
     run_ids = get_list(request, "acquisition")
     well_ids = get_list(request, "well")
     page = get_long_or_default(request, "page", 1)
-    limit = get_long_or_default(request, "limit", settings.PAGE)
+    limit = get_long_or_default(request, "limit", 10000)
 
     ann_type = r.get("type", None)
     ns = r.get("ns", None)

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -133,6 +133,10 @@ logger = logging.getLogger(__name__)
 
 logger.info("INIT '%s'" % os.getpid())
 
+# We want to allow a higher default limit for annotations so we can load
+# all the annotations expected for a PAGE of images
+ANNOTATIONS_LIMIT = settings.PAGE * 100
+
 
 def get_long_or_default(request, name, default):
     """
@@ -1307,7 +1311,7 @@ def api_annotations(request, conn=None, **kwargs):
     run_ids = get_list(request, "acquisition")
     well_ids = get_list(request, "well")
     page = get_long_or_default(request, "page", 1)
-    limit = get_long_or_default(request, "limit", 10000)
+    limit = get_long_or_default(request, "limit", ANNOTATIONS_LIMIT)
 
     ann_type = r.get("type", None)
     ns = r.get("ns", None)
@@ -2626,7 +2630,7 @@ def annotate_tags(request, conn=None, **kwargs):
         well_ids=selected["wells"],
         ann_type="tag",
         # If we reach this limit we'll get some tags not removed
-        limit=100000,
+        limit=ANNOTATIONS_LIMIT,
     )
 
     userMap = {}

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2540,9 +2540,7 @@ def download_as(request, iid=None, conn=None, **kwargs):
             temp.close()
             stack = traceback.format_exc()
             logger.error(stack)
-            return HttpResponseServerError(
-                "Cannot download file (id:%s).\n%s" % (iid, stack)
-            )
+            return HttpResponseServerError("Cannot download file (id:%s)" % iid)
 
     rsp["Content-Type"] = "application/force-download"
     return rsp


### PR DESCRIPTION
This fixes an issue noticed during testing of #225.

With a large number of images selected e.g.
https://merge-ci.openmicroscopy.org/web/webclient/?show=dataset-13651
it is possible to get a large number of annotations:

![Screenshot 2021-02-02 at 12 23 34](https://user-images.githubusercontent.com/900055/106599814-80a53880-6551-11eb-87fb-f770a93a8825.png)

However, if the `Key-Value Pairs` tab is expanded here, we won't load all 2520 annotations, because the default limit is much lower at 500. So even if all the images have a particular Key-Value pair, you won't see them all.

Another example from IDR:
http://idr.openmicroscopy.org/webclient/?show=dataset-12101

Here, 231 images are selected (with 696 Key-Value pairs), but only 500 are loaded, so only 38 Gene annotations are loaded:
![Screenshot 2021-02-02 at 12 32 09](https://user-images.githubusercontent.com/900055/106601253-5b192e80-6553-11eb-91db-dc2a429c6ca2.png)

With this higher limit, this bug should be much less likely.