### PR TITLE
multi-select click well images

### DIFF
--- a/omeroweb/webgateway/static/webgateway/js/ome.spwgridview.js
+++ b/omeroweb/webgateway/static/webgateway/js/ome.spwgridview.js
@@ -183,7 +183,7 @@ $(function(){
             thumbs.slice(start, end+1).parent().addClass("ui-selected");
             
         }
-        else if (event && event.metaKey) {
+        else if (event && event[OME.multi_key() + "Key"]) {
             if ( primaryIndex === -1 ) {
                 primaryIndex = selIndex;
             }


### PR DESCRIPTION
As reported at https://forum.image.sc/t/screens-data-cant-be-displayed-in-omero-figure/40321/5
the multi-select click doesn't work on non-Mac OS machines.

To test:
 - On various OS (Mac, Windows, Linux), should be able to use the appropriate multi-select key with click to toggle selection of Wells of a Plate, and also for individual Images within Wells (at the bottom panel of HCS layout).