### PR TITLE
Add link to datasets for dataset column values

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -130,6 +130,8 @@
                 <td><a target="_blank" href="{% url 'webindex' %}?show=image-{{ col }}">{{ col }}</a></td>
                 {% elif well_column_index == forloop.counter0 %}
                 <td><a target="_blank" href="{% url 'webindex' %}?show=well-{{ col }}">{{ col }}</a></td>
+                {% elif dataset_column_index == forloop.counter0 %}
+                <td><a target="_blank" href="{% url 'webindex' %}?show=dataset-{{ col }}">{{ col }}</a></td>
                 {% elif roi_column_index == forloop.counter0 and iviewer_url != None %}
                 <td><a target="_blank" href="{{ iviewer_url }}?roi={{ col }}">{{ col }}</a></td>
                 {% elif shape_column_index == forloop.counter0 and iviewer_url != None %}

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3274,6 +3274,8 @@ def omero_table(request, file_id, mtype=None, conn=None, **kwargs):
             context["well_column_index"] = col_types.index("WellColumn")
         if "RoiColumn" in col_types:
             context["roi_column_index"] = col_types.index("RoiColumn")
+        if "DatasetColumn" in col_types: 
+            context["dataset_column_index"] = col_types.index("DatasetColumn")
         # we don't use ShapeColumn type - just check name and LongColumn type...
         # TODO: when ShapeColumn is supported, add handling to this code
         cnames = [n.lower() for n in context["data"]["columns"]]


### PR DESCRIPTION
Referencing #354.

As `omero metadata populate --detect_header` in https://github.com/ome/omero-metadata/pull/67 supports DatasetColumn, this PR makes the dataset column reference back to its corresponding dataset in the table via a table link.

This uses the name "dataset" for the `DatasetColumn`, using the same convention we have adopted of "Image" for the ImageColumn and "Roi" for the `RoiColumn`.

Example of dataset table link:

<img width="784" alt="Screenshot 2022-02-08 at 4 21 01 pm" src="https://user-images.githubusercontent.com/86613209/153029819-32785e57-3127-4b96-8345-c101123648f9.png">

With the table link being in this example: http://localhost:8080/webclient/?show=dataset-101


To test (How I tested this, possible there are easier/better ways) :

Run `omero metadata populate --detect_header` from https://github.com/ome/omero-metadata/pull/67 on a project level with a csv file with dataset column and image column. 