### PR TITLE
remove shares

### DIFF
--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -37,7 +37,6 @@ from .custom_forms import MetadataModelChoiceField
 from .custom_forms import AnnotationModelMultipleChoiceField
 from .custom_forms import ObjectModelMultipleChoiceField
 from omeroweb.webadmin.custom_forms import ExperimenterModelMultipleChoiceField
-from omeroweb.webadmin.custom_forms import GroupModelMultipleChoiceField
 from omeroweb.webadmin.custom_forms import GroupModelChoiceField
 from omeroweb.webclient.webclient_utils import formatPercentFraction
 
@@ -125,23 +124,6 @@ class ShareForm(NonASCIIForm):
             if time.mktime(date.timetuple()) <= time.time():
                 raise forms.ValidationError("Expiry date must be in the future.")
         return self.cleaned_data["expiration"]
-
-
-class BasketShareForm(ShareForm):
-    def __init__(self, *args, **kwargs):
-        super(BasketShareForm, self).__init__(*args, **kwargs)
-
-        try:
-            self.fields["image"] = GroupModelMultipleChoiceField(
-                queryset=kwargs["initial"]["images"],
-                initial=kwargs["initial"]["selected"],
-                widget=forms.SelectMultiple(attrs={"size": 10}),
-            )
-        except Exception:
-            self.fields["image"] = GroupModelMultipleChoiceField(
-                queryset=kwargs["initial"]["images"],
-                widget=forms.SelectMultiple(attrs={"size": 10}),
-            )
 
 
 class ContainerForm(NonASCIIForm):

--- a/omeroweb/webclient/templates/webclient/base/includes/toolbar_forms.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/toolbar_forms.html
@@ -3,7 +3,7 @@
 
 {% comment %}
 <!--
-  Copyright (C) 2021 University of Dundee & Open Microscopy Environment.
+  Copyright (C) 2011-2021 University of Dundee & Open Microscopy Environment.
   All rights reserved.
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as
@@ -50,7 +50,7 @@ if (typeof OME === "undefined") { OME={}; }
 
 <!-- hidden dialog -->
 <div id="create_share_form" style="display:none">
-    <p>Share functionality is no-longer supported.</p>
+    <p>Share functionality is no longer supported.</p>
     <p>Please see <a target="_blank" href="https://www.openmicroscopy.org/omero/features/share/">Sharing your data in OMERO</a>
         for alternative workflows.
     </p>

--- a/omeroweb/webclient/templates/webclient/base/includes/toolbar_forms.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/toolbar_forms.html
@@ -3,7 +3,7 @@
 
 {% comment %}
 <!--
-  Copyright (C) 2011 University of Dundee & Open Microscopy Environment.
+  Copyright (C) 2021 University of Dundee & Open Microscopy Environment.
   All rights reserved.
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as
@@ -25,45 +25,18 @@
 if (typeof OME === "undefined") { OME={}; }
 
     OME.createShare = function() {
-
-        var productListQuery = [];
-
-        // we do inst.get_selected() here, since we then get objects
-        // instead of ids for some reason?
-        var inst = $.jstree.reference('#dataTree');
-        data = inst.get_selected(true);
-        data.forEach(function(node){
-            productListQuery.push(node.type + "=" + node.data.id);
-        });
-
-        var query = '{% url 'manage_action_containers' "add" "share" %}' + "?"+productListQuery.join("&");
         $("#create_share_form").dialog("open");
-        $("#create_share_form").attr("action", query)
-        $("#create_share_form").load(query);
         return false;
     }
 
     $(document).ready(function(){
 
-        // AJAX handling of create-discussion form
-        $("#create_share_form").ajaxForm({
-            success: function(html) {
-                if (html.indexOf("shareId") > -1) {
-                    var shareId = html.replace("shareId:", "");
-                    $("#create_share_form").dialog( "close" );
-                    $("#shareCreatedId").text(shareId);
-                    $("#share_dialog_form").dialog("open").show();
-                } else {
-                    $("#create_share_form").html(html);
-                }
-            },
-        });
-
-        $("#share_dialog_form").dialog({
+        $("#create_share_form").dialog({
+            title: "Shares not supported",
             autoOpen: false,
             resizable: true,
-            height: 150,
-            width:300,
+            height: 250,
+            width:450,
             modal: true,
             buttons: {
                 "OK": function() {
@@ -71,36 +44,16 @@ if (typeof OME === "undefined") { OME={}; }
                 }
             }
         });
-
-        $("#create_share_form").dialog({
-            autoOpen: false,
-            resizable: true,
-            height: 600,
-            width:450,
-            modal: true,
-            buttons: {
-                "Accept": function() {
-                    // simply submit the form
-                    $("#create_share_form").submit();
-                },
-                "Cancel": function() {
-                    $( this ).dialog( "close" );
-                }
-            }
-        });
-
-
     });
 </script>
 
 
-
-<!-- hidden form for creating share - shown in dialog & loaded by AJAX -->
-<form id="create_share_form" action="#" method="post" title="Create Share" class="standard_form">{% csrf_token %}
-</form>
-
-<form id="share_dialog_form" action="#" title="Create Share" style="display:none">
-    <p style="font-size: 120%; font-weight: bold">
-        Share <span id="shareCreatedId"></span> was created successfully.
-    </p>
-</form>
+<!-- hidden dialog -->
+<div id="create_share_form" style="display:none">
+    <p>Share functionality is no-longer supported.</p>
+    <p>If you wish to share data with users in a different group (without removing
+        the data from it's current group) the command line tool
+        <a target="_blank" href="https://github.com/ome/omero-cli-duplicate">
+            omero-cli-duplicate</a>
+        may be of use to you.</p>
+</div>

--- a/omeroweb/webclient/templates/webclient/base/includes/toolbar_forms.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/toolbar_forms.html
@@ -51,9 +51,7 @@ if (typeof OME === "undefined") { OME={}; }
 <!-- hidden dialog -->
 <div id="create_share_form" style="display:none">
     <p>Share functionality is no-longer supported.</p>
-    <p>If you wish to share data with users in a different group (without removing
-        the data from it's current group) the command line tool
-        <a target="_blank" href="https://github.com/ome/omero-cli-duplicate">
-            omero-cli-duplicate</a>
-        may be of use to you.</p>
+    <p>Please see <a target="_blank" href="https://www.openmicroscopy.org/omero/features/share/">Sharing your data in OMERO</a>
+        for alternative workflows.
+    </p>
 </div>

--- a/omeroweb/webclient/templates/webclient/public/public.html
+++ b/omeroweb/webclient/templates/webclient/public/public.html
@@ -489,7 +489,15 @@
 
 <div class="left_panel_tree_container">
 
-    <div id="tree_details" class="left_panel_tree">
+    <div style="height: 110px; padding: 15px; box-sizing: border-box;">
+        <p>Creating new shares is no-longer supported. Previously created shares are shown below.</p>
+        <p>Please see <a target="_blank" href="https://www.openmicroscopy.org/omero/features/share/">Sharing your data in
+                OMERO</a>
+            for alternative workflows.
+        </p>
+    </div>
+
+    <div id="tree_details" class="left_panel_tree" style="height: calc(100% - 110px)">
         <div class="datashareTree" id="dataTree"></div>
     </div>
 

--- a/omeroweb/webclient/templates/webclient/public/public.html
+++ b/omeroweb/webclient/templates/webclient/public/public.html
@@ -490,7 +490,7 @@
 <div class="left_panel_tree_container">
 
     <div style="height: 110px; padding: 15px; box-sizing: border-box;">
-        <p>Creating new shares is no-longer supported. Previously created shares are shown below.</p>
+        <p>Creating new shares is no longer supported. Previously created shares are shown below.</p>
         <p>Please see <a target="_blank" href="https://www.openmicroscopy.org/omero/features/share/">Sharing your data in
                 OMERO</a>
             for alternative workflows.

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -67,7 +67,7 @@ from django.shortcuts import render
 
 from omeroweb.webclient.webclient_utils import _formatReport, _purgeCallback
 from .forms import GlobalSearchForm, ContainerForm
-from .forms import ShareForm, BasketShareForm
+from .forms import ShareForm
 from .forms import ContainerNameForm, ContainerDescriptionForm
 from .forms import CommentAnnotationForm, TagsAnnotationForm
 from .forms import MetadataFilterForm, MetadataDetectorForm
@@ -2866,47 +2866,6 @@ def manage_action_containers(
                 d.update({e[0]: unicode(e[1])})
             rdict = {"bad": "true", "errs": d}
             return JsonResponse(rdict)
-    elif action == "add":
-        template = "webclient/public/share_form.html"
-        experimenters = list(conn.getExperimenters())
-        experimenters.sort(key=lambda x: x.getOmeName().lower())
-        if o_type == "share":
-            img_ids = request.GET.getlist("image", request.POST.getlist("image"))
-            if request.method == "GET" and len(img_ids) == 0:
-                return HttpResponse("No images specified")
-            images_to_share = list(conn.getObjects("Image", img_ids))
-            if request.method == "POST":
-                form = BasketShareForm(
-                    initial={"experimenters": experimenters, "images": images_to_share},
-                    data=request.POST.copy(),
-                )
-                if form.is_valid():
-                    images = form.cleaned_data["image"]
-                    message = form.cleaned_data["message"]
-                    expiration = form.cleaned_data["expiration"]
-                    members = form.cleaned_data["members"]
-                    # guests = request.POST['guests']
-                    enable = form.cleaned_data["enable"]
-                    host = "%s?server=%i" % (
-                        request.build_absolute_uri(
-                            reverse("load_template", args=["public"])
-                        ),
-                        int(conn.server_id),
-                    )
-                    shareId = manager.createShare(
-                        host, images, message, members, enable, expiration
-                    )
-                    return HttpResponse("shareId:%s" % shareId)
-            else:
-                initial = {
-                    "experimenters": experimenters,
-                    "images": images_to_share,
-                    "enable": True,
-                    "selected": request.GET.getlist("image"),
-                }
-                form = BasketShareForm(initial=initial)
-        template = "webclient/public/share_form.html"
-        context = {"manager": manager, "form": form}
 
     elif action == "edit":
         # form for editing Shares only


### PR DESCRIPTION
See https://github.com/ome/omero-web/issues/179

This removes the "Create Share" form, which is broken.
It is replaced with a message linking to https://www.openmicroscopy.org/omero/features/share/

![Screenshot 2021-03-01 at 14 18 54](https://user-images.githubusercontent.com/900055/109511954-8122e780-7a9b-11eb-896b-bc8e63745f4a.png)

Also, it adds the same link under the Shares tab:

![Screenshot 2021-03-01 at 14 33 57](https://user-images.githubusercontent.com/900055/109511970-841dd800-7a9b-11eb-95f2-8f6ec26369a8.png)





