### PR TITLE
Handle parent not found on POST webclient/api/links

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1062,8 +1062,14 @@ def _api_links_POST(conn, json_data, **kwargs):
         ptype = parent_type.title()
         if ptype in ["Tagset", "Tag"]:
             ptype = "TagAnnotation"
-        p = conn.getQueryService().get(ptype, parent_id, conn.SERVICE_OPTS)
-        conn.SERVICE_OPTS.setOmeroGroup(p.details.group.id.val)
+        try:
+            p = conn.getQueryService().get(ptype, parent_id, conn.SERVICE_OPTS)
+            conn.SERVICE_OPTS.setOmeroGroup(p.details.group.id.val)
+        except omero.ValidationException:
+            return JsonResponse(
+                {"error": "Object of type %s and ID %s not found" % (ptype, parent_id)},
+                status=404,
+            )
         logger.info("api_link: Saving %s links" % len(linksToSave))
 
         try:


### PR DESCRIPTION
Fixes error reported at https://www.openmicroscopy.org/qa2/qa/feedback/30207/

To test:
 - Open the webclient in 2 tabs
 - In one, delete a Project
 - In the other (without refreshing, drag a Dataset on to the deleted Project)
 - Should now see a 404 message instead of a Error.

<summary>Error:
<details>

```
Traceback (most recent call last):
...
File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omeroweb/webclient/views.py", line 935, in api_links
return _api_links_POST(conn, json_data)
File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omeroweb/webclient/views.py", line 972, in _api_links_POST
conn.SERVICE_OPTS)
File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omero/gateway/__init__.py", line 4796, in __call__
return self.handle_exception(e, *args, **kwargs)
File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omeroweb/webclient/webclient_gateway.py", line 2133, in handle_exception
e, *args, **kwargs)
File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omero/gateway/__init__.py", line 4793, in __call__
return self.f(*args, **kwargs)
File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omero_api_IQuery_ice.py", line 322, in get
return _M_omero.api.IQuery._op_get.invoke(self, ((klass, id), _ctx))

omero.ValidationException: exception ::omero::ValidationException
{
serverStackTrace = ome.conditions.ValidationException: No row with the given identifier exists: [ome.model.containers.Project#253];
```

</details>
</summary>