### PR TITLE
Handle show object in invalid group

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -446,7 +446,11 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
 
     # need to be sure that tree will be correct omero.group
     if first_sel is not None:
-        switch_active_group(request, first_sel.details.group.id.val)
+        group_id = first_sel.details.group.id.val
+        if conn.isValidGroup(group_id):
+            switch_active_group(request, group_id)
+        else:
+            first_sel = None
 
     # search support
     init = {}


### PR DESCRIPTION
Fixes #236 

To test:
 - Remove a user from a group where they have some data e.g. a Project (remember it's ID)
 - Log them out, then log them in again, and try to load the project: `/webclient/?show=project-1`
 - The webclient should load showing their default group (but not finding any Project) - instead of recursively re-loading the page.