### PR TITLE
table_errors status_codes

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3191,7 +3191,7 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
     )
 
     if context.get("error") or not context.get("data"):
-        return JsonResponse(context)
+        return JsonResponse(context, status=context.get("status", 500))
 
     # OR, return as csv or html
     if mtype == "csv":


### PR DESCRIPTION
See discussion at https://github.com/ome/omero-web/pull/300#discussion_r657133704

This aims to return appropriate `status` codes for Json Responses for the `_table` end-points:

`/webclient/omero_table/50534/json/`
`/webgateway/table/Screen.plateLinks.child.wells.wellSamples.image/806/query/?query=Image-806`
`/webgateway/table/Dataset.imageLinks.child/806/query/?query=*`
`/webgateway/table/5/metadata/`
`/webgateway/table/50534/query/?query=Image>1211`

However, this breaks the webclient, since the [global ajaxError handling](https://github.com/ome/omero-web/blob/b25ce9e19a6f55f6b7f71b582bf211b15eb5abd6/omeroweb/webgateway/static/webgateway/js/ome.popup.js#L517) shows an error message for any 404s, 500s etc instead of simply ignoring them as before:

![Screenshot 2021-06-25 at 10 25 56](https://user-images.githubusercontent.com/900055/123403299-8bb04200-d5a0-11eb-9412-b536f699a6c1.png)

cc @ chris-allan @kkoz 

--exclude