### PR TITLE
Acquisition metadata json

### DIFF
--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -147,8 +147,15 @@ api_image = url(
 Image url to GET or DELETE a single Image
 """
 
+api_image_objective_settings = url(
+    r"^v(?P<api_version>%s)/m/images/(?P<image_id>[0-9]+)/objective_settings/$"
+    % versions,
+    views.image_objective_settings,
+    name="api_image_objective_settings",
+)
+
 api_image_datasets = url(
-    r"^v(?P<api_version>%s)/m/images/" "(?P<image_id>[0-9]+)/datasets/$" % versions,
+    r"^v(?P<api_version>%s)/m/images/(?P<image_id>[0-9]+)/datasets/$" % versions,
     views.DatasetsView.as_view(),
     name="api_image_datasets",
 )
@@ -414,6 +421,7 @@ urlpatterns = [
     api_dataset_images,
     api_dataset_projects,
     api_image,
+    api_image_objective_settings,
     api_image_datasets,
     api_screen,
     api_screens,

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -873,6 +873,30 @@ class ExperimenterGroupsView(ObjectsView):
         return opts
 
 
+@json_response()
+@login_required(useragent="OMERO.webapi")
+def image_objective_settings(request, image_id, conn=None, **kwargs):
+
+    image = conn.getObject("Image", image_id)
+    if image is None:
+        raise NotFoundError("Image not found")
+
+    settings = image.getObjectiveSettings()
+    objective = settings.getObjective()
+    correction = objective.getCorrection()
+    immersion = objective.getImmersion()
+
+    settings_object = settings._obj
+    objective_object = objective._obj
+    # replace unloaded objects with loaded ones
+    objective_object.correction = correction._obj
+    objective_object.immersion = immersion._obj
+    settings_object.objective = objective_object
+
+    encoder = get_encoder(settings_object.__class__)
+    return encoder.encode(settings_object)
+
+
 class SaveView(View):
     """
     This view provides 'Save' functionality for all types of objects.

--- a/omeroweb/webclient/urls.py
+++ b/omeroweb/webclient/urls.py
@@ -112,6 +112,11 @@ urlpatterns = [
         name="load_metadata_acquisition",
     ),
     url(
+        r"^api/metadata_acquisition/(?P<image_id>[0-9]+)/$",
+        views.api_metadata_acquisition,
+        name="api_metadata_acquisition",
+    ),
+    url(
         r"^metadata_preview/(?P<c_type>((?i)image|well))/"
         r"(?P<c_id>[0-9]+)/(?:(?P<share_id>[0-9]+)/)?$",
         views.load_metadata_preview,

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1841,20 +1841,24 @@ def api_metadata_acquisition(request, image_id, conn=None, **kwargs):
 
     json_data = {"channels": []}
     for ch in channels:
-        channel_json = {"id": ch.id}
+        channel_json = {
+            "id": ch.id,
+            "excitationWave": ch.getExcitationWave(),
+            "emissionWave": ch.getEmissionWave(),
+        }
         logicalChannel = ch.getLogicalChannel()
         if logicalChannel is not None:
-            channel_json = {
-                "exWave": ch.getExcitationWave(),
-                "emWave": ch.getEmissionWave(),
+            channel_json["logicalChannel"] = {
+                "id": logicalChannel.id,
             }
             lightPath = logicalChannel.getLightPath()
             if lightPath is not None:
-                lightPathDichroic = lightPath.getDichroic()
-                if lightPathDichroic and lightPathDichroic._obj is not None:
-                    channel_json["dichroic"] = {
-                        "manufacturer": lightPathDichroic.manufacturer,
-                        "model": lightPathDichroic.model,
+                channel_json["logicalChannel"]["lightPath"] = {"id": lightPath.id}
+                dichroic = lightPath.getDichroic()
+                if dichroic and dichroic._obj is not None:
+                    channel_json["logicalChannel"]["lightPath"]["dichroic"] = {
+                        "manufacturer": dichroic.manufacturer,
+                        "model": dichroic.model,
                     }
         json_data["channels"].append(channel_json)
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1850,6 +1850,7 @@ def api_metadata_acquisition(request, image_id, conn=None, **kwargs):
         if logicalChannel is not None:
             channel_json["logicalChannel"] = {
                 "id": logicalChannel.id,
+                "name": logicalChannel.name,
             }
             lightPath = logicalChannel.getLightPath()
             if lightPath is not None:

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -275,6 +275,86 @@ def imageMarshal(image, key=None, request=None):
     return rv
 
 
+def acquisitionMetadataMarshal(image):
+    """
+    Marshal channels, objective settings and instrument for an Image
+    """
+    channels = image.getChannels(noRE=True)
+
+    json_data = {"channels": []}
+    for ch in channels:
+        channel_json = {
+            "id": ch.id,
+            "excitationWave": ch.getExcitationWave(),
+            "emissionWave": ch.getEmissionWave(),
+        }
+        logicalChannel = ch.getLogicalChannel()
+        if logicalChannel is not None:
+            channel_json["logicalChannel"] = {
+                "id": logicalChannel.id,
+                "name": logicalChannel.name,
+            }
+            lightPath = logicalChannel.getLightPath()
+            if lightPath is not None:
+                channel_json["logicalChannel"]["lightPath"] = {"id": lightPath.id}
+                dichroic = lightPath.getDichroic()
+                if dichroic and dichroic._obj is not None:
+                    channel_json["logicalChannel"]["lightPath"]["dichroic"] = {
+                        "manufacturer": dichroic.manufacturer,
+                        "model": dichroic.model,
+                    }
+        json_data["channels"].append(channel_json)
+
+    if image.getObjectiveSettings() is not None:
+        json_data["objectiveSettings"] = {}
+        settings = image.getObjectiveSettings()
+        for prop in ["id", "correctionCollar", "refractiveIndex"]:
+            prop_value = getattr(settings, prop)
+            if prop_value:
+                json_data["objectiveSettings"][prop] = prop_value
+            if settings.getMedium():
+                json_data["objectiveSettings"]["medium"] = settings.getMedium().value
+
+        objective = settings.getObjective()
+        obj_json = {}
+        for prop in [
+            "id",
+            "model",
+            "manufacturer",
+            "serialNumber",
+            "lotNumber",
+            "calibratedMagnification",
+            "nominalMagnification",
+            "lensNA",
+        ]:
+            prop_value = getattr(objective, prop)
+            if prop_value:
+                obj_json[prop] = prop_value
+        if objective.workingDistance:
+            obj_json["workingDistance"] = objective.workingDistance.getValue()
+        for prop in ["getImmersion", "getCorrection", "getIris"]:
+            prop_value = getattr(objective, prop)()
+            if prop_value is not None:
+                obj_json[prop[3:].lower()] = prop_value.getValue()
+        json_data["objectiveSettings"]["objective"] = obj_json
+
+    instrument = image.getInstrument()
+    if instrument is not None:
+        microscope = instrument.getMicroscope()
+        if microscope is not None:
+            json_data["microscope"] = {}
+            for prop in ["id", "model", "manufacturer", "serialNumber", "lotNumber"]:
+                prop_value = getattr(microscope, prop)
+                if prop_value:
+                    json_data["microscope"][prop] = prop_value
+            if microscope.getMicroscopeType() is not None:
+                json_data["microscope"][
+                    "microscopeType"
+                ] = microscope.getMicroscopeType().value
+
+    return json_data
+
+
 def shapeMarshal(shape):
     """
     return a dict with all there is to know about a shape

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -326,13 +326,14 @@ def acquisitionMetadataMarshal(image):
             "calibratedMagnification",
             "nominalMagnification",
             "lensNA",
+            "iris",
         ]:
             prop_value = getattr(objective, prop)
             if prop_value:
                 obj_json[prop] = prop_value
         if objective.workingDistance:
             obj_json["workingDistance"] = objective.workingDistance.getValue()
-        for prop in ["getImmersion", "getCorrection", "getIris"]:
+        for prop in ["getImmersion", "getCorrection"]:
             prop_value = getattr(objective, prop)()
             if prop_value is not None:
                 obj_json[prop[3:].lower()] = prop_value.getValue()


### PR DESCRIPTION
See https://github.com/IDR/idr.openmicroscopy.org/issues/149

This adds Acquisition metadata URL to webclient. Also adds ObjectiveSettings support to JSON api, which requires https://github.com/ome/omero-marshal/pull/72

To test, go to:
 - /webclient/api/metadata_acquisition/IMAGE_ID/ 
 - /api/v0/m/images/IMAGE_ID/objective_settings/
 

e.g. https://merge-ci.openmicroscopy.org/web/webclient/api/metadata_acquisition/140015/ (user-3)
and https://merge-ci.openmicroscopy.org/web/webclient/api/metadata_acquisition/200515/ 
and depending on the metadata available, you should get JSON like:

```
{
    "channels": [
        {
            "id": 2641,
            "excitationWave": null,
            "emissionWave": 528,
            "logicalChannel": {
                "id": 2636
            }
        }
    ],
    "objectiveSettings": {
        "id": 1072,
        "objective": {
            "id": 1068,
            "model": "1-UB932",
            "manufacturer": "Olympus",
            "nominalMagnification": 60,
            "lensNA": 1.4,
            "workingDistance": 0.1,
            "immersion": "Oil",
            "correction": "PlanApo"
        }
    }
}
```

cc @gwaygenomics 