### PR TITLE
Add user table metadata to metadata endpoint

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3042,7 +3042,18 @@ def _table_metadata(request, fileid, conn=None, query=None, lazy=False, **kwargs
     try:
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
+        allmeta = t.getAllMetadata()
 
+        user_metadata = {}
+        for k in allmeta:
+            if allmeta[k].__class__ == omero.rtypes.RStringI:
+                try:
+                    val = json.loads(allmeta[k].val)
+                    user_metadata[k] = val
+                except json.decoder.JSONDecodeError:
+                    user_metadata[k] = allmeta[k].val
+            else:
+                user_metadata[k] = allmeta[k].val
         rsp_data = {
             "columns": [
                 {
@@ -3053,6 +3064,7 @@ def _table_metadata(request, fileid, conn=None, query=None, lazy=False, **kwargs
                 for col in cols
             ],
             "totalCount": rows,
+            "attributes": user_metadata,
         }
         return rsp_data
     finally:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3064,7 +3064,7 @@ def _table_metadata(request, fileid, conn=None, query=None, lazy=False, **kwargs
                 for col in cols
             ],
             "totalCount": rows,
-            "attributes": user_metadata,
+            "user_metadata": user_metadata,
         }
         return rsp_data
     finally:


### PR DESCRIPTION
It is possible to add custom user metadata to an Omero table using the `setMetadata` or `setAllMetadata` methods (see https://docs.openmicroscopy.org/omero/5.6.1/developers/Tables.html#omero.grid.Table.setMetadata). We would like this to be added to the response of the get table metadata endpoint. To test, add some metadata to an existing table and then request the metadata for that table (`/webgateway/table/<File ID>/metadata/`). The response should contain the metadata added under `user_metadata`.