### PR TITLE
Fix link to referrer-policy

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1101,7 +1101,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
         (
             "Default content for the HTML Meta referrer tag. "
             "See https://www.w3.org/TR/referrer-policy/#referrer-policies for "
-            "allowed values and https://caniuse.com/#feat=referrer-policy for "
+            "allowed values and https://caniuse.com/referrer-policy for "
             "browser compatibility. "
             "Warning: Internet Explorer 11 does not support the default value "
             'of this setting, you may want to change this to "origin" after '


### PR DESCRIPTION
The inclusion of this new property in the generated configuration documentation (https://github.com/ome/omero-documentation/pull/2203/files#diff-f9698d6a6ee93a6e33a579f394fd06094e079981b7fb54f8b8a70a8f7469e2cbR2260) highlighted that the anchor does not longer exists but redirects to a new URL