### PR TITLE
Table query case insensitive

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -409,17 +409,11 @@
                                 loadBulkAnnotations(projectQuery, query, function(data) {
                                     if (data && data.id) {
                                         showBulkAnnTooltip(data);
-                                    } else {
-                                        // If query1 didn't work, try query2 on the same OMERO.table
-                                        loadBulkAnnotations(projectQuery, query2, showBulkAnnTooltip);
                                     }
                                 });
                                 loadBulkAnnotations(datasetQuery, query, function(data) {
                                     if (data && data.id) {
                                         showBulkAnnTooltip(data);
-                                    } else {
-                                        // If query1 didn't work, try query2 on the same OMERO.table
-                                        loadBulkAnnotations(datasetQuery, query2, showBulkAnnTooltip);
                                     }
                                 });
                             {% endif %}

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -352,7 +352,6 @@
                     var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child' manager.image.id %}";
                     var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child' manager.image.id %}";
                     var query = "Image-{{ manager.image.id }}";
-                    var query2 = "image-{{ manager.image.id }}";
                     {% endif %}
 
                     var showBulkAnnTooltip = function(data) {
@@ -392,24 +391,8 @@
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
                             {% if manager.image %}
-                                // Try query1 and query2 in *series* (not at the same time on same OMERO.table)
-                                // to avoid the table.close() causing errors if in parallel
-                                loadBulkAnnotations(projectQuery, query, function(data) {
-                                    if (data && data.id) {
-                                        showBulkAnnTooltip(data);
-                                    } else {
-                                        // If query1 didn't work, try query2 on the same OMERO.table
-                                        loadBulkAnnotations(projectQuery, query2, showBulkAnnTooltip);
-                                    }
-                                });
-                                loadBulkAnnotations(datasetQuery, query, function(data) {
-                                    if (data && data.id) {
-                                        showBulkAnnTooltip(data);
-                                    } else {
-                                        // If query1 didn't work, try query2 on the same OMERO.table
-                                        loadBulkAnnotations(datasetQuery, query2, showBulkAnnTooltip);
-                                    }
-                                });
+                                loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
+                                loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
                             {% endif %}
                         }
                     });


### PR DESCRIPTION
See discussion at https://github.com/ome/omero-metadata/pull/56#issuecomment-801030871
Currently, we don't know whether an OMERO.table column will be named 'Image' or 'image'.
So we have to query for BOTH (in series, since parallel queries lead to table.close() race conditions).

As @sbesson suggested, this logic can be simplified if we handle case mismatches in column names.
In this PR, if you query a table for `Image, Roi, Plate or Well` and the table doesn't have a matching
column name but *does* contain the column name in lower case, e.g. `image`, then we
simply use the lower case for the query.

This means we don't need duplicate queries from the UI (see the JavaScript code is much simpler).

To test:
 - See https://merge-ci.openmicroscopy.org/web/webclient/?show=project-857 (user-3)
 - The most recent table on this Project (which is always picked for queries) has the Image column named 'image': https://merge-ci.openmicroscopy.org/web/webclient/omero_table/634804/
 - Images named `img-xx.png` in that Project should display the Tables data correctly in the right-panel
 - The URL https://merge-ci.openmicroscopy.org/web/webgateway/table/Project.datasetLinks.child.imageLinks.child/36638/query/?query=Image-36638 (using query `Image-36638`) should return results for the table, even though the column names in the JSON data will be "image".