### PR TITLE
Add support for /shape/ID/

### DIFF
--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -316,12 +316,21 @@ ROI url to GET or DELETE a single ROI
 """
 
 api_image_rois = url(
-    r"^v(?P<api_version>%s)/m/images/" "(?P<image_id>[0-9]+)/rois/$" % versions,
+    r"^v(?P<api_version>%s)/m/images/(?P<image_id>[0-9]+)/rois/$" % versions,
     views.RoisView.as_view(),
     name="api_image_rois",
 )
 """
 GET ROIs that belong to an Image, using omero-marshal to generate json
+"""
+
+api_shape = url(
+    r"^v(?P<api_version>%s)/m/shapes/(?P<object_id>[0-9]+)/$" % versions,
+    views.ShapeView.as_view(),
+    name="api_shape",
+)
+"""
+Shape url to GET or DELETE a single Shape
 """
 
 api_experimenters = url(
@@ -415,6 +424,7 @@ urlpatterns = [
     api_rois,
     api_roi,
     api_image_rois,
+    api_shape,
     api_experimenters,
     api_experimenter,
     api_group_experimenters,

--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -324,6 +324,15 @@ api_image_rois = url(
 GET ROIs that belong to an Image, using omero-marshal to generate json
 """
 
+api_shapes = url(
+    r"^v(?P<api_version>%s)/m/shapes/$" % versions,
+    views.ShapesView.as_view(),
+    name="api_shapes",
+)
+"""
+GET all Shapes, using omero-marshal to generate json
+"""
+
 api_shape = url(
     r"^v(?P<api_version>%s)/m/shapes/(?P<object_id>[0-9]+)/$" % versions,
     views.ShapeView.as_view(),
@@ -424,6 +433,7 @@ urlpatterns = [
     api_rois,
     api_roi,
     api_image_rois,
+    api_shapes,
     api_shape,
     api_experimenters,
     api_experimenter,

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -755,6 +755,12 @@ class RoisView(ObjectsView):
         return opts
 
 
+class ShapesView(ObjectsView):
+    """Handles GET for /shapes/ to list available Shapes."""
+
+    OMERO_TYPE = "Shape"
+
+
 class ExperimentersView(ObjectsView):
     """Handles GET for /experimenters/ to list Experimenters."""
 

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -165,6 +165,7 @@ class ObjectView(ApiView):
         query, params, wrapper = conn.buildQuery(
             self.OMERO_TYPE, [object_id], opts=opts
         )
+        # Allow subclasses to access the result object
         self.result = conn.getQueryService().findByQuery(
             query, params, conn.SERVICE_OPTS
         )
@@ -781,7 +782,7 @@ class ShapesView(ObjectsView):
 
         # We need the shape.roi (if it's been added by omero-marshal)
         if "roi" in marshalled:
-            roi_id = marshalled["roi"]
+            roi_id = marshalled["roi"]["@id"]
             url = build_url(request, "api_roi", kwargs["api_version"], object_id=roi_id)
             marshalled["url:roi"] = url
 

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -390,6 +390,12 @@ class RoiView(ObjectView):
         return opts
 
 
+class ShapeView(ObjectView):
+    """Handle access to an individual Shape to GET or DELETE it."""
+
+    OMERO_TYPE = "Shape"
+
+
 class ExperimenterView(ObjectView):
 
     OMERO_TYPE = "Experimenter"

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -773,6 +773,20 @@ class ShapesView(ObjectsView):
 
     OMERO_TYPE = "Shape"
 
+    def add_data(self, marshalled, request, conn, urls=None, **kwargs):
+        """Add url:roi to each Shape"""
+        marshalled = super(ShapesView, self).add_data(
+            marshalled, request, conn, urls=urls, **kwargs
+        )
+
+        # We need the shape.roi (if it's been added by omero-marshal)
+        if "roi" in marshalled:
+            roi_id = marshalled["roi"]
+            url = build_url(request, "api_roi", kwargs["api_version"], object_id=roi_id)
+            marshalled["url:roi"] = url
+
+        return marshalled
+
 
 class ExperimentersView(ObjectsView):
     """Handles GET for /experimenters/ to list Experimenters."""


### PR DESCRIPTION
Fixes #290

This adds support for `/api/v0/m/shapes/[ID]/`
and `/api/v0/m/shapes/`.

To test:

 - Go to `/api/v0/m/shapes/`. Check JSON returned OK.
 - Check `/api/v0/m/shapes/ID/` for a particular Shape. This should include `"url:roi"` with a URL to the parent ROI.
 
Tests added in https://github.com/ome/openmicroscopy/pull/6281/