### PR TITLE
Added an option to set SESSION_COOKIE_PATH via "omero config set"

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -508,6 +508,12 @@ CUSTOM_SETTINGS_MAPPINGS = {
         leave_none_unset,
         "The name to use for session cookies",
     ],
+    "omero.web.session_cookie_path": [
+        "SESSION_COOKIE_PATH",
+        None,
+        leave_none_unset,
+        "The path to use for session cookies",
+    ],
     "omero.web.session_cookie_secure": [
         "SESSION_COOKIE_SECURE",
         "false",


### PR DESCRIPTION
While developing Volume Browser we came to an issue where our login sessions are in conflinct. The solution was to add SESSION_COOKIE_PATH Django variable to distinguish omero-web session from ours. We did this directly in settings.py file, however, it would be nice if omero-web could recognise such a setting activated via
`
omero web set
`
command.