### PR TITLE
show sizeT in centre panel table

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1688,7 +1688,13 @@
         text-align: center;
         float: left;
     }
-    .iconLayout .desc, .iconLayout .date, .iconLayout .thead, .iconLayout .sizeX, .iconLayout .sizeY, .iconLayout .sizeZ{
+    .iconLayout .desc,
+    .iconLayout .date,
+    .iconLayout .thead,
+    .iconLayout .sizeX,
+    .iconLayout .sizeY,
+    .iconLayout .sizeZ,
+    .iconLayout .sizeT {
         display: none;
     }
 

--- a/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -9,6 +9,7 @@
         <div class='sort-numeric'>Size X</div> 
         <div class='sort-numeric'>Size Y</div> 
         <div class='sort-numeric'>Size Z</div>
+        <div class='sort-numeric'>Size T</div>
     </li>
 
     <% _.each(images, function(img) { %>
@@ -38,6 +39,7 @@
             <div class="sizeX" valign="middle"><%- img.data.obj.sizeX %></div>
             <div class="sizeY" valign="middle"><%- img.data.obj.sizeY %></div>
             <div class="sizeZ" valign="middle"><%- img.data.obj.sizeZ %></div>
+            <div class="sizeT" valign="middle"><%- img.data.obj.sizeT %></div>
         </li>
     <% }) %>
 </ul>

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -537,10 +537,11 @@ def _marshal_image(
       * details.permissions (dict)
       * fileset_id (rlong)
 
-    May also take a row_pixels (list) if X,Y,Z dimensions are loaded
+    May also take a row_pixels (list) if X,Y,Z,T dimensions are loaded
       * pixels.sizeX (rlong)
       * pixels.sizeY (rlong)
       * pixels.sizeZ (rlong)
+      * pixels.sizeT (rlong)
 
     @param conn OMERO gateway.
     @type conn L{omero.gateway.BlitzGateway}
@@ -559,10 +560,11 @@ def _marshal_image(
     if fileset_id_val is not None:
         image["filesetId"] = fileset_id_val
     if row_pixels:
-        sizeX, sizeY, sizeZ = row_pixels
+        sizeX, sizeY, sizeZ, sizeT = row_pixels
         image["sizeX"] = unwrap(sizeX)
         image["sizeY"] = unwrap(sizeY)
         image["sizeZ"] = unwrap(sizeZ)
+        image["sizeT"] = unwrap(sizeT)
     if share_id is not None:
         image["shareId"] = share_id
     if date is not None:
@@ -657,6 +659,7 @@ def marshal_images(
              ,
              pix.sizeX as sizeX,
              pix.sizeY as sizeY,
+             pix.sizeT as sizeT,
              pix.sizeZ as sizeZ
              """
 
@@ -759,7 +762,7 @@ def marshal_images(
         ]
         kwargs = {"conn": conn, "row": d[0:5]}
         if load_pixels:
-            d = [e["sizeX"], e["sizeY"], e["sizeZ"]]
+            d = [e["sizeX"], e["sizeY"], e["sizeZ"], e["sizeT"]]
             kwargs["row_pixels"] = d
         if date:
             kwargs["acqDate"] = e["acqDate"]
@@ -1502,6 +1505,7 @@ def marshal_tagged(
              ,
              pix.sizeX as sizeX,
              pix.sizeY as sizeY,
+             pix.sizeT as sizeT
              pix.sizeZ as sizeZ
              """
         extraObjs = " left outer join obj.pixels pix"
@@ -1540,7 +1544,7 @@ def marshal_tagged(
         ]
         kwargs = {}
         if load_pixels:
-            d = [e[0]["sizeX"], e[0]["sizeY"], e[0]["sizeZ"]]
+            d = [e[0]["sizeX"], e[0]["sizeY"], e[0]["sizeZ"], e[0]["sizeT"]]
             kwargs["row_pixels"] = d
         if date:
             kwargs["acqDate"] = e[0]["acqDate"]

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -1505,7 +1505,7 @@ def marshal_tagged(
              ,
              pix.sizeX as sizeX,
              pix.sizeY as sizeY,
-             pix.sizeT as sizeT
+             pix.sizeT as sizeT,
              pix.sizeZ as sizeZ
              """
         extraObjs = " left outer join obj.pixels pix"


### PR DESCRIPTION
This was something I found useful at https://forum.image.sc/t/leica-spectral-scans/59762/4 and have wanted at other times too. NB: not intended for up-coming milestone.

To test:
 - Open a Dataset in the table view in webclient centre panel
 - Should see that sizeT column has been added and can sort etc. as for the other columns
 - Check the same works for Images in the Tag tree

![Screenshot 2021-11-10 at 09 52 30](https://user-images.githubusercontent.com/900055/141326087-8a152f02-d2d7-46be-a382-f9d854010a21.png)


