### PR TITLE
purgeCallback Activities

### DIFF
--- a/omeroweb/webclient/webclient_utils.py
+++ b/omeroweb/webclient/webclient_utils.py
@@ -65,11 +65,10 @@ def _formatReport(callback):
     # Might want to take advantage of other feedback here
 
 
-def _purgeCallback(request):
+def _purgeCallback(request, limit=200):
 
     callbacks = request.session.get("callback", {}).keys()
-    if len(callbacks) > 200:
-        for (cbString, count) in zip(
-            request.session.get("callback").keys(), range(0, len(callbacks) - 200)
-        ):
+    if len(callbacks) > limit:
+        cbKeys = list(request.session.get("callback").keys())
+        for (cbString, count) in zip(cbKeys, range(0, len(callbacks) - limit)):
             del request.session["callback"][cbString]


### PR DESCRIPTION
See https://www.openmicroscopy.org/qa2/qa/feedback/30523/

The `purgeCallbacks` only deletes items if there are `> 200` callbacks when the `activities` panel is loaded.
But this causes an error below, fixed by this PR:

```
Traceback (most recent call last):

File "/opt/omero/web/venv3/lib64/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
response = get_response(request)

File "/opt/omero/web/venv3/lib64/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
response = self.process_exception_by_middleware(e, request)

File "/opt/omero/web/venv3/lib64/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omeroweb/decorators.py", line 538, in wrapped
retval = f(request, *args, **kwargs)

File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omeroweb/decorators.py", line 597, in wrapper
context = f(request, *args, **kwargs)

File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omeroweb/webclient/views.py", line 3498, in activities
_purgeCallback(request)

File "/opt/omero/web/venv3/lib64/python3.6/site-packages/omeroweb/webclient/webclient_utils.py", line 73, in _purgeCallback
request.session.get("callback").keys(), range(0, len(callbacks) - 200)

RuntimeError: dictionary changed size during iteration
```

To test:
 - either generate over 200 callbacks (activities in the Activities panel) but running a lot of scripts or doing lots of deletes etc OR...
 - I tested by modifying the code to use a limit of 2
 - When you view the Activities panel, this should remove items from the Activities list above the limit without causing the error above.