### PR TITLE
Multiple omero tables

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1243,9 +1243,14 @@
 	
 	
     /*   Acquisition Details */
+
+    h1.can-collapse {
+        border: 1px solid #bbb;
+        margin:5px 0;
+        padding: 7px;
+    }
     
     .can-collapse {
-        border: 1px solid #bbb;
         -webkit-box-shadow:0 1px 0 rgba(255,255,255,.7);
 		
 		-webkit-box-shadow: 0 1px 0 rgba(255,255,255,0.7); /* Saf3.0+, Chrome */
@@ -1271,8 +1276,6 @@
 		   -moz-border-radius:4px; /* FF1+ */
 		        border-radius:4px; /* Opera 10.5, IE 9 */ 
 				position:relative;
-        padding: 7px;
-        margin:5px 0;
     }
 	
 	

--- a/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_table.html
@@ -25,10 +25,8 @@
     </h1>
     <div class="annotations_section" style="display:none">
 
-        <h2 id="bulk-annotations" class="bulk_annotation" style="display: none;">Info</h2>
-        <div style="display: none;">
-            <table id="bulk_annotations_table" class="bulk_annotations_table"></table>
-        </div>
+        <div id="bulk_annotations_list"></div>
+
         <div style="clear:both; margin:8px"></div>
     </div>
     {% endif %}

--- a/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_table.html
@@ -21,7 +21,7 @@
     <!-- TABLES -->
     {% if manager.well or manager.image %}
     <h1 class="can-collapse closed" data-name="tables">
-        {{ label|default:"Tables" }}
+        {{ label|default:"Tables" }} <span class="annotationCount">{{ tableCountsOnParents }}</span>
     </h1>
     <div class="annotations_section" style="display:none">
 

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -362,7 +362,7 @@
                         let promises = urls.map(url => fetch(url).then(rsp => rsp.json()));
                         let results = await Promise.all(promises);
 
-                        var compareParentName = function (a, b) {
+                        var compareNameDate = function (a, b) {
                             if (a.name == b.name) {
                                 return a.addedOn > b.addedOn ? 1 : -1;
                             }
@@ -371,21 +371,24 @@
 
                         // Show list of tables, allow user to expand...
                         let html = results.flatMap(tables => {
-                            tables.data.sort(compareParentName);
+                            tables.data.sort(compareNameDate);
                             return tables.data.map(ann => `
                                 <ul class="lnfiles">
                                     <li class="can-collapse closed" data-tableid="${ann.file}">
-                                        <a class="tooltip" href="#">${ann.name.escapeHTML()}</a>
-                                        <span>(linked to <a href="${WEBCLIENT.URLS.webindex}?show=${ann.parentType.toLowerCase()}-${ann.parentId}">
-                                                ${ann.parentType}: ${ann.parentId}</a>)
-                                        </span>
-                                        <span class="tooltip_html" style="display: none">
-                                            <b>Annotation ID:</b> ${ann.id}<br>
-                                            <b>Owner:</b> ${ann.owner.escapeHTML()}<br>
-                                            <b>Linked by:</b> ${ann.addedBy.escapeHTML()}<br>
-                                            <b>On</b> ${OME.formatDate(ann.addedOn)}</br>
-                                            <b>Namespace:</b> ${(ann.ns || "").escapeHTML()}<br>
-                                            <b>File ID:</b> ${ann.file}
+                                        <a class="tooltip" href="#">${ann.name.escapeHTML()}
+                                            <span class="tooltip_html" style="display: none">
+                                                <b>Annotation ID:</b> ${ann.id}<br>
+                                                <b>Owner:</b> ${ann.owner.escapeHTML()}<br>
+                                                <b>Linked by:</b> ${ann.addedBy.escapeHTML()}<br>
+                                                <b>On</b> ${OME.formatDate(ann.addedOn)}</br>
+                                                <b>Namespace:</b> ${(ann.ns || "").escapeHTML()}<br>
+                                                <b>File ID:</b> ${ann.file}
+                                            </span>
+                                        </a>
+                                        <span>(linked to
+                                            <a title="Open ${ann.parentType} in new tab" target="_blank" href="${WEBCLIENT.URLS.webindex}?show=${ann.parentType.toLowerCase()}-${ann.parentId}">
+                                                ${ann.parentType}: ${ann.parentId}
+                                            </a>)
                                         </span>
                                     </li>
                                 </ul>
@@ -394,7 +397,7 @@
                         });
                         $("#bulk_annotations_list").html(html.join("\n"));
                         $("#bulk_annotations_list").tooltip({
-                                items: 'li',
+                                items: 'li a.tooltip',
                                 content: function() {
                                     return $("span.tooltip_html", this).html();
                                 },
@@ -404,7 +407,7 @@
                             });
                         // If only a single table was found - expand it automatically:
                         if (html.length == 1) {
-                            $("#bulk_annotations_list li a.tooltip").click();
+                            $("#bulk_annotations_list li").click();
                         }
                     }
 
@@ -435,9 +438,9 @@
                     }
 
                     // Handle clicking on a table: load data for this Image or Well
-                    $("#bulk_annotations_list").on("click", "a.tooltip", function () {
+                    $("#bulk_annotations_list").on("click", "li", function (event) {
                         // toggle collapse/expand and show/hide table
-                        let $li = $(this).parent();
+                        let $li = $(this);
                         $li.toggleClass('closed');
                         let tableId = $li.data("tableid");
                         let $table = $(`#bulk_annotations_table_${tableId}`);

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -373,7 +373,7 @@
                                         <span class="tooltip_html" style="display: none">
                                             <b>Annotation ID:</b> ${ann.id}<br>
                                             <b>Owner:</b> ${ann.owner.escapeHTML()}<br>
-                                            <b>Added by:</b> ${ann.owner.escapeHTML()}<br>
+                                            <b>Linked by:</b> ${ann.addedBy.escapeHTML()}<br>
                                             <b>On</b> ${OME.formatDate(ann.addedOn)}</br>
                                             <b>Namespace:</b> ${ann.ns.escapeHTML()}<br>
                                             <b>File ID:</b> ${ann.file}

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -387,8 +387,7 @@
                                         </a>
                                         <span>(linked to
                                             <a title="Open ${ann.parentType} in new tab" target="_blank" href="${WEBCLIENT.URLS.webindex}?show=${ann.parentType.toLowerCase()}-${ann.parentId}">
-                                                ${ann.parentType}: ${ann.parentId}
-                                            </a>)
+                                                ${ann.parentType}: ${ann.parentId}</a>)
                                         </span>
                                     </li>
                                 </ul>

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -343,30 +343,49 @@
                 // loading just the row we need for the current well.
                 {% if manager.well or manager.image %}
                     {% if manager.well %}
-                    var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells' manager.well.id %}";
-                    var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells' manager.well.id %}";
+                    var screenQuery = "{% url 'webgateway_annotations' 'Screen.plateLinks.child.wells' manager.well.id %}";
+                    var plateQuery = "{% url 'webgateway_annotations' 'Plate.wells' manager.well.id %}";
                     var query = "Well-{{ manager.well.id }}";
                     {% elif manager.image %}
-                    var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells.wellSamples.image' manager.image.id %}";
-                    var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
-                    var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child' manager.image.id %}";
-                    var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child' manager.image.id %}";
+                    var screenQuery = "{% url 'webgateway_annotations' 'Screen.plateLinks.child.wells.wellSamples.image' manager.image.id %}";
+                    var plateQuery = "{% url 'webgateway_annotations' 'Plate.wells.wellSamples.image' manager.image.id %}";
+                    var projectQuery = "{% url 'webgateway_annotations' 'Project.datasetLinks.child.imageLinks.child' manager.image.id %}";
+                    var datasetQuery = "{% url 'webgateway_annotations' 'Dataset.imageLinks.child' manager.image.id %}";
                     var query = "Image-{{ manager.image.id }}";
                     {% endif %}
 
-                    var showBulkAnnTooltip = function(data) {
-                        if (!data || !data.id) return;
-                        var bulkAnnTooltip = "<span class='tooltip_html' style='display:none'>" +
-                            "Data from tables file:<br />" +
-                            "<b>File ID:</b> " + data.id + "<br />" +
-                            "<b>Owner:</b> " + data.owner.escapeHTML() + " <br />" +
-                            "<b>Annotation ID:</b> " + data.annId + "<br />" +
-                            "<b>Linked to:</b> " + data.parentType + " " + data.parentId + "<br />" +
-                            "<b>Linked by:</b> " + data.addedBy.escapeHTML() + " <br />" +
-                            "<b>On:</b> " + OME.formatDate(data.addedOn) + "</span>";
-                        $("#bulk-annotations").append(bulkAnnTooltip);
-                        $("#bulk-annotations").parent().tooltip({
-                                items: '.bulk_annotation',
+                    async function loadTablesOnParents() {
+                        let urls = [screenQuery, plateQuery];
+                            {% if manager.image %}
+                                urls = urls.concat([projectQuery, datasetQuery]);
+                            {% endif %}
+                        let promises = urls.map(url => fetch(url).then(rsp => rsp.json()));
+                        let results = await Promise.all(promises);
+
+                        // Show list of tables, allow user to expand...
+                        let html = results.flatMap(tables => {
+                            return tables.data.map(ann => `
+                                <ul class="lnfiles">
+                                    <li class="can-collapse closed" data-tableid="${ann.file}">
+                                        <a class="tooltip" href="#"/>${ann.name.escapeHTML()}
+                                            <span>(linked to ${ann.parentType}: ${ann.parentId})</span>
+                                        </a>
+                                        <span class="tooltip_html" style="display: none">
+                                            <b>Annotation ID:</b> ${ann.id}<br>
+                                            <b>Owner:</b> ${ann.owner.escapeHTML()}<br>
+                                            <b>Added by:</b> ${ann.owner.escapeHTML()}<br>
+                                            <b>Namespace:</b> ${ann.ns.escapeHTML()}<br>
+                                            <b>On</b> ${OME.formatDate(ann.addedOn)}</br>
+                                            <b>File ID:</b> ${ann.file}
+                                        </span>
+                                    </li>
+                                </ul>
+                                <table id="bulk_annotations_table_${ann.file}" style="display: none; margin: 10px"></table>
+                                `);
+                        }).join("\n");
+                        $("#bulk_annotations_list").html(html);
+                        $("#bulk_annotations_list").tooltip({
+                                items: 'li',
                                 content: function() {
                                     return $("span.tooltip_html", this).html();
                                 },
@@ -387,13 +406,8 @@
                         var expanded = !$header.hasClass('closed');
                         OME.setPaneExpanded('tables', expanded);
 
-                        if (expanded && $("#bulk_annotations_table").is(":empty")) {
-                            loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
-                            loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
-                            {% if manager.image %}
-                                loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
-                                loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
-                            {% endif %}
+                        if (expanded && $("#bulk_annotations_list").is(":empty")) {
+                            loadTablesOnParents();
                         }
                     });
 
@@ -402,23 +416,37 @@
                         $('.can-collapse.closed[data-name="tables"]')
                             .toggleClass('closed')
                             .next().slideToggle();
-                        if ($("#bulk_annotations_table").is(":empty")) {
-                            loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
-                            loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
-                            {% if manager.image %}
-                                loadBulkAnnotations(projectQuery, query, function(data) {
-                                    if (data && data.id) {
-                                        showBulkAnnTooltip(data);
-                                    }
-                                });
-                                loadBulkAnnotations(datasetQuery, query, function(data) {
-                                    if (data && data.id) {
-                                        showBulkAnnTooltip(data);
-                                    }
-                                });
-                            {% endif %}
+                        if ($("#bulk_annotations_list").is(":empty")) {
+                            loadTablesOnParents();
                         }
                     }
+
+                    // Handle clicking on a table: load data for this Image or Well
+                    $("#bulk_annotations_list").on("click", "li", function () {
+                        // toggle collapse/expand and show/hide table
+                        $(this).toggleClass('closed');
+                        let tableId = $(this).data("tableid");
+                        let $table = $(`#bulk_annotations_table_${tableId}`);
+                        $table.toggle();
+
+                        // Don't need to load if table populated already
+                        if (!$table.is(":empty")) return;
+                        let url = `{% url 'webgateway' %}table/${tableId}/query/?query=${query}`;
+                        $.getJSON(url, function(result) {
+                            if (result.data && result.data.rows) {
+                                var html = result.data.columns.map(function (col, colIdx) {
+                                    var label = col.escapeHTML();
+                                    var values = result.data.rows.map(function (row) {
+                                        return ("" + row[colIdx]).escapeHTML();
+                                    });
+                                    values = values.join('<br />');
+                                    var oddEvenClass = col % 2 == 1 ? 'odd' : 'even';
+                                    return '<tr><td class="title ' + oddEvenClass + '">' + label + ':&nbsp;</td><td>' + values + '</td></tr>';
+                                }).join("");
+                                $table.html(html);
+                            }
+                        });
+                    });
 
                 {% endif %}
 

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -367,15 +367,16 @@
                             return tables.data.map(ann => `
                                 <ul class="lnfiles">
                                     <li class="can-collapse closed" data-tableid="${ann.file}">
-                                        <a class="tooltip" href="#"/>${ann.name.escapeHTML()}
-                                            <span>(linked to ${ann.parentType}: ${ann.parentId})</span>
-                                        </a>
+                                        <a class="tooltip" href="#">${ann.name.escapeHTML()}</a>
+                                        <span>(linked to <a href="${WEBCLIENT.URLS.webindex}?show=${ann.parentType.toLowerCase()}-${ann.parentId}">
+                                                ${ann.parentType}: ${ann.parentId}</a>)
+                                        </span>
                                         <span class="tooltip_html" style="display: none">
                                             <b>Annotation ID:</b> ${ann.id}<br>
                                             <b>Owner:</b> ${ann.owner.escapeHTML()}<br>
                                             <b>Linked by:</b> ${ann.addedBy.escapeHTML()}<br>
                                             <b>On</b> ${OME.formatDate(ann.addedOn)}</br>
-                                            <b>Namespace:</b> ${ann.ns.escapeHTML()}<br>
+                                            <b>Namespace:</b> ${(ann.ns || "").escapeHTML()}<br>
                                             <b>File ID:</b> ${ann.file}
                                         </span>
                                     </li>
@@ -395,7 +396,7 @@
                             });
                         // If only a single table was found - expand it automatically:
                         if (html.length == 1) {
-                            $("#bulk_annotations_list li").click();
+                            $("#bulk_annotations_list li a.tooltip").click();
                         }
                     }
 
@@ -426,10 +427,11 @@
                     }
 
                     // Handle clicking on a table: load data for this Image or Well
-                    $("#bulk_annotations_list").on("click", "li", function () {
+                    $("#bulk_annotations_list").on("click", "a.tooltip", function () {
                         // toggle collapse/expand and show/hide table
-                        $(this).toggleClass('closed');
-                        let tableId = $(this).data("tableid");
+                        let $li = $(this).parent();
+                        $li.toggleClass('closed');
+                        let tableId = $li.data("tableid");
                         let $table = $(`#bulk_annotations_table_${tableId}`);
                         $table.toggle();
 

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -362,8 +362,16 @@
                         let promises = urls.map(url => fetch(url).then(rsp => rsp.json()));
                         let results = await Promise.all(promises);
 
+                        var compareParentName = function (a, b) {
+                            if (a.name == b.name) {
+                                return a.addedOn > b.addedOn ? 1 : -1;
+                            }
+                            return a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1;
+                        };
+
                         // Show list of tables, allow user to expand...
                         let html = results.flatMap(tables => {
+                            tables.data.sort(compareParentName);
                             return tables.data.map(ann => `
                                 <ul class="lnfiles">
                                     <li class="can-collapse closed" data-tableid="${ann.file}">

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -374,16 +374,16 @@
                                             <b>Annotation ID:</b> ${ann.id}<br>
                                             <b>Owner:</b> ${ann.owner.escapeHTML()}<br>
                                             <b>Added by:</b> ${ann.owner.escapeHTML()}<br>
-                                            <b>Namespace:</b> ${ann.ns.escapeHTML()}<br>
                                             <b>On</b> ${OME.formatDate(ann.addedOn)}</br>
+                                            <b>Namespace:</b> ${ann.ns.escapeHTML()}<br>
                                             <b>File ID:</b> ${ann.file}
                                         </span>
                                     </li>
                                 </ul>
                                 <table id="bulk_annotations_table_${ann.file}" style="display: none; margin: 10px"></table>
                                 `);
-                        }).join("\n");
-                        $("#bulk_annotations_list").html(html);
+                        });
+                        $("#bulk_annotations_list").html(html.join("\n"));
                         $("#bulk_annotations_list").tooltip({
                                 items: 'li',
                                 content: function() {
@@ -393,6 +393,10 @@
                                 show: false,
                                 hide: false
                             });
+                        // If only a single table was found - expand it automatically:
+                        if (html.length == 1) {
+                            $("#bulk_annotations_list li").click();
+                        }
                     }
 
                     // If user opens tables tab, also load tables

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1738,6 +1738,7 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None, **kwa
             template = "webclient/annotations/metadata_general.html"
             context["canExportAsJpg"] = manager.canExportAsJpg(request)
             context["annotationCounts"] = manager.getAnnotationCounts()
+            context["tableCountsOnParents"] = manager.countTablesOnParents()
             figScripts = manager.listFigureScripts()
     context["manager"] = manager
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2894,7 +2894,9 @@ def _bulk_file_annotations(request, objtype, objid, conn=None, **kwargs):
         data.append(
             dict(
                 id=annotation.id.val,
+                name=unwrap(annotation.file.name),
                 file=annotation.file.id.val,
+                ns=unwrap(annotation.ns),
                 parentType=objtype[0],
                 parentId=link.parent.id.val,
                 owner=ownerName,


### PR DESCRIPTION
Fixes #351

This adds support for multiple OMERO.tables on the containers of an Image or Well. See issue above.

To test:

 - For the cases where we only have a single table on a image container (Screen, Plate, Project or Dataset) this table will be loaded immediately: e.g. https://merge-ci.openmicroscopy.org/web/webclient/?show=well-10584 (user-3)

![Screenshot 2022-02-07 at 17 14 17](https://user-images.githubusercontent.com/900055/152838554-7cc308f7-c412-4668-9b58-f7c8d1b85011.png)

 - When we have multiple tables, they are listed and can each be loaded by clicking on them. e.g. https://merge-ci.openmicroscopy.org/web/webclient/?show=image-18221 (user-3):

![Screenshot 2022-02-07 at 17 18 23](https://user-images.githubusercontent.com/900055/152838657-4d3fc49d-ebc3-49bc-b04c-1927474a3837.png).

In both cases, the tooltip on the table gives extra info as before.

cc @sbesson @francesw 
