### PR TITLE
Set keepalive response content type to text/plain

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -340,7 +340,7 @@ def keepalive_ping(request, conn=None, **kwargs):
 
     # login_required handles ping, timeout etc, so we don't need to do
     # anything else
-    return HttpResponse("OK")
+    return HttpResponse("OK", content_type="text/plain")
 
 
 @login_required()


### PR DESCRIPTION
We ran into a setup where an intermediary proxy server modified the response of the `keepalive_ping` API call by appending extra whitespace.  This did not affect OMERO.web itself, which does not check the response content, but broke another client that expects the exact two-character response `OK`.

While this is easy to work around, it might be useful to change the response content type to `text/plain` to match the actual response, and to discourage intermediaries from processing the response as HTML.