### PR TITLE
Obj id bitmask endpoint

### DIFF
--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -54,6 +54,16 @@ table_obj_id_bitmask = url(
 )
 """
 Get object id bitmask
+The user specifies a fileid for an OMERO Table and a query, and
+optionally provides a "col_name" query parameter for the column
+name to get a bitmask for. By default, "object" is used.
+The server will return a bitmask with the nth bit flipped to 1
+if the query returns a row where the col_name has a value of n.
+The bits returned are 0-indexed.
+E.g. if your query returns col_name values of 1, 7, 11, and 12,
+you will get back 2 bytes and the bitmask will be 0100000100011000
+Note that the 1st, 7th, 11th, and 12th bits are flipped to 1 and
+the rest are 0.
 """
 
 object_table_query = url(

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -47,9 +47,11 @@ table_metadata = url(
 Get omero table metadata
 """
 
-table_obj_id_bitmask = url(r'^table/(?P<fileid>\d+)/obj_id_bitmask/$',
-                  views.obj_id_bitmask,
-                  name="webgateway_table_obj_id_bitmask")
+table_obj_id_bitmask = url(
+    r"^table/(?P<fileid>\d+)/obj_id_bitmask/$",
+    views.obj_id_bitmask,
+    name="webgateway_table_obj_id_bitmask",
+)
 """
 Get object id bitmask
 """

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -47,6 +47,13 @@ table_metadata = url(
 Get omero table metadata
 """
 
+table_obj_id_bitmask = url(r'^table/(?P<fileid>\d+)/obj_id_bitmask/$',
+                  views.obj_id_bitmask,
+                  name="webgateway_table_obj_id_bitmask")
+"""
+Get object id bitmask
+"""
+
 object_table_query = url(
     r"^table/(?P<objtype>[\w.]+)/(?P<objid>\d+)/query/$",
     views.object_table_query,
@@ -597,6 +604,7 @@ urlpatterns = [
     annotations,
     table_query,
     table_metadata,
+    table_obj_id_bitmask,
     object_table_query,
     open_with_options,
 ]

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3136,18 +3136,22 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
     )
     if "error" in rsp_data:
         return rsp_data
+    data = rowsToByteArray(rsp_data["data"]["rows"])
+    return HttpResponse(bytes(data), content_type="application/octet-stream")
+
+def rowsToByteArray(rows):
     maxval = 0
-    for obj in rsp_data["data"]["rows"]:
+    for obj in rows:
         obj_id = int(obj[0])
         maxval = max(obj_id, maxval)
     bytesSize = (maxval // 8) + 1
     data = bytearray(bytesSize)
-    for obj in rsp_data["data"]["rows"]:
+    for obj in rows:
         obj_id = int(obj[0])
         byteIdx = obj_id // 8
         bitToSet = obj_id % 8
         data[byteIdx] = data[byteIdx] | 2 ** (bitToSet)
-    return HttpResponse(bytes(data), content_type="application/octet-stream")
+    return data
 
 
 @login_required()

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3039,7 +3039,7 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
             else None
         )
     return perform_table_query(
-        conn, fileid, query, col_names, offset=offset, limit=limit, lazy=False
+        conn, fileid, query, col_names, offset=offset, limit=limit, lazy=lazy
     )
 
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3134,7 +3134,7 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
         lazy=False,
         check_max_rows=False,
     )
-    if 'error' in rsp_data:
+    if "error" in rsp_data:
         return rsp_data
     maxval = 0
     for obj in rsp_data["data"]["rows"]:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3165,12 +3165,18 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, **kwargs):
     )
     if "error" in rsp_data:
         return rsp_data
-    data = rowsToByteArray(rsp_data["data"]["rows"])
-    return HttpResponse(bytes(data), content_type="application/octet-stream")
+    try:
+        data = rowsToByteArray(rsp_data["data"]["rows"])
+        return HttpResponse(bytes(data), content_type="application/octet-stream")
+    except ValueError as e:
+        logger.error("ValueError when getting obj_id_bitmask")
+        return {"error": "Specified column has invalid type"}
 
 
 def rowsToByteArray(rows):
     maxval = 0
+    if len(rows) > 0 and type(rows[0][0]) == float:
+        raise ValueError('Cannot have ID of float')
     for obj in rows:
         obj_id = int(obj[0])
         maxval = max(obj_id, maxval)

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2893,7 +2893,14 @@ annotations = login_required()(jsonp(_bulk_file_annotations))
 
 
 def perform_table_query(
-    conn, fileid, query, col_names, offset=0, limit=None, lazy=False, check_max_rows=True
+    conn,
+    fileid,
+    query,
+    col_names,
+    offset=0,
+    limit=None,
+    lazy=False,
+    check_max_rows=True,
 ):
     ctx = conn.createServiceOptsDict()
     ctx.setOmeroGroup("-1")
@@ -3118,8 +3125,14 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
         )
 
     rsp_data = perform_table_query(
-        conn, fileid, query, [col_name], offset=offset, limit=limit, lazy=False,
-        check_max_rows=False
+        conn,
+        fileid,
+        query,
+        [col_name],
+        offset=offset,
+        limit=limit,
+        lazy=False,
+        check_max_rows=False,
     )
     maxval = 0
     for obj in rsp_data["data"]["rows"]:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2968,7 +2968,6 @@ def perform_table_query(conn, fileid, query, col_names, offset=0, limit=None, la
                 idx += batch
                 # yield a list of rows
                 yield [[col.values[row] for col in res.columns] for row in range(0,len(res.rowNumbers))]
-            logger.info(time.perf_counter() - start)
 
         row_gen = row_generator(t, hits)
 
@@ -3103,7 +3102,6 @@ def _obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs
         limit = int(request.GET.get("limit")) if request.GET.get("limit") is not None else None
 
     rsp_data = perform_table_query(conn, fileid, query, [col_name], offset=offset, limit=limit, lazy=False)
-    logger.info(rsp_data)
     bitmask = bytearray()
     index = 0
     value = 0

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -21,6 +21,7 @@ from functools import wraps
 import omero
 import omero.clients
 from past.builtins import unicode
+import numpy
 
 from django.http import (
     HttpResponse,
@@ -3145,13 +3146,14 @@ def rowsToByteArray(rows):
     for obj in rows:
         obj_id = int(obj[0])
         maxval = max(obj_id, maxval)
-    bytesSize = (maxval // 8) + 1
-    data = bytearray(bytesSize)
+    bitArray = numpy.zeros(maxval + 1, dtype='uint8')
     for obj in rows:
         obj_id = int(obj[0])
-        byteIdx = obj_id // 8
-        bitToSet = obj_id % 8
-        data[byteIdx] = data[byteIdx] | 2 ** (bitToSet)
+        bitArray[obj_id] = 1
+    packed = numpy.packbits(bitArray, bitorder='big')
+    data = bytearray()
+    for val in packed:
+        data.append(val)
     return data
 
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3139,6 +3139,7 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
     data = rowsToByteArray(rsp_data["data"]["rows"])
     return HttpResponse(bytes(data), content_type="application/octet-stream")
 
+
 def rowsToByteArray(rows):
     maxval = 0
     for obj in rows:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3114,20 +3114,19 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
     rsp_data = perform_table_query(
         conn, fileid, query, [col_name], offset=offset, limit=limit, lazy=False
     )
-    index = 0
-    value = 0
-    data = bytearray()
+    maxval = 0
     for obj in rsp_data["data"]["rows"]:
         obj_id = int(obj[0])
-        while index < obj_id:
-            index += 1
-            if index % 8 == 0:
-                data.append(value)
-                value = 0
-        # index == obj_id
-        value += 2 ** (index % 8)
-    if value != 0:
-        data.append(value)
+        maxval = max(obj_id, maxval)
+    index = 0
+    value = 0
+    bytesSize = (maxval // 8) + 1
+    data = bytearray(bytesSize)
+    for obj in rsp_data["data"]["rows"]:
+        obj_id = int(obj[0])
+        byteIdx = obj_id // 8
+        bitToSet = obj_id % 8
+        data[byteIdx] = data[byteIdx] | 2 ** (bitToSet)
     return HttpResponse(bytes(data), content_type="application/octet-stream")
 
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3118,8 +3118,6 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
     for obj in rsp_data["data"]["rows"]:
         obj_id = int(obj[0])
         maxval = max(obj_id, maxval)
-    index = 0
-    value = 0
     bytesSize = (maxval // 8) + 1
     data = bytearray(bytesSize)
     for obj in rsp_data["data"]["rows"]:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3176,7 +3176,7 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, **kwargs):
 def rowsToByteArray(rows):
     maxval = 0
     if len(rows) > 0 and type(rows[0][0]) == float:
-        raise ValueError('Cannot have ID of float')
+        raise ValueError("Cannot have ID of float")
     for obj in rows:
         obj_id = int(obj[0])
         maxval = max(obj_id, maxval)

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3107,7 +3107,7 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
     value = 0
     data = bytearray()
     for obj in rsp_data['data']['rows']:
-        obj_id = obj[0]
+        obj_id = int(obj[0])
         while index < obj_id:
             index += 1
             if index % 8 == 0:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3146,11 +3146,11 @@ def rowsToByteArray(rows):
     for obj in rows:
         obj_id = int(obj[0])
         maxval = max(obj_id, maxval)
-    bitArray = numpy.zeros(maxval + 1, dtype='uint8')
+    bitArray = numpy.zeros(maxval + 1, dtype="uint8")
     for obj in rows:
         obj_id = int(obj[0])
         bitArray[obj_id] = 1
-    packed = numpy.packbits(bitArray, bitorder='big')
+    packed = numpy.packbits(bitArray, bitorder="big")
     data = bytearray()
     for val in packed:
         data.append(val)

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3088,7 +3088,9 @@ def _table_metadata(request, fileid, conn=None, query=None, lazy=False, **kwargs
 table_metadata = login_required()(jsonp(_table_metadata))
 
 
-def _obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs):
+@login_required()
+@jsonp
+def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs):
     col_name = request.GET.get("col_name", "object")
     if query is None:
         query = request.GET.get("query")
@@ -3102,7 +3104,6 @@ def _obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs
         limit = int(request.GET.get("limit")) if request.GET.get("limit") is not None else None
 
     rsp_data = perform_table_query(conn, fileid, query, [col_name], offset=offset, limit=limit, lazy=False)
-    bitmask = bytearray()
     index = 0
     value = 0
     data = bytearray()
@@ -3113,15 +3114,11 @@ def _obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs
             if index % 8 == 0:
                 data.append(value)
                 value = 0
-                counter = 0
         # index == obj_id
         value += 2 ** (index % 8)
     if value != 0:
         data.append(value)
     return HttpResponse(bytes(data), content_type='application/octet-stream')
-
-
-obj_id_bitmask = login_required()(_obj_id_bitmask)
 
 
 @login_required()

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2922,18 +2922,8 @@ def perform_table_query(conn, fileid, query, col_names, offset=0, limit=None, la
         column_names = [col.name for col in cols]
         rows = t.getNumberOfRows()
 
-        offset = kwargs.get("offset", 0)
-        limit = kwargs.get("limit", None)
-        if not offset:
-            offset = int(request.GET.get("offset", 0))
-        if not limit:
-            limit = (
-                int(request.GET.get("limit"))
-                if request.GET.get("limit") is not None
-                else rows
-            )
         range_start = offset
-        range_size = limit
+        range_size = limit if limit is not None else rows
         range_end = min(rows, range_start + range_size)
 
         if query == "*":
@@ -3030,13 +3020,17 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
     if not query:
         return dict(error="Must specify query parameter, use * to retrieve all")
     col_names = request.GET.getlist("col_names")
+
     offset = kwargs.get("offset", 0)
     limit = kwargs.get("limit", None)
     if not offset:
         offset = int(request.GET.get("offset", 0))
     if not limit:
-        limit = int(request.GET.get("limit")) if request.GET.get("limit") is not None else None
-
+        limit = (
+            int(request.GET.get("limit"))
+            if request.GET.get("limit") is not None
+            else None
+        )
     return perform_table_query(conn, fileid, query, col_names, offset=offset, limit=limit, lazy=False)
 
 
@@ -3096,12 +3090,17 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
         query = request.GET.get("query")
     if not query:
         return dict(error="Must specify query parameter, use * to retrieve all")
+
     offset = kwargs.get("offset", 0)
     limit = kwargs.get("limit", None)
     if not offset:
         offset = int(request.GET.get("offset", 0))
     if not limit:
-        limit = int(request.GET.get("limit")) if request.GET.get("limit") is not None else None
+        limit = (
+            int(request.GET.get("limit"))
+            if request.GET.get("limit") is not None
+            else None
+        )
 
     rsp_data = perform_table_query(conn, fileid, query, [col_name], offset=offset, limit=limit, lazy=False)
     index = 0

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2892,7 +2892,9 @@ def _bulk_file_annotations(request, objtype, objid, conn=None, **kwargs):
 annotations = login_required()(jsonp(_bulk_file_annotations))
 
 
-def perform_table_query(conn, fileid, query, col_names, offset=0, limit=None, lazy=False):
+def perform_table_query(
+    conn, fileid, query, col_names, offset=0, limit=None, lazy=False
+):
     ctx = conn.createServiceOptsDict()
     ctx.setOmeroGroup("-1")
 
@@ -2948,6 +2950,7 @@ def perform_table_query(conn, fileid, query, col_names, offset=0, limit=None, la
                 return dict(error="Error executing query: %s" % query)
 
         logger.info("Retrieving {} rows".format(len(hits)))
+
         def row_generator(table, h):
             # hits are all consecutive rows - can load them in batches
             idx = 0
@@ -2957,7 +2960,10 @@ def perform_table_query(conn, fileid, query, col_names, offset=0, limit=None, la
                 res = table.slice(col_indices, h[idx : idx + batch])
                 idx += batch
                 # yield a list of rows
-                yield [[col.values[row] for col in res.columns] for row in range(0,len(res.rowNumbers))]
+                yield [
+                    [col.values[row] for col in res.columns]
+                    for row in range(0, len(res.rowNumbers))
+                ]
 
         row_gen = row_generator(t, hits)
 
@@ -2988,6 +2994,7 @@ def perform_table_query(conn, fileid, query, col_names, offset=0, limit=None, la
     finally:
         if not lazy:
             t.close()
+
 
 def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
     """
@@ -3031,7 +3038,9 @@ def _table_query(request, fileid, conn=None, query=None, lazy=False, **kwargs):
             if request.GET.get("limit") is not None
             else None
         )
-    return perform_table_query(conn, fileid, query, col_names, offset=offset, limit=limit, lazy=False)
+    return perform_table_query(
+        conn, fileid, query, col_names, offset=offset, limit=limit, lazy=False
+    )
 
 
 table_query = login_required()(jsonp(_table_query))
@@ -3102,11 +3111,13 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
             else None
         )
 
-    rsp_data = perform_table_query(conn, fileid, query, [col_name], offset=offset, limit=limit, lazy=False)
+    rsp_data = perform_table_query(
+        conn, fileid, query, [col_name], offset=offset, limit=limit, lazy=False
+    )
     index = 0
     value = 0
     data = bytearray()
-    for obj in rsp_data['data']['rows']:
+    for obj in rsp_data["data"]["rows"]:
         obj_id = int(obj[0])
         while index < obj_id:
             index += 1
@@ -3117,7 +3128,7 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
         value += 2 ** (index % 8)
     if value != 0:
         data.append(value)
-    return HttpResponse(bytes(data), content_type='application/octet-stream')
+    return HttpResponse(bytes(data), content_type="application/octet-stream")
 
 
 @login_required()

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3168,7 +3168,7 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, **kwargs):
     try:
         data = rowsToByteArray(rsp_data["data"]["rows"])
         return HttpResponse(bytes(data), content_type="application/octet-stream")
-    except ValueError as e:
+    except ValueError:
         logger.error("ValueError when getting obj_id_bitmask")
         return {"error": "Specified column has invalid type"}
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -21,7 +21,6 @@ from functools import wraps
 import omero
 import omero.clients
 from past.builtins import unicode
-import numpy
 
 from django.http import (
     HttpResponse,
@@ -3108,6 +3107,8 @@ table_metadata = login_required()(jsonp(_table_metadata))
 @login_required()
 @jsonp
 def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs):
+    if not numpyInstalled:
+        raise NotImplementedError("numpy not installed")
     col_name = request.GET.get("col_name", "object")
     if query is None:
         query = request.GET.get("query")

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3134,6 +3134,8 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, lazy=False, **kwargs)
         lazy=False,
         check_max_rows=False,
     )
+    if 'error' in rsp_data:
+        return rsp_data
     maxval = 0
     for obj in rsp_data["data"]["rows"]:
         obj_id = int(obj[0])

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -8,6 +8,7 @@ import pytest
 
 from omeroweb.webgateway.webgateway_cache import FileCache, WebGatewayCache
 from omeroweb.webgateway.webgateway_cache import WebGatewayTempFile
+from omeroweb.webgateway import views
 import omero.gateway
 
 
@@ -384,3 +385,10 @@ class TestWebGatewayCache(object):
         assert self.wcache._json_cache._num_entries != 0
         self.wcache.clear()
         assert self.wcache._json_cache._num_entries == 0
+
+class TestViews(object):
+    def testRowstoByteArray(self):
+        rows = [[1],[7],[11],[12]]
+        data = views.rowsToByteArray(rows)
+        assert data[0] == 130 #01000001 First and 7th bits
+        assert data[1] == 24  #00011000 11th and 12th bits

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -386,9 +386,10 @@ class TestWebGatewayCache(object):
         self.wcache.clear()
         assert self.wcache._json_cache._num_entries == 0
 
+
 class TestViews(object):
     def testRowstoByteArray(self):
-        rows = [[1],[2],[7],[11],[12]]
+        rows = [[1], [2], [7], [11], [12]]
         data = views.rowsToByteArray(rows)
-        assert data[0] == 97  #01100001 First, Second and 7th bits
-        assert data[1] == 24  #00011000 11th and 12th bits
+        assert data[0] == 97  # 01100001 First, Second and 7th bits
+        assert data[1] == 24  # 00011000 11th and 12th bits

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -386,10 +386,9 @@ class TestWebGatewayCache(object):
         self.wcache.clear()
         assert self.wcache._json_cache._num_entries == 0
 
-
 class TestViews(object):
     def testRowstoByteArray(self):
-        rows = [[1], [7], [11], [12]]
+        rows = [[1],[2],[7],[11],[12]]
         data = views.rowsToByteArray(rows)
-        assert data[0] == 130  # 01000001 First and 7th bits
-        assert data[1] == 24  # 00011000 11th and 12th bits
+        assert data[0] == 97  #01100001 First, Second and 7th bits
+        assert data[1] == 24  #00011000 11th and 12th bits

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -386,9 +386,10 @@ class TestWebGatewayCache(object):
         self.wcache.clear()
         assert self.wcache._json_cache._num_entries == 0
 
+
 class TestViews(object):
     def testRowstoByteArray(self):
-        rows = [[1],[7],[11],[12]]
+        rows = [[1], [7], [11], [12]]
         data = views.rowsToByteArray(rows)
-        assert data[0] == 130 #01000001 First and 7th bits
-        assert data[1] == 24  #00011000 11th and 12th bits
+        assert data[0] == 130  # 01000001 First and 7th bits
+        assert data[1] == 24  # 00011000 11th and 12th bits


### PR DESCRIPTION
This PR adds an endpoint to make label image data retrieval more efficient from omero tables. Rather than returning the entire result of a query which could be a very large number of objects, the endpoint returns a bitmask representing the object IDs, where the bit is set to 1 if that ID matched the query and 0 otherwise. You can hit the endpoint using a URL like `http://localhost/webgateway/table/123/obj_id_bitmask/?query=value<14`. A `col_name` parameter can also be passed if your object ID column name is not named `object`