### PR TITLE
omero table link to shape

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -101,6 +101,8 @@
                 <td><a target="_blank" href="{% url 'webindex' %}?show=well-{{ col }}">{{ col }}</a></td>
                 {% elif roi_column_index == forloop.counter0 and iviewer_url != None %}
                 <td><a target="_blank" href="{{ iviewer_url }}?roi={{ col }}">{{ col }}</a></td>
+                {% elif shape_column_index == forloop.counter0 and iviewer_url != None %}
+                <td><a target="_blank" href="{{ iviewer_url }}?shape={{ col }}">{{ col }}</a></td>
                 {% else %}
                 <td>{{ col }}</td>
                 {% endif %}

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3248,6 +3248,7 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
         if "RoiColumn" in col_types:
             context["roi_column_index"] = col_types.index("RoiColumn")
         # we don't use ShapeColumn type - just check name and LongColumn type...
+        # TODO: when ShapeColumn is supported, add handling to this code
         cnames = [n.lower() for n in context["data"]["columns"]]
         if "shape" in cnames and col_types[cnames.index("shape")] == "LongColumn":
             context["shape_column_index"] = cnames.index("shape")

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3247,6 +3247,10 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
             context["well_column_index"] = col_types.index("WellColumn")
         if "RoiColumn" in col_types:
             context["roi_column_index"] = col_types.index("RoiColumn")
+        # we don't use ShapeColumn type - just check name and LongColumn type...
+        cnames = [n.lower() for n in context["data"]["columns"]]
+        if "shape" in cnames and col_types[cnames.index("shape")] == "LongColumn":
+            context["shape_column_index"] = cnames.index("shape")
         # provide example queries - pick first DoubleColumn...
         for idx, c_type in enumerate(col_types):
             if c_type in ("DoubleColumn", "LongColumn"):


### PR DESCRIPTION
Follow-up of #264, this PR links Shape IDs in an OMERO.table to `iviewer?shape=ID`.

However, in this case we don't have a `ShapeColumn` to check for, so I've just looked for a column where `name.lower() == "shape"` and type is `LongColumn`.

This is useful for cases like `idr0101` where you have many Shapes per ROI, so that linking to the ROI is not sufficient.

To test - see example Image with bulk_annotations table that has `shape`: https://merge-ci.openmicroscopy.org/web/webclient/?show=image-94481
NB: that image doesn't have correct dimensions for the ROI - it's a fake image with ROIs from idr0101 applied to it, so selection of the expected Shape may not happen if the z-index is greater than sizeZ for the image.

 - Table values in the `shape` column should be links to open iviewer?shape=ID` in new tab

cc @sbesson 