### PR TITLE
omero table link to ROI

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -99,6 +99,8 @@
                 <td><a target="_blank" href="{% url 'webindex' %}?show=image-{{ col }}">{{ col }}</a></td>
                 {% elif well_column_index == forloop.counter0 %}
                 <td><a target="_blank" href="{% url 'webindex' %}?show=well-{{ col }}">{{ col }}</a></td>
+                {% elif roi_column_index == forloop.counter0 and iviewer_url != None %}
+                <td><a target="_blank" href="{{ iviewer_url }}?roi={{ col }}">{{ col }}</a></td>
                 {% else %}
                 <td>{{ col }}</td>
                 {% endif %}


### PR DESCRIPTION
Since `populate metadata` now supports ROI columns, and they will be used in idr0101, it is useful to be able to link from an ROI in omero_table to view the ROI in iviewer.

To test:
 - Need to create an OMERO.table with RoiColumn - see https://merge-ci.openmicroscopy.org/web/webclient/?show=image-39715
 - With iviewer installed, ROI IDs will become links to `/iviewer/?roi=ID` (as they already do for Images and Wells)