### PR TITLE
mapr object id fix

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -58,7 +58,7 @@
                 // If single object selected
               {% if manager.obj_type %}
                 selectedObjs = ["{{ manager.obj_type }}-{{ manager.obj_id }}"];
-                selJson = [{'id': {{ manager.obj_id }},
+                selJson = [{'id': '{{ manager.obj_id }}',
                            'name': '{{ manager.obj_name }}',
                            'type': '{{ manager.obj_type }}' }]
               {% endif %}

--- a/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -37,7 +37,7 @@
                       <% print (ann.permissions.canEdit && clientMapAnn ? 'editing' : 'viewing') %>
                       <b><%= ann.parentNames.length %></b> identical Key-Value annotations:
                     <% } %>
-                    <% if (!ann.parentNames) { %>
+                    <% if (!ann.parentNames && ann.link) { %>
                         <!-- If single object show e.g. Image ID: (slice ImageI -> Image) -->
                         <b><%= ann.link.parent.class.slice(0, ann.link.parent.class.length-1) %>
                             ID:</b> <%= ann.link.parent.id %><br />


### PR DESCRIPTION
This fixes 2 OMERO.mapr bugs reported as the "second issue" at https://forum.image.sc/t/omero-mapr-questions/50843

The first bug is a long-standing issue with Mapr: https://github.com/ome/omero-mapr/issues/67

To test:
 - Click on the top-level item in the Tree for a mapr search (as in the screenshot at https://github.com/ome/omero-mapr/issues/67). 
 - In the right panel, the annotations should load (instead of permanently saying "Loading key value annotations"

The other was caused by https://github.com/ome/omero-web/pull/232 (omero-web 5.9.0) since it assumes that Object IDs are numbers and can be rendered in Django to a valid JavaScript value.
But when you click on a mapr value in the tree (e.g. `AB_528479` in the screenshot below) then this String is the `obj_id` and causes a JavaScript error when rendered in the Django template.

This JS error shows up when you browse down to an Image and find that the Map Annotations tab won't load (as reported above).

![Screenshot 2021-04-01 at 10 29 41](https://user-images.githubusercontent.com/900055/113274115-3af8b800-92d5-11eb-876d-5ce2d51646a7.png)
the right panel omapr 

To test:
 - Search in mapr for a Value, browse down the Tree to Project/Dataset/Image etc and check that the Map Annotations load OK
 - If you check the JS console, you won't see the `Uncaught Reference Error` (first error in the console screenshot reported above) but you will still see another error that has been highlighted by that report - created https://github.com/ome/omero-mapr/issues/67
 - Also confirm that the right-panel Open-with menu is working with the various apps/viewers