### PR TITLE
Respect login view for public login button

### DIFF
--- a/omeroweb/webclient/decorators.py
+++ b/omeroweb/webclient/decorators.py
@@ -238,3 +238,4 @@ class render_response(omeroweb.decorators.render_response):
         context["ome"]["center_plugins"] = c_plugins
 
         context["ome"]["user_dropdown"] = settings.USER_DROPDOWN
+        context["ome"]["login_view"] = settings.LOGIN_VIEW

--- a/omeroweb/webclient/templates/webclient/base/includes/user_dropdown.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/user_dropdown.html
@@ -21,7 +21,7 @@
 {% if ome.user_dropdown %}
 {% if ome.is_public_user %}
     <div id="public_login_button">
-        <a href="{% url 'weblogin' %}">
+        <a href="{% url ome.login_view %}">
             <div id="show_public_login_button">
                 <img src="{% static 'webclient/image/personal32.png' %}"/>
                 <span>Login</span>


### PR DESCRIPTION
The changes in this PR pass the Login View setting to the OMERO.web "Login" button when public user is enabled.

![image](https://user-images.githubusercontent.com/2600663/130625851-506ad618-c13d-4be2-970e-c2d7622adee5.png)
