### PR TITLE
Omero table json link

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -55,7 +55,7 @@
             </button>
         {% endif %}
         <br>
-        Show page as:
+        Show current page as:
         <a href="{% url 'omero_table' data.id 'csv' %}?limit={{ meta.limit }}&offset={{ meta.offset }}{% if meta.query != '*' %}&query={{ meta.query|urlencode }}{% endif %}">CSV</a> |
         <a href="{% url 'omero_table' data.id 'json' %}?limit={{ meta.limit }}&offset={{ meta.offset }}{% if meta.query != '*' %}&query={{ meta.query|urlencode }}{% endif %}">JSON</a>
     </div>
@@ -69,7 +69,7 @@
 
     {% if meta.query != '*' %}
         <div class="back">
-            <a href="{{ meta.url }}">< Remove query</a>
+            <a href="{{ meta.url }}">< Remove filter</a>
         </div>
     {% endif %}
     <h2>{{ data.name }}</h2>

--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -21,6 +21,8 @@
                 position: absolute;
                 top: 10px;
                 right: 20px;
+                text-align: right;
+                line-height: 150%;
             }
             .back {
                 position: absolute;
@@ -29,6 +31,15 @@
             }
             #cancel_btn {
                 border: solid black 1px;
+                border-radius: 10px;
+            }
+            #progress_display {
+                position: absolute;
+                top: 70px;
+                right: 20px;
+                background: #eee;
+                padding: 20px;
+                width: fit-content;
                 border-radius: 10px;
             }
         </style>
@@ -43,13 +54,19 @@
                 With Filter
             </button>
         {% endif %}
-        <button class="download_btn" id="download_current_view" title="Dowload just the current page{% if meta.query != '*' %}, filtered with: {{meta.query}}{% endif %}">
-            Current View</button>
-        <div id="progress_display" style="visibility:hidden">
-            Downloading: <span id="download_percent">0 MB</span> <progress id="download_progress" value="50" max="100">50%</progress>
-            <button title="Cancel Download" id="cancel_btn">X</button>
-        </div>
+        <br>
+        Show page as:
+        <a href="{% url 'omero_table' data.id 'csv' %}?limit={{ meta.limit }}&offset={{ meta.offset }}{% if meta.query != '*' %}&query={{ meta.query|urlencode }}{% endif %}">CSV</a> |
+        <a href="{% url 'omero_table' data.id 'json' %}?limit={{ meta.limit }}&offset={{ meta.offset }}{% if meta.query != '*' %}&query={{ meta.query|urlencode }}{% endif %}">JSON</a>
     </div>
+
+    <div id="progress_display" style="visibility:hidden">
+        Downloading: <span id="download_percent">0 MB</span>
+        <br />
+        <progress id="download_progress" value="50" max="100">50%</progress>
+        <button title="Cancel Download" id="cancel_btn">X</button>
+    </div>
+
     {% if meta.query != '*' %}
         <div class="back">
             <a href="{{ meta.url }}">< Remove query</a>
@@ -57,7 +74,7 @@
     {% endif %}
     <h2>{{ data.name }}</h2>
     {% if example_column %}
-        <p>
+        <p style="margin:0 250px">
             To filter rows you can use a query based on named columns.
             For example, to filter for rows where <b>{{ example_column }}</b>
             is greater than <b>{{ example_min_value }}</b> add 
@@ -248,10 +265,6 @@
     });
     document.getElementById("download_filtered_csv")?.addEventListener("click", function(){
         download_csv(true);
-    });
-    document.getElementById("download_current_view").addEventListener("click", function(){
-        // Don't need progressing download, just use URL directly
-        window.location.href="{% url 'omero_table' data.id 'csv' %}?limit={{ meta.limit }}&offset={{ meta.offset }}&query={{ meta.query|urlencode }}";
     });
 
     document.getElementById("cancel_btn").addEventListener("click", function() {

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3232,8 +3232,6 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
         rsp = TableClosingHttpResponse(csv_gen(), content_type="text/csv")
         rsp.conn = conn
         rsp.table = context.get("table")
-        rsp["Content-Type"] = "application/force-download"
-        # rsp['Content-Length'] = ann.getFileSize()
         rsp["Content-Disposition"] = "attachment; filename=%s" % downloadName
         return rsp
 


### PR DESCRIPTION
Fixes #340.

Adds a link to JSON view of the page (with same pagination and filtering). Also moves the similar link to CSV page from a Button to a link (bad practice to use a button for a link!).

When there is no pagination, the Download as CSV button and the CSV link do the same thing, but I think it's still useful to have the link available.

To test:
 - Click the JSON link - it should open the JSON version of the page in the browser.
 - The CSV link will download the CSV
 - Both links should include the current pagination and filtering queries
 
cc @erindiel 

![Screenshot 2021-12-15 at 12 07 55](https://user-images.githubusercontent.com/900055/146183943-d6cb1971-95f7-4de1-9efe-b96a707bd987.png)

