### PR TITLE
Jstree padding bottom

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -24,7 +24,7 @@
 .left_panel_content {
 	position: relative;
 	width: 100%;
-	height: 100%;
+	height: calc(100% - 20px);
 	overflow: hidden;
 }
 

--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -24,7 +24,7 @@
 .left_panel_content {
 	position: relative;
 	width: 100%;
-	height: calc(100% - 20px);
+	height: 100%;
 	overflow: hidden;
 }
 

--- a/omeroweb/webclient/static/webclient/javascript/jquery.jstree.childcount_plugin.js
+++ b/omeroweb/webclient/static/webclient/javascript/jquery.jstree.childcount_plugin.js
@@ -12,7 +12,7 @@
 
             if(obj) {
                 var node = inst.get_node(obj);
-                var anchor = $(obj).children('a.jstree-anchor');
+                var anchor = $(obj).children('.jstree-anchor');
 
                 // Add child count html
                 if (node.data !== undefined && node.data.obj.childCount > 0) {

--- a/omeroweb/webgateway/static/3rdparty/jquery.jstree-3.0.8/jstree.js
+++ b/omeroweb/webgateway/static/3rdparty/jquery.jstree-3.0.8/jstree.js
@@ -49,9 +49,10 @@
 	_temp1.className = 'jstree-icon jstree-ocl';
 	_temp1.setAttribute('role', 'presentation');
 	_node.appendChild(_temp1);
-	_temp1 = _d.createElement('A');
+	// In the absense of _create_node_plugin, editing here to use SPAN
+	// See https://github.com/vakata/jstree/pull/1616 and https://github.com/ome/omero-web/pull/257
+	_temp1 = _d.createElement('SPAN');
 	_temp1.className = 'jstree-anchor';
-	_temp1.setAttribute('href','#');
 	_temp1.setAttribute('tabindex','-1');
 	_temp2 = _d.createElement('I');
 	_temp2.className = 'jstree-icon jstree-themeicon';

--- a/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
@@ -11,10 +11,12 @@
   padding: 0;
   list-style-type: none;
   list-style-image: none;
-  padding-bottom: 2em;
 }
 .jstree-node {
   white-space: nowrap;
+}
+.jstree-container-ul {
+  padding-bottom: 2em;
 }
 .jstree-anchor {
   display: inline-block;

--- a/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
@@ -15,9 +15,6 @@
 .jstree-node {
   white-space: nowrap;
 }
-.jstree-container-ul {
-  padding-bottom: 2em;
-}
 .jstree-anchor {
   display: inline-block;
   color: black;

--- a/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
@@ -11,6 +11,7 @@
   padding: 0;
   list-style-type: none;
   list-style-image: none;
+  padding-bottom: 2em;
 }
 .jstree-node {
   white-space: nowrap;

--- a/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.jstree_theme.css
@@ -341,11 +341,11 @@
   transition: 1s background linear;
 }
 
-.jstree-default ul li ul li a {
+/* .jstree-default ul li ul li a {
   opacity: .9;
-}
+} */
 
-.jstree-default a {
+.jstree-default .jstree-anchor {
   -webkit-border-radius: 2px;
   -moz-border-radius: 2px;
   border-radius: 2px;
@@ -359,6 +359,7 @@
   position: relative;
   cursor: pointer;
   font-size: 120%;
+  opacity: .9;
 }
 
 .jstree-default .jstree-no-icons .jstree-anchor > .jstree-themeicon {


### PR DESCRIPTION
This replaces https://github.com/ome/omero-web/pull/237

EDIT: Instead of padding under the tree, we now use a `<span>` element instead of `<a>` for the jstree nodes, as discussed at https://github.com/vakata/jstree/pull/1616

The tree should look and behave the same, but nodes are no-longer links so we don't get the link popup when we mouse over.