### PR TITLE
Custom response headers

### DIFF
--- a/omeroweb/middleware/__init__.py
+++ b/omeroweb/middleware/__init__.py
@@ -1,0 +1,5 @@
+from .customheaders import CustomHeadersMiddleware
+
+__all__ = [
+    'CustomHeadersMiddleware',
+]

--- a/omeroweb/middleware/__init__.py
+++ b/omeroweb/middleware/__init__.py
@@ -1,5 +1,5 @@
 from .customheaders import CustomHeadersMiddleware
 
 __all__ = [
-    'CustomHeadersMiddleware',
+    "CustomHeadersMiddleware",
 ]

--- a/omeroweb/middleware/customheaders.py
+++ b/omeroweb/middleware/customheaders.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# https://docs.djangoproject.com/en/1.8/ref/middleware/
+
+from django.conf import settings
+
+
+class CustomHeadersMiddleware(object):
+    """
+    Django middleware to add custom headers to a response.
+
+    Headers will only be set if not already present in the response.
+    """
+
+    # https://docs.djangoproject.com/en/1.11/topics/http/middleware/
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        for header in settings.HTTP_RESPONSE_HEADERS:
+            k, v = header
+            if not response.has_header(k):
+                response[k] = v
+        return response

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -394,13 +394,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
             '{"index": 3, '
             '"class": "django.contrib.sessions.middleware.SessionMiddleware"},'
             '{"index": 4, '
-            '"class": "omeroweb.middleware.CustomHeadersMiddleware"},'
-            '{"index": 5, '
             '"class": "django.middleware.csrf.CsrfViewMiddleware"},'
-            '{"index": 6, '
+            '{"index": 5, '
             '"class": "django.contrib.messages.middleware.MessageMiddleware"},'
+            '{"index": 6, '
+            '"class": "django.middleware.clickjacking.XFrameOptionsMiddleware"},'
             '{"index": 7, '
-            '"class": "django.middleware.clickjacking.XFrameOptionsMiddleware"}'
+            '"class": "omeroweb.middleware.CustomHeadersMiddleware"}'
             "]"
         ),
         json.loads,

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -394,10 +394,12 @@ CUSTOM_SETTINGS_MAPPINGS = {
             '{"index": 3, '
             '"class": "django.contrib.sessions.middleware.SessionMiddleware"},'
             '{"index": 4, '
-            '"class": "django.middleware.csrf.CsrfViewMiddleware"},'
+            '"class": "omeroweb.middleware.CustomHeadersMiddleware"},'
             '{"index": 5, '
-            '"class": "django.contrib.messages.middleware.MessageMiddleware"},'
+            '"class": "django.middleware.csrf.CsrfViewMiddleware"},'
             '{"index": 6, '
+            '"class": "django.contrib.messages.middleware.MessageMiddleware"},'
+            '{"index": 7, '
             '"class": "django.middleware.clickjacking.XFrameOptionsMiddleware"}'
             "]"
         ),
@@ -1027,6 +1029,16 @@ CUSTOM_SETTINGS_MAPPINGS = {
         "SAMEORIGIN",
         str,
         "Whether to allow OMERO.web to be loaded in a frame.",
+    ],
+    "omero.web.http_response_headers": [
+        "HTTP_RESPONSE_HEADERS",
+        "[]",
+        json.loads,
+        (
+            "List of pairs of additional HTTP response headers e.g."
+            '[["X-Header-Name", "Value"]]. A header will only be added if it'
+            "hasn't already been set by the application."
+        ),
     ],
     "omero.web.django_additional_settings": [
         "DJANGO_ADDITIONAL_SETTINGS",

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -384,25 +384,8 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ("The maximum number of requests a worker will process before " "restarting."),
     ],
     "omero.web.middleware": [
-        "MIDDLEWARE_CLASSES_LIST",
-        (
-            "["
-            '{"index": 1, '
-            '"class": "django.middleware.common.BrokenLinkEmailsMiddleware"},'
-            '{"index": 2, '
-            '"class": "django.middleware.common.CommonMiddleware"},'
-            '{"index": 3, '
-            '"class": "django.contrib.sessions.middleware.SessionMiddleware"},'
-            '{"index": 4, '
-            '"class": "django.middleware.csrf.CsrfViewMiddleware"},'
-            '{"index": 5, '
-            '"class": "django.contrib.messages.middleware.MessageMiddleware"},'
-            '{"index": 6, '
-            '"class": "django.middleware.clickjacking.XFrameOptionsMiddleware"},'
-            '{"index": 7, '
-            '"class": "omeroweb.middleware.CustomHeadersMiddleware"}'
-            "]"
-        ),
+        "ADDITIONAL_MIDDLEWARE_CLASSES",
+        "[]",
         json.loads,
         (
             "Warning: Only system administrators should use this feature. "
@@ -1614,6 +1597,19 @@ SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 # Load custom settings from etc/grid/config.xml
 # Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228
 # MIDDLEWARE: A tuple of middleware classes to use.
+
+MIDDLEWARE_CLASSES_LIST = [
+    {"index": 1, "class": "django.middleware.common.BrokenLinkEmailsMiddleware"},
+    {"index": 2, "class": "django.middleware.common.CommonMiddleware"},
+    {"index": 3, "class": "django.contrib.sessions.middleware.SessionMiddleware"},
+    {"index": 4, "class": "omeroweb.middleware.CustomHeadersMiddleware"},
+    {"index": 5, "class": "django.middleware.csrf.CsrfViewMiddleware"},
+    {"index": 6, "class": "django.contrib.messages.middleware.MessageMiddleware"},
+    {"index": 7, "class": "django.middleware.clickjacking.XFrameOptionsMiddleware"},
+]
+# Add user-configured middleware
+additional_middleware = getattr(sys.modules[__name__], "ADDITIONAL_MIDDLEWARE_CLASSES")
+MIDDLEWARE_CLASSES_LIST += additional_middleware
 MIDDLEWARE = sort_properties_to_tuple(MIDDLEWARE_CLASSES_LIST)  # noqa
 
 for k, v in DJANGO_ADDITIONAL_SETTINGS:  # noqa


### PR DESCRIPTION
This replaces https://github.com/ome/omero-web/pull/143 (having merged in origin/master).

Add property to set custom headers in Django OMERO.web response

# What this PR does

This allows custom headers to be added to the HTTP response sent to the client by OMERO.web.
These header(s) will only be added if they're not already present in the response.

# Testing this PR

Set one or more custom headers, e.g.

```
omero config append omero.web.http_response_headers '["X-custom-header", "my value"]'
omero web start
```
Check the headers sent by OMERO.web, e.g. `curl -I localhost:4080`. You should see the custom headers you configured.