### PR TITLE
Add omero.web config option to set custom favicon

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -834,9 +834,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
         "FAVICON_URL",
         '"webgateway/img/ome.ico"',
         json.loads,
-        (
-            "Favicon URL, specifies the path relative to django's static file dirs."
-        ),
+        ("Favicon URL, specifies the path relative to django's static file dirs."),
     ],
     "omero.web.staticfile_dirs": [
         "STATICFILES_DIRS",

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -833,7 +833,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.favicon_url": [
         "FAVICON_URL",
         '"webgateway/img/ome.ico"',
-        json.loads,
+        str,
         ("Favicon URL, specifies the path relative to django's static file dirs."),
     ],
     "omero.web.staticfile_dirs": [

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -830,6 +830,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
             "(OME team by default)."
         ),
     ],
+    "omero.web.favicon_url": [
+        "FAVICON_URL",
+        '"webgateway/img/ome.ico"',
+        json.loads,
+        (
+            "Favicon URL, specifies the path relative to django's static file dirs."
+        ),
+    ],
     "omero.web.staticfile_dirs": [
         "STATICFILES_DIRS",
         "[]",

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -832,7 +832,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     ],
     "omero.web.favicon_url": [
         "FAVICON_URL",
-        '"webgateway/img/ome.ico"',
+        "webgateway/img/ome.ico",
         str,
         ("Favicon URL, specifies the path relative to django's static file dirs."),
     ],

--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -118,7 +118,7 @@ OMERO.web are compatible
 urlpatterns += [
     url(
         r"^favicon\.ico$",
-        lambda request: redirect("%swebgateway/img/ome.ico" % settings.STATIC_URL),
+        lambda request: redirect("%s%s" % (settings.STATIC_URL, settings.FAVICON_URL)),
     ),
     url(r"^(?i)webgateway/", include("omeroweb.webgateway.urls")),
     url(r"^(?i)webadmin/", include("omeroweb.webadmin.urls")),


### PR DESCRIPTION
This PR introduces a config option to overwrite `webgateway/img/ome.ico` with a custom icon.

Favicon can be overwritten by setting `favicon_url` option with:

```
omero config set omero.web.favicon_url 'omero_web_module_name/subdir/new.ico'
```

The URL to the favicon needs to be specified relative to the Django's static directory.