### PR TITLE
Filtering handles ampersands in image names

### DIFF
--- a/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -536,6 +536,17 @@ $(document).ready(function() {
             'bind': 'keyup',
             'loader': 'span.loading',
             'selector': '.hidden_sort_text',
+            // override to replace &amp; from item.innerHTML with '&'
+            testQuery: function (query, txt, _row) {
+                // query is a list of strings
+                for (var i = 0; i < query.length; i += 1) {
+                    txt = txt.replace(/&amp;/g, '&')
+                    if (txt.indexOf(query[i]) === -1) {
+                        return false;
+                    }
+                }
+                return true;
+            },
             onAfter: function(){
                 // onAfter can get triggered without text change, E.g. by tree selection!
                 var new_txt = $filter_input.val();


### PR DESCRIPTION
Fixes #322

To test:
 - Find or rename images with one or more `&` in the name
 - If re-named, refresh jsTree or whole page
 - Filter images by name with text including `&`. Images should not be filtered out.

cc @pwalczysko 