### PR TITLE
Make 'remove all filters' properly clear map filters.

### DIFF
--- a/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -448,6 +448,11 @@ $(document).ready(function() {
                 $("#dataIcons li.row").removeClass('ratingFilter_hidden');
                 // reset Tag filtering
                 filter_tag_ids = [];
+                // clear filter objects if any exist
+                if (filterObjects.length) {
+                    filterObjects = [];
+                    doFiltering();
+                }
                 renderFilterTags();
             }
 


### PR DESCRIPTION
Fixes #348

I believe that the problem with the 'remove all filters' option was that it didn't wipe the Key-Value filters list. Adding code to do this (if any filters are present) seems to fix the issue.