### PR TITLE
saveToAll includes Z and T

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -326,7 +326,7 @@
                     spanTxt = $span.text();
                   $span.text("Saving...");
                   var typeId = pid.split("-");
-                  var rdefQry = OME.preview_viewport.getQuery();
+                  var rdefQry = OME.preview_viewport.getQuery(true);
                   // need to paste current settings to all images...
                   var url = "{% url 'webgateway_copy_image_rdef_json' %}"+ "?" + rdefQry;
                   data = {


### PR DESCRIPTION
See https://forum.image.sc/t/updating-plate-thumbnails-in-omero-web/59729

To test:

 - Need a Plate or a Dataset with multi-T or multi-Z images (probably needs images with the same sizeT or sizeZ).
 - View one Image in the Preview Tab. Adjust settings, including Z or T slider.
 - Click "SaveToAll"
 - Check that the Z or T index is saved to that Image AND applied to all the other Images in the Dataset or Plate.