### PR TITLE
Run script no params error log

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -4918,7 +4918,11 @@ def run_script(request, conn, sId, inputMap, scriptName="Script"):
             status = "no processor available"
             message = ""  # template displays message and link
         else:
-            logger.error(traceback.format_exc())
+            # Don't log user mistake as ERROR
+            if x.message.startswith("Invalid parameters"):
+                logger.debug(x.message)
+            else:
+                logger.error(traceback.format_exc())
             error = traceback.format_exc()
             status = "failed"
             message = x.message

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -4919,7 +4919,7 @@ def run_script(request, conn, sId, inputMap, scriptName="Script"):
             message = ""  # template displays message and link
         else:
             # Don't log user mistake as ERROR
-            if x.message.startswith("Invalid parameters"):
+            if isinstance(x, omero.ValidationException):
                 logger.debug(x.message)
             else:
                 logger.error(traceback.format_exc())


### PR DESCRIPTION
Fixes #34 

To test:
 - Need to observe OMERO.web log
 - Run a script without a required parameter, e.g. IDs
 - Log should not show Error (as in ticket above).