### PR TITLE
Improve OMERO.table download usability

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -689,7 +689,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     ],
     "omero.web.max_table_download_rows": [
         "MAX_TABLE_DOWNLOAD_ROWS",
-        100000,
+        10000,
         int,
         "Prevent download of OMERO.tables exceeding this number of rows "
         "in a single request.",

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -687,6 +687,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
         "Prevent multiple files with total aggregate size greater than this "
         "value in bytes from being downloaded as a zip archive.",
     ],
+    "omero.web.max_table_download_rows": [
+        "MAX_TABLE_DOWNLOAD_ROWS",
+        100000,
+        int,
+        "Prevent download of OMERO.tables exceeding this number of rows "
+        "in a single request.",
+    ],
     # VIEWER
     "omero.web.viewer.view": [
         "VIEWER_VIEW",

--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -33,13 +33,13 @@
 
     <div class="download">
         Download as CSV:
-        <button id="download_csv" title="Download the whole table as CSV">Whole Table</button>
+        <button class="download_btn" id="download_csv" title="Download the whole table as CSV">Whole Table</button>
         {% if meta.query != '*' %}
-            <button id="download_filtered_csv" title="Download the whole table filtered with: {{meta.query}}">
+            <button class="download_btn" id="download_filtered_csv" title="Download the whole table filtered with: {{meta.query}}">
                 With Filter
             </button>
         {% endif %}
-        <button id="download_current_view" title="Dowload just the current page{% if meta.query != '*' %}, filtered with: {{meta.query}}{% endif %}">
+        <button class="download_btn" id="download_current_view" title="Dowload just the current page{% if meta.query != '*' %}, filtered with: {{meta.query}}{% endif %}">
             Current View</button>
         <div id="progress_display" style="visibility:hidden">
             Downloading: <span id="download_percent">0 MB</span> <progress id="download_progress" value="50" max="100">50%</progress>
@@ -159,7 +159,14 @@
         document.getElementById("download_progress").value = value;
     }
 
+    function enableDownloadButtons(enable) {
+        document.querySelectorAll(".download_btn").forEach(function(el){
+            el.disabled = !enable;
+        });
+    }
+
     async function download_csv(filter){
+        enableDownloadButtons(false);
         const rowCount = filter ? parseInt("{{ meta.totalCount }}") : parseInt("{{ meta.rowCount }}");
         console.log('rowCount', filter, rowCount);
         const tableName = "{{ data.name }}.csv";
@@ -192,6 +199,7 @@
 
         // hide progress
         showProgress(100, bytes, true);
+        enableDownloadButtons(true);
     };
 
     // Bind Event Listeners to buttons...

--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -32,9 +32,18 @@
     <body>
 
     <div class="download">
-        Download as CSV
-        <a href="{% url 'omero_table' data.id 'csv' %}?limit={{ meta.rowCount }}">Whole Table</a> |
-        <a href="{% url 'omero_table' data.id 'csv' %}?limit={{ meta.limit }}&offset={{ meta.offset }}&query={{ meta.query|urlencode }}">This View</a>
+        Download as CSV:
+        <button id="download_csv" title="Download the whole table as CSV">Whole Table</button>
+        {% if meta.query != '*' %}
+            <button id="download_filtered_csv" title="Download the whole table filtered with: {{meta.query}}">
+                With Filter
+            </button>
+        {% endif %}
+        <button id="download_current_view" title="Dowload just the current page{% if meta.query != '*' %}, filtered with: {{meta.query}}{% endif %}">
+            Current View</button>
+        <div id="progress_display" style="visibility:hidden">
+            Downloading: <span id="download_percent">0 MB</span> <progress id="download_progress" value="50" max="100">50%</progress>
+        </div>
     </div>
     {% if meta.query != '*' %}
         <div class="back">
@@ -108,4 +117,94 @@
         </tr>
         {% endfor %}
     </body>
+
+    <script>
+
+    function downloadString(array, fileType, fileName) {
+      // https://gist.github.com/danallison/3ec9d5314788b337b682
+      var blob = new Blob(array, { type: fileType });
+      var a = document.createElement('a');
+      a.download = fileName;
+      a.href = URL.createObjectURL(blob);
+      a.dataset.downloadurl = [fileType, a.download, a.href].join(':');
+      a.style.display = "none";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setTimeout(function () { URL.revokeObjectURL(a.href); }, 1500);
+    }
+
+    async function readData(reader) {
+        const decoder = new TextDecoder();
+        let result = "";
+        while (true) {
+            const { value, done } = await reader.read();
+            const str = decoder.decode(value);
+            result = result + str;
+            if (done) break;
+        }
+        return result;
+    }
+
+    function bytesToSize(bytes) {
+        var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+        if (bytes == 0) return '0 Byte';
+        var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
+        return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
+    }
+
+    function showProgress(value, bytes, hide) {
+        document.getElementById("progress_display").style.visibility = hide ? 'hidden' : 'visible';
+        document.getElementById("download_percent").innerHTML = bytesToSize(bytes);
+        document.getElementById("download_progress").value = value;
+    }
+
+    async function download_csv(filter){
+        const rowCount = filter ? parseInt("{{ meta.totalCount }}") : parseInt("{{ meta.rowCount }}");
+        console.log('rowCount', filter, rowCount);
+        const tableName = "{{ data.name }}.csv";
+        // Use 10 batches, or max 1000 rows per batch
+        const MAX_BATCH_ROWS = 1000;
+        const batchSize = Math.min(parseInt(rowCount/10), MAX_BATCH_ROWS);
+
+        // load csv in batches...
+        const csvUrl = "{% url 'omero_table' data.id 'csv' %}";
+        const query = "{{ meta.query|urlencode }}";
+
+        let count = 0;
+        let bytes = 0;
+        let blobData = [];
+        showProgress(0)
+        while(count <= rowCount) {
+            let url = `${csvUrl}?&limit=${batchSize}&offset=${count}&header=${count===0 ? 'true' : 'false'}`;
+            if (filter) {
+                url += `&query=${query}`;
+            }
+            const csvString = await fetch(url).then(rsp => rsp.body.getReader()).then(reader => readData(reader));
+            blobData.push(csvString);
+            bytes += csvString.length;
+            count += batchSize;
+            showProgress((count/rowCount) * 100, bytes);
+        }
+        showProgress(100, bytes);
+
+        downloadString(blobData, "text/csv", tableName);
+
+        // hide progress
+        showProgress(100, bytes, true);
+    };
+
+    // Bind Event Listeners to buttons...
+    document.getElementById("download_csv").addEventListener("click", function(){
+        download_csv(false);
+    });
+    document.getElementById("download_filtered_csv")?.addEventListener("click", function(){
+        download_csv(true);
+    });
+    document.getElementById("download_current_view").addEventListener("click", function(){
+        // Don't need progressing download, just use URL directly
+        window.location.href="{% url 'omero_table' data.id 'csv' %}?limit={{ meta.limit }}&offset={{ meta.offset }}&query={{ meta.query|urlencode }}";
+    });
+
+    </script>
 </html>

--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -181,7 +181,7 @@
         let count = 0;
         let bytes = 0;
         let blobData = [];
-        showProgress(0)
+        showProgress(0, 0)
         while(count <= rowCount) {
             let url = `${csvUrl}?&limit=${batchSize}&offset=${count}&header=${count===0 ? 'true' : 'false'}`;
             if (filter) {

--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -27,6 +27,10 @@
                 top: 10px;
                 left: 20px;
             }
+            #cancel_btn {
+                border: solid black 1px;
+                border-radius: 10px;
+            }
         </style>
     </head>
     <body>
@@ -43,6 +47,7 @@
             Current View</button>
         <div id="progress_display" style="visibility:hidden">
             Downloading: <span id="download_percent">0 MB</span> <progress id="download_progress" value="50" max="100">50%</progress>
+            <button title="Cancel Download" id="cancel_btn">X</button>
         </div>
     </div>
     {% if meta.query != '*' %}
@@ -165,10 +170,19 @@
         });
     }
 
+    var cancelled = false;
+
+    function cancel_download() {
+        // This will interrupt the download of chunks
+        cancelled = true;
+        // hide progress
+        showProgress(0, 0, true);
+        enableDownloadButtons(true);
+    }
+
     async function download_csv(filter){
         enableDownloadButtons(false);
         const rowCount = filter ? parseInt("{{ meta.totalCount }}") : parseInt("{{ meta.rowCount }}");
-        console.log('rowCount', filter, rowCount);
         const tableName = "{{ data.name }}.csv";
         // Use 10 batches, or max 1000 rows per batch
         const MAX_BATCH_ROWS = 1000;
@@ -181,8 +195,9 @@
         let count = 0;
         let bytes = 0;
         let blobData = [];
+        cancelled = false;
         showProgress(0, 0)
-        while(count <= rowCount) {
+        while(count <= rowCount && !cancelled) {
             let url = `${csvUrl}?&limit=${batchSize}&offset=${count}&header=${count===0 ? 'true' : 'false'}`;
             if (filter) {
                 url += `&query=${query}`;
@@ -195,7 +210,9 @@
         }
         showProgress(100, bytes);
 
-        downloadString(blobData, "text/csv", tableName);
+        if (!cancelled) {
+            downloadString(blobData, "text/csv", tableName);
+        }
 
         // hide progress
         showProgress(100, bytes, true);
@@ -212,6 +229,10 @@
     document.getElementById("download_current_view").addEventListener("click", function(){
         // Don't need progressing download, just use URL directly
         window.location.href="{% url 'omero_table' data.id 'csv' %}?limit={{ meta.limit }}&offset={{ meta.offset }}&query={{ meta.query|urlencode }}";
+    });
+
+    document.getElementById("cancel_btn").addEventListener("click", function() {
+        cancel_download();
     });
 
     </script>

--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -202,10 +202,23 @@
             if (filter) {
                 url += `&query=${query}`;
             }
-            const csvString = await fetch(url).then(rsp => rsp.body.getReader()).then(reader => readData(reader));
-            blobData.push(csvString);
-            bytes += csvString.length;
-            count += batchSize;
+            const csvString = await fetch(url)
+            .then(rsp => {
+                if (rsp.status != 200) {
+                    throw rsp;
+                }
+                return rsp.body.getReader();
+            })
+            .then(reader => readData(reader))
+            .catch(rsp => {
+                console.log("FAILED to load chunk:", url);
+            });
+            if (csvString !== undefined) {
+                console.log("csvString.length", csvString.length);
+                blobData.push(csvString);
+                bytes += csvString.length;
+                count += batchSize;
+            }
             showProgress((count/rowCount) * 100, bytes);
         }
         showProgress(100, bytes);

--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -184,8 +184,9 @@
         enableDownloadButtons(false);
         const rowCount = filter ? parseInt("{{ meta.totalCount }}") : parseInt("{{ meta.rowCount }}");
         const tableName = "{{ data.name }}.csv";
-        // Use 10 batches, or max 1000 rows per batch
+        // Use 10 batches, or max 3000 rows per batch
         const MAX_BATCH_ROWS = 3000;
+        const MAX_FAILED_CALLS = 5;
         const batchSize = Math.min(parseInt(rowCount/10), MAX_BATCH_ROWS);
 
         // load csv in batches...
@@ -196,7 +197,8 @@
         let bytes = 0;
         let blobData = [];
         cancelled = false;
-        showProgress(0, 0)
+        showProgress(0, 0);
+        failedChunks = 0;
         while(count <= rowCount && !cancelled) {
             let url = `${csvUrl}?&limit=${batchSize}&offset=${count}&header=${count===0 ? 'true' : 'false'}`;
             if (filter) {
@@ -212,6 +214,10 @@
             .then(reader => readData(reader))
             .catch(rsp => {
                 console.log("FAILED to load chunk:", url);
+                failedChunks += 1;
+                if (failedChunks >= MAX_FAILED_CALLS){
+                    cancelled = true;
+                }
             });
             if (csvString !== undefined) {
                 console.log("csvString.length", csvString.length);
@@ -225,6 +231,8 @@
 
         if (!cancelled) {
             downloadString(blobData, "text/csv", tableName);
+        } else if (failedChunks >= MAX_FAILED_CALLS) {
+            alert(`Downloading cancelled due to ${failedChunks} failed reads of table data.`)
         }
 
         // hide progress

--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -185,7 +185,7 @@
         const rowCount = filter ? parseInt("{{ meta.totalCount }}") : parseInt("{{ meta.rowCount }}");
         const tableName = "{{ data.name }}.csv";
         // Use 10 batches, or max 1000 rows per batch
-        const MAX_BATCH_ROWS = 1000;
+        const MAX_BATCH_ROWS = 3000;
         const batchSize = Math.min(parseInt(rowCount/10), MAX_BATCH_ROWS);
 
         // load csv in batches...

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3165,6 +3165,12 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
     """
     Download OMERO.table as CSV (streaming response) or return as HTML or json
 
+    Request parameters:
+    header: 'false' excludes the column names row if mtype is 'csv'
+    offset: table rows offset for pagination
+    limit: table rows limit for pagination
+    query: OMERO.table query for filtering rows
+
     @param file_id:     OriginalFile ID
     @param mtype:       None for html table or 'csv' or 'json'
     @param conn:        BlitzGateway connection
@@ -3196,10 +3202,12 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
     # OR, return as csv or html
     if mtype == "csv":
         table_data = context.get("data")
+        hide_header = request.GET.get("header") == "false"
 
         def csv_gen():
-            csv_cols = ",".join(table_data.get("columns"))
-            yield csv_cols
+            if not hide_header:
+                csv_cols = ",".join(table_data.get("columns"))
+                yield csv_cols
             for rows in table_data.get("lazy_rows"):
                 yield (
                     "\n" + "\n".join([",".join([str(d) for d in row]) for row in rows])

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2963,12 +2963,7 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
                 if request.GET.get("limit") is not None
                 else rows
             )
-        if limit > settings.MAX_TABLE_DOWNLOAD_ROWS:
-            error = (
-                "Trying to download %s rows exceeds configured"
-                " omero.web.max_table_download_rows of %s"
-            ) % (limit, settings.MAX_TABLE_DOWNLOAD_ROWS)
-            return dict(error=error)
+
         range_start = offset
         range_size = limit
         range_end = min(rows, range_start + range_size)
@@ -2993,6 +2988,13 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
                 hits = hits[range_start:range_end]
             except Exception:
                 return dict(error="Error executing query: %s" % query)
+
+        if len(hits) > settings.MAX_TABLE_DOWNLOAD_ROWS:
+            error = (
+                "Trying to download %s rows exceeds configured"
+                " omero.web.max_table_download_rows of %s"
+            ) % (len(hits), settings.MAX_TABLE_DOWNLOAD_ROWS)
+            return {"error": error, "status": 404}
 
         def row_generator(table, h):
             # hits are all consecutive rows - can load them in batches

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2963,6 +2963,12 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
                 if request.GET.get("limit") is not None
                 else rows
             )
+        if limit > settings.MAX_TABLE_DOWNLOAD_ROWS:
+            error = (
+                "Trying to download %s rows exceeds configured"
+                " omero.web.max_table_download_rows of %s"
+            ) % (limit, settings.MAX_TABLE_DOWNLOAD_ROWS)
+            return dict(error=error)
         range_start = offset
         range_size = limit
         range_end = min(rows, range_start + range_size)


### PR DESCRIPTION
This improves the experience and options when downloading OMERO.tables as CSV from `/webclient/omero_table/FILEID/`.

 - 2 buttons allow: Download of whole table (showing progress etc) or Download Currently displayed page (open URL, same behaviour as before).
 - If the table is being filtered (e.g. `?query=colname>value`) then we offer another option of download the Whole table using the current filter (which wasn't possible before), and showing progress.
 - Downloading while showing progress is performed by loading a number of rows at a time into the browser, showing the total size downloaded and the percentage number of total rows (see screenshot). When all rows have been download, we use Blob to download the string for the user. 


![Screenshot 2021-06-23 at 14 26 45](https://user-images.githubusercontent.com/900055/123105457-bd55cb80-d42f-11eb-9865-e0b797f56043.png)

To test UI:
- Open table, e.g. https://merge-ci.openmicroscopy.org/web/webclient/omero_table/406232/ (user-3)
- Without filtering (no query), check that the Download `Whole Table` downloads the whole table with progress shown and that the `Current View` downloads just the current page. Check the CSV files with Excell etc.
- With filtering (use a ?query=... to limit the rows shown, e.g. https://merge-ci.openmicroscopy.org/web/webclient/omero_table/406232/?query=Y%3E50000), the `Whole Table` button should behave as before. The `Current View` button should download the current page of filtered results and the `With Filter` button should download ALL the filtered results (with progress bar). Check the CSV files with Excell etc that they have all the expected rows.
- For a table above with over 10,000 rows edit the URL to add `?limit=11000` and this should return an error page with appropriate message. E.g. https://merge-ci.openmicroscopy.org/web/webclient/omero_table/406232/?limit=11000 (user-3)
- Smaller limits should work fine, e.g. `?limit=5000`

To test other URLs:
- https://merge-ci.openmicroscopy.org/web/webclient/omero_table/406232/json/?limit=11000 Error above 10k, OK below.
- https://merge-ci.openmicroscopy.org/web/webgateway/table/Project.datasetLinks.child.imageLinks.child/105665/query/?query=* Should say 'too high' but adding e.g. `&limit=1000` OR a query with fewer than 10k results should be fine: e.g. https://merge-ci.openmicroscopy.org/web/webgateway/table/Project.datasetLinks.child.imageLinks.child/105665/query/?query=Y>52000
- https://merge-ci.openmicroscopy.org/web/webgateway/table/406232/query/?query=* fail but adding e.g. `&limit=1000` OR https://merge-ci.openmicroscopy.org/web/webgateway/table/406232/query/?query=Y>52000 should be fine

cc @chris-allan 
