### PR TITLE
Only return the column names that were requested

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2934,7 +2934,6 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
 
     try:
         cols = t.getHeaders()
-        column_names = [col.name for col in cols]
         col_indices = range(len(cols))
         if col_names:
             enumerated_columns = (
@@ -2951,6 +2950,7 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
                         cols.append(j)
                         break
 
+        column_names = [col.name for col in cols]
         rows = t.getNumberOfRows()
 
         offset = kwargs.get("offset", 0)


### PR DESCRIPTION
Return requested column names
When performing an OMERO Table query, currently all column names are included in the response even if a subset was selected. This PR makes it so if a subset of columns was selected only those column names are returned.
Can test by hitting the `webgateway/table/<file id>/query/` endpoint and include the `col_names` URL parameter to specify 1 or more columns.