### PR TITLE
Update to Django 3.2.x

### DIFF
--- a/omero/plugins/web.py
+++ b/omero/plugins/web.py
@@ -82,7 +82,7 @@ def config_required(func):
                 import django  # NOQA
             except Exception:
                 self.ctx.die(681, "ERROR: Django not installed!")
-            if django.VERSION < (1, 11) or django.VERSION >= (2, 0):
+            if django.VERSION < (3, 2) or django.VERSION >= (3, 3):
                 self.ctx.err(
                     "ERROR: Django version %s is not "
                     "supported!" % django.get_version()

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -22,7 +22,7 @@
 from django.views.generic import View
 from django.middleware import csrf
 from django.utils.decorators import method_decorator
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from . import api_settings
 
 import traceback

--- a/omeroweb/connector.py
+++ b/omeroweb/connector.py
@@ -109,6 +109,10 @@ class Server(ServerBase):
         return r
 
     @classmethod
+    def all(cls):
+        return cls._registry.values()
+
+    @classmethod
     def find(cls, host=None, port=None, server=None):
         rv = []
         for s in cls._registry.values():

--- a/omeroweb/connector.py
+++ b/omeroweb/connector.py
@@ -109,10 +109,6 @@ class Server(ServerBase):
         return r
 
     @classmethod
-    def all(cls):
-        return cls._registry.values()
-
-    @classmethod
     def find(cls, host=None, port=None, server=None):
         rv = []
         for s in cls._registry.values():

--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -33,7 +33,7 @@ from django.http import HttpResponseForbidden, StreamingHttpResponse
 from django.conf import settings
 from django.utils.http import urlencode
 from functools import update_wrapper
-from django.core.urlresolvers import reverse, resolve, NoReverseMatch
+from django.urls import reverse, resolve, NoReverseMatch
 from django.core.cache import cache
 
 from omeroweb.utils import reverse_with_params

--- a/omeroweb/feedback/views.py
+++ b/omeroweb/feedback/views.py
@@ -37,7 +37,7 @@ from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.http import HttpResponseServerError, HttpResponseNotFound
 from django.views.defaults import page_not_found
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import render
 
 from django.views.debug import get_exception_reporter_filter

--- a/omeroweb/filesessionstore.py
+++ b/omeroweb/filesessionstore.py
@@ -92,7 +92,7 @@ class SessionStore(SessionBase):
     def load(self):
         session_data = {}
         try:
-            with open(self._key_to_file(), "rb") as session_file:
+            with open(self._key_to_file(), "r") as session_file:
                 file_data = session_file.read()
             # Don't fail if there is no data in the session file.
             # We may have opened the empty placeholder file.

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1366,8 +1366,9 @@ if not DEBUG:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 
 
 def report_settings(module):
-    from django.views.debug import cleanse_setting
+    from django.views.debug import SafeExceptionReporterFilter
 
+    setting_filter = SafeExceptionReporterFilter()
     custom_settings_mappings = getattr(module, "CUSTOM_SETTINGS_MAPPINGS", {})
     for key in sorted(custom_settings_mappings):
         values = custom_settings_mappings[key]
@@ -1378,7 +1379,7 @@ def report_settings(module):
             logger.debug(
                 "%s = %r (source:%s)",
                 global_name,
-                cleanse_setting(global_name, global_value),
+                setting_filter.cleanse_setting(global_name, global_value),
                 source,
             )
 
@@ -1391,7 +1392,7 @@ def report_settings(module):
             logger.debug(
                 "%s = %r (deprecated:%s, %s)",
                 global_name,
-                cleanse_setting(global_name, global_value),
+                setting_filter.cleanse_setting(global_name, global_value),
                 key,
                 description,
             )

--- a/omeroweb/testlib/__init__.py
+++ b/omeroweb/testlib/__init__.py
@@ -28,7 +28,7 @@ import warnings
 
 from django.test import Client
 from django.test.client import MULTIPART_CONTENT
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from omero.testlib import ITest
 

--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -31,7 +31,7 @@ from django.conf.urls import url, include
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.shortcuts import redirect
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.functional import lazy
 from django.views.generic import RedirectView
 from django.views.decorators.cache import never_cache

--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -101,7 +101,7 @@ for app in settings.ADDITIONAL_APPS:
             if label == settings.OMEROWEB_ROOT_APPLICATION:
                 regex = r"^"
             else:
-                regex = "^(?i)%s/" % label
+                regex = "^%s/" % label
             urlpatterns.append(url(regex, include(urlmodule)))
         except ImportError:
             print(
@@ -120,12 +120,12 @@ urlpatterns += [
         r"^favicon\.ico$",
         lambda request: redirect("%s%s" % (settings.STATIC_URL, settings.FAVICON_URL)),
     ),
-    url(r"^(?i)webgateway/", include("omeroweb.webgateway.urls")),
-    url(r"^(?i)webadmin/", include("omeroweb.webadmin.urls")),
-    url(r"^(?i)webclient/", include("omeroweb.webclient.urls")),
-    url(r"^(?i)url/", include("omeroweb.webredirect.urls")),
-    url(r"^(?i)feedback/", include("omeroweb.feedback.urls")),
-    url(r"^(?i)api/", include("omeroweb.api.urls")),
+    url(r"^webgateway/", include("omeroweb.webgateway.urls")),
+    url(r"^webadmin/", include("omeroweb.webadmin.urls")),
+    url(r"^webclient/", include("omeroweb.webclient.urls")),
+    url(r"^url/", include("omeroweb.webredirect.urls")),
+    url(r"^feedback/", include("omeroweb.feedback.urls")),
+    url(r"^api/", include("omeroweb.api.urls")),
     url(r"^index/$", webclient_views.custom_index, name="webindex_custom"),
 ]
 

--- a/omeroweb/utils.py
+++ b/omeroweb/utils.py
@@ -22,8 +22,8 @@
 import logging
 
 from django.utils.http import urlencode
-from django.core.urlresolvers import reverse
-from django.core.urlresolvers import NoReverseMatch
+from django.urls import reverse
+from django.urls import NoReverseMatch
 from past.builtins import basestring
 
 
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 def reverse_with_params(*args, **kwargs):
     """
-    Adds query string to django.core.urlresolvers.reverse
+    Adds query string to django.urls.reverse
     """
 
     url = ""

--- a/omeroweb/webadmin/custom_forms.py
+++ b/omeroweb/webadmin/custom_forms.py
@@ -76,7 +76,8 @@ class ServerQuerySetIterator(object):
 
 
 class ServerModelChoiceField(ModelChoiceField):
-    def _get_choices(self):
+    @property
+    def choices(self):
         # If self._choices is set, then somebody must have manually set
         # the property self.choices. In this case, just return self._choices.
         if hasattr(self, "_choices"):
@@ -89,13 +90,11 @@ class ServerModelChoiceField(ModelChoiceField):
         # been consumed.
         return ServerQuerySetIterator(self.queryset, self.empty_label)
 
-    def _set_choices(self, value):
-        # This method is copied from ChoiceField._set_choices(). It's necessary
-        # because property() doesn't allow a subclass to overwrite only
-        # _get_choices without implementing _set_choices.
-        self._choices = self.widget.choices = list(value)
+    def _set_queryset(self, queryset):
+        self._queryset = queryset
+        self.widget.choices = self.choices
 
-    choices = property(_get_choices, _set_choices)
+    queryset = property(ModelChoiceField._get_queryset, _set_queryset)
 
     def to_python(self, value):
         if value in EMPTY_VALUES:
@@ -135,7 +134,8 @@ class GroupQuerySetIterator(object):
 
 
 class GroupModelChoiceField(ModelChoiceField):
-    def _get_choices(self):
+    @property
+    def choices(self):
         # If self._choices is set, then somebody must have manually set
         # the property self.choices. In this case, just return self._choices.
         if hasattr(self, "_choices"):
@@ -148,13 +148,11 @@ class GroupModelChoiceField(ModelChoiceField):
         # been consumed.
         return GroupQuerySetIterator(self.queryset, self.empty_label)
 
-    def _set_choices(self, value):
-        # This method is copied from ChoiceField._set_choices(). It's necessary
-        # because property() doesn't allow a subclass to overwrite only
-        # _get_choices without implementing _set_choices.
-        self._choices = self.widget.choices = list(value)
+    def _set_queryset(self, queryset):
+        self._queryset = queryset
+        self.widget.choices = self.choices
 
-    choices = property(_get_choices, _set_choices)
+    queryset = property(ModelChoiceField._get_queryset, _set_queryset)
 
     def to_python(self, value):
         if value in EMPTY_VALUES:
@@ -320,7 +318,8 @@ class ExperimenterQuerySetIterator(object):
 
 
 class ExperimenterModelChoiceField(ModelChoiceField):
-    def _get_choices(self):
+    @property
+    def choices(self):
         # If self._choices is set, then somebody must have manually set
         # the property self.choices. In this case, just return self._choices.
         if hasattr(self, "_choices"):
@@ -333,13 +332,11 @@ class ExperimenterModelChoiceField(ModelChoiceField):
         # been consumed.
         return ExperimenterQuerySetIterator(self.queryset, self.empty_label)
 
-    def _set_choices(self, value):
-        # This method is copied from ChoiceField._set_choices(). It's necessary
-        # because property() doesn't allow a subclass to overwrite only
-        # _get_choices without implementing _set_choices.
-        self._choices = self.widget.choices = list(value)
+    def _set_queryset(self, queryset):
+        self._queryset = queryset
+        self.widget.choices = self.choices
 
-    choices = property(_get_choices, _set_choices)
+    queryset = property(ModelChoiceField._get_queryset, _set_queryset)
 
     def to_python(self, value):
         """

--- a/omeroweb/webadmin/custom_forms.py
+++ b/omeroweb/webadmin/custom_forms.py
@@ -27,12 +27,12 @@
 import re
 
 from django import forms
-from django.forms.fields import ChoiceField, EMPTY_VALUES
+from django.forms.fields import ChoiceField
 from django.forms.widgets import SelectMultiple, MultipleHiddenInput
 from django.forms import ModelChoiceField, ValidationError
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import smart_text
-from django.core.validators import validate_email
+from django.core.validators import validate_email, EMPTY_VALUES
 
 from past.builtins import long
 

--- a/omeroweb/webadmin/forms.py
+++ b/omeroweb/webadmin/forms.py
@@ -50,7 +50,7 @@ class LoginForm(NonASCIIForm):
         super(LoginForm, self).__init__(*args, **kwargs)
         self.fields["server"] = ServerModelChoiceField(Server, empty_label=None)
 
-        self.fields.keyOrder = ["server", "username", "password"]
+        self.field_order = ["server", "username", "password"]
 
     username = forms.CharField(
         max_length=50,
@@ -389,7 +389,7 @@ class GroupForm(NonASCIIForm):
                 "title"
             ] = "Changing of system group name would be un-doable"
 
-        self.fields.keyOrder = [
+        self.field_order = [
             "name",
             "description",
             "owners",
@@ -439,7 +439,7 @@ class GroupOwnerForm(forms.Form):
                 queryset=kwargs["initial"]["experimenters"], required=False
             )
 
-        self.fields.keyOrder = ["owners", "members", "permissions"]
+        self.field_order = ["owners", "members", "permissions"]
 
     permissions = forms.ChoiceField(
         choices=PERMISSION_CHOICES,
@@ -465,7 +465,7 @@ class MyAccountForm(NonASCIIForm):
             self.fields["default_group"] = GroupModelChoiceField(
                 queryset=kwargs["initial"]["groups"], empty_label=None
             )
-        self.fields.keyOrder = [
+        self.field_order = [
             "omename",
             "first_name",
             "middle_name",
@@ -528,7 +528,7 @@ class ContainedExperimentersForm(NonASCIIForm):
                 queryset=kwargs["initial"]["experimenters"], required=False
             )
 
-        self.fields.keyOrder = ["members"]
+        self.field_order = ["members"]
 
 
 class UploadPhotoForm(forms.Form):
@@ -616,7 +616,7 @@ class EnumerationEntries(NonASCIIForm):
                     label=i + 1,
                 )
 
-        self.fields.keyOrder = [str(k) for k in self.fields.keys()]
+        self.field_order = [str(k) for k in self.fields.keys()]
 
 
 class EmailForm(forms.Form):

--- a/omeroweb/webadmin/urls.py
+++ b/omeroweb/webadmin/urls.py
@@ -47,12 +47,12 @@ urlpatterns = [
     ),
     url(r"^groups/$", views.groups, name="wagroups"),
     url(
-        r"^group/(?P<action>((?i)new|create|edit|save))/" "(?:(?P<gid>[0-9]+)/)?$",
+        r"^group/(?P<action>(new|create|edit|save))/" "(?:(?P<gid>[0-9]+)/)?$",
         views.manage_group,
         name="wamanagegroupid",
     ),
     url(
-        r"^group_owner/(?P<action>((?i)edit|save))/(?P<gid>[0-9]+)/$",
+        r"^group_owner/(?P<action>(edit|save))/(?P<gid>[0-9]+)/$",
         views.manage_group_owner,
         name="wamanagegroupownerid",
     ),

--- a/omeroweb/webadmin/views.py
+++ b/omeroweb/webadmin/views.py
@@ -38,7 +38,7 @@ import omeroweb.webclient.views
 from omeroweb.version import omeroweb_buildyear as build_year
 from omeroweb.version import omeroweb_version as omero_version
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.decorators.debug import sensitive_post_parameters
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _

--- a/omeroweb/webclient/custom_forms.py
+++ b/omeroweb/webclient/custom_forms.py
@@ -24,10 +24,11 @@ import re
 from django import forms
 from django.forms.widgets import SelectMultiple, MultipleHiddenInput
 
-from django.forms.fields import Field, EMPTY_VALUES
+from django.forms.fields import Field
 from django.forms import ModelChoiceField, ValidationError
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import smart_text
+from django.core.validators import EMPTY_VALUES
 
 from omero_model_FileAnnotationI import FileAnnotationI
 from omero_model_TagAnnotationI import TagAnnotationI

--- a/omeroweb/webclient/custom_forms.py
+++ b/omeroweb/webclient/custom_forms.py
@@ -93,7 +93,8 @@ class MetadataQuerySetIterator(object):
 
 
 class MetadataModelChoiceField(ModelChoiceField):
-    def _get_choices(self):
+    @property
+    def choices(self):
         # If self._choices is set, then somebody must have manually set
         # the property self.choices. In this case, just return self._choices.
         if hasattr(self, "_choices"):
@@ -106,13 +107,11 @@ class MetadataModelChoiceField(ModelChoiceField):
         # been consumed.
         return MetadataQuerySetIterator(self.queryset, self.empty_label)
 
-    def _set_choices(self, value):
-        # This method is copied from ChoiceField._set_choices(). It's necessary
-        # because property() doesn't allow a subclass to overwrite only
-        # _get_choices without implementing _set_choices.
-        self._choices = self.widget.choices = list(value)
+    def _set_queryset(self, queryset):
+        self._queryset = queryset
+        self.widget.choices = self.choices
 
-    choices = property(_get_choices, _set_choices)
+    queryset = property(ModelChoiceField._get_queryset, _set_queryset)
 
     def clean(self, value):
         Field.clean(self, value)
@@ -173,7 +172,8 @@ class AnnotationQuerySetIterator(object):
 
 
 class AnnotationModelChoiceField(ModelChoiceField):
-    def _get_choices(self):
+    @property
+    def choices(self):
         # If self._choices is set, then somebody must have manually set
         # the property self.choices. In this case, just return self._choices.
         if hasattr(self, "_choices"):
@@ -186,13 +186,11 @@ class AnnotationModelChoiceField(ModelChoiceField):
         # been consumed.
         return AnnotationQuerySetIterator(self.queryset, self.empty_label)
 
-    def _set_choices(self, value):
-        # This method is copied from ChoiceField._set_choices(). It's
-        # necessary because property() doesn't allow a subclass to overwrite
-        # only _get_choices without implementing _set_choices.
-        self._choices = self.widget.choices = list(value)
+    def _set_queryset(self, queryset):
+        self._queryset = queryset
+        self.widget.choices = self.choices
 
-    choices = property(_get_choices, _set_choices)
+    queryset = property(ModelChoiceField._get_queryset, _set_queryset)
 
     def clean(self, value):
         Field.clean(self, value)
@@ -283,7 +281,8 @@ class ObjectQuerySetIterator(object):
 
 
 class ObjectModelChoiceField(ModelChoiceField):
-    def _get_choices(self):
+    @property
+    def choices(self):
         # If self._choices is set, then somebody must have manually set
         # the property self.choices. In this case, just return self._choices.
         if hasattr(self, "_choices"):
@@ -296,13 +295,11 @@ class ObjectModelChoiceField(ModelChoiceField):
         # been consumed.
         return ObjectQuerySetIterator(self.queryset, self.empty_label)
 
-    def _set_choices(self, value):
-        # This method is copied from ChoiceField._set_choices(). It's
-        # necessary because property() doesn't allow a subclass to overwrite
-        # only _get_choices without implementing _set_choices.
-        self._choices = self.widget.choices = list(value)
+    def _set_queryset(self, queryset):
+        self._queryset = queryset
+        self.widget.choices = self.choices
 
-    choices = property(_get_choices, _set_choices)
+    queryset = property(ModelChoiceField._get_queryset, _set_queryset)
 
     def clean(self, value):
         Field.clean(self, value)

--- a/omeroweb/webclient/decorators.py
+++ b/omeroweb/webclient/decorators.py
@@ -30,8 +30,8 @@ from omero import constants
 
 from django.http import HttpResponse
 from django.conf import settings
-from django.core.urlresolvers import reverse
-from django.core.urlresolvers import NoReverseMatch
+from django.urls import reverse
+from django.urls import NoReverseMatch
 
 from omeroweb.webclient.forms import GlobalSearchForm
 from omeroweb.utils import reverse_with_params

--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -30,7 +30,7 @@ import logging
 from django.conf import settings
 from django import forms
 from django.forms.formsets import formset_factory
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from omeroweb.custom_forms import NonASCIIForm
 from .custom_forms import MetadataModelChoiceField

--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -88,7 +88,7 @@ class ShareForm(NonASCIIForm):
                 queryset=kwargs["initial"]["experimenters"],
                 widget=forms.SelectMultiple(attrs={"size": 28}),
             )
-        self.fields.keyOrder = [
+        self.field_order = [
             "message",
             "expiration",
             "enable",
@@ -382,7 +382,7 @@ class ActiveGroupForm(forms.Form):
                     }
                 ),
             )
-        self.fields.keyOrder = ["active_group"]
+        self.field_order = ["active_group"]
 
 
 class WellIndexForm(forms.Form):
@@ -398,7 +398,7 @@ class WellIndexForm(forms.Form):
                 }
             ),
         )
-        self.fields.keyOrder = ["index"]
+        self.field_order = ["index"]
 
 
 ###############################
@@ -805,7 +805,7 @@ class MetadataChannelForm(forms.Form):
             )
             set_widget_attrs(self.fields["pockelCellSetting"])
 
-        self.fields.keyOrder = [
+        self.field_order = [
             "name",
             "excitationWave",
             "emissionWave",
@@ -987,7 +987,7 @@ class MetadataDichroicForm(forms.Form):
             )
             set_widget_attrs(self.fields["lotNumber"])
 
-        self.fields.keyOrder = ["model", "manufacturer", "serialNumber", "lotNumber"]
+        self.field_order = ["model", "manufacturer", "serialNumber", "lotNumber"]
 
 
 class MetadataMicroscopeForm(forms.Form):
@@ -1195,7 +1195,7 @@ class MetadataMicroscopeForm(forms.Form):
             )
             set_widget_attrs(self.fields["type"])
 
-        self.fields.keyOrder = [
+        self.field_order = [
             "model",
             "manufacturer",
             "serialNumber",
@@ -1671,7 +1671,7 @@ class MetadataObjectiveForm(forms.Form):
             )
             set_widget_attrs(self.fields["iris"])
 
-        self.fields.keyOrder = [
+        self.field_order = [
             "model",
             "manufacturer",
             "serialNumber",
@@ -1830,7 +1830,7 @@ class MetadataObjectiveSettingsForm(MetadataObjectiveForm):
             )
             set_widget_attrs(self.fields["refractiveIndex"])
 
-        self.fields.keyOrder = [
+        self.field_order = [
             "model",
             "manufacturer",
             "serialNumber",
@@ -2312,7 +2312,7 @@ class MetadataFilterForm(forms.Form):
             )
             set_widget_attrs(self.fields["transmittance"])
 
-        self.fields.keyOrder = [
+        self.field_order = [
             "model",
             "manufacturer",
             "serialNumber",
@@ -2797,7 +2797,7 @@ class MetadataDetectorForm(forms.Form):
             )
             set_widget_attrs(self.fields["binning"])
 
-        self.fields.keyOrder = [
+        self.field_order = [
             "model",
             "manufacturer",
             "serialNumber",
@@ -3400,7 +3400,7 @@ class MetadataLightSourceForm(forms.Form):
             )
         set_widget_attrs(self.fields["attenuation"])
 
-        self.fields.keyOrder = [
+        self.field_order = [
             "model",
             "manufacturer",
             "serialNumber",
@@ -3589,7 +3589,7 @@ class MetadataEnvironmentForm(forms.Form):
             )
             set_widget_attrs(self.fields["co2percent"])
 
-        self.fields.keyOrder = ["airPressure", "co2percent", "humidity", "temperature"]
+        self.field_order = ["airPressure", "co2percent", "humidity", "temperature"]
 
 
 class MetadataStageLabelForm(forms.Form):
@@ -3724,4 +3724,4 @@ class MetadataStageLabelForm(forms.Form):
             )
             set_widget_attrs(self.fields["positionz"])
 
-        self.fields.keyOrder = ["positionx", "positiony", "positionz"]
+        self.field_order = ["positionx", "positiony", "positionz"]

--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -28,7 +28,7 @@ import omero
 import re
 
 from omero.rtypes import rint, rlong
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from copy import deepcopy
 from django.conf import settings
 

--- a/omeroweb/webclient/urls.py
+++ b/omeroweb/webclient/urls.py
@@ -29,7 +29,7 @@ from django.conf.urls import url
 from omeroweb.webclient import views
 from omeroweb.webgateway import views as webgateway
 from omeroweb.webclient.webclient_gateway import defaultThumbnail
-from django.core.urlresolvers import get_callable
+from django.urls import get_callable
 
 viewer_view = get_callable(settings.VIEWER_VIEW)
 

--- a/omeroweb/webclient/urls.py
+++ b/omeroweb/webclient/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
     url(r"^$", views.load_template, {"menu": "userdata"}, name="webindex"),
     # render main template
     url(
-        r"^(?P<menu>((?i)userdata|public|history|search|help|usertags))/$",
+        r"^(?P<menu>(userdata|public|history|search|help|usertags))/$",
         views.load_template,
         name="load_template",
     ),
@@ -65,7 +65,7 @@ urlpatterns = [
     # loading data
     url(
         r"^load_plate/(?:(?P<o1_type>"
-        r"((?i)plate|acquisition))/)"
+        r"(plate|acquisition))/)"
         r"?(?:(?P<o1_id>[0-9]+)/)?$",
         views.load_plate,
         name="load_plate",
@@ -77,7 +77,7 @@ urlpatterns = [
     ),  # Query E.g. ?Image=1,2&Dataset=3
     url(
         r"^load_chgrp_target/(?P<group_id>[0-9]+)/"
-        r"(?P<target_type>((?i)project|dataset|screen))/$",
+        r"(?P<target_type>(project|dataset|screen))/$",
         views.load_chgrp_target,
         name="load_chgrp_target",
     ),
@@ -94,7 +94,7 @@ urlpatterns = [
     ),
     # load search
     url(
-        r"^load_searching/(?:(?P<form>((?i)form))/)?$",
+        r"^load_searching/(?:(?P<form>(form))/)?$",
         views.load_searching,
         name="load_searching",
     ),
@@ -112,7 +112,7 @@ urlpatterns = [
         name="load_metadata_acquisition",
     ),
     url(
-        r"^metadata_preview/(?P<c_type>((?i)image|well))/"
+        r"^metadata_preview/(?P<c_type>(image|well))/"
         r"(?P<c_id>[0-9]+)/(?:(?P<share_id>[0-9]+)/)?$",
         views.load_metadata_preview,
         name="load_metadata_preview",
@@ -229,7 +229,7 @@ urlpatterns = [
     # Fileset query (for delete or chgrp dialogs) obj-types and ids in REQUEST
     # data
     url(
-        r"^fileset_check/(?P<action>((?i)delete|chgrp))/$",
+        r"^fileset_check/(?P<action>(delete|chgrp))/$",
         views.fileset_check,
         name="fileset_check",
     ),
@@ -294,7 +294,7 @@ urlpatterns = [
         name="download_orig_metadata",
     ),
     url(
-        r"^omero_table/(?P<file_id>[0-9]+)/(?:(?P<mtype>((?i)json|csv))/)?$",
+        r"^omero_table/(?P<file_id>[0-9]+)/(?:(?P<mtype>(json|csv))/)?$",
         views.omero_table,
         name="omero_table",
     ),
@@ -322,7 +322,7 @@ urlpatterns = [
         name="download_original_file",
     ),  # for stderr, stdout etc
     url(
-        r"^figure_script/(?P<scriptName>" r"((?i)SplitView|Thumbnail|MakeMovie))/$",
+        r"^figure_script/(?P<scriptName>" r"(SplitView|Thumbnail|MakeMovie))/$",
         views.figure_script,
         name="figure_script",
     ),  # shows a form for running a script

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -62,7 +62,7 @@ from django.http import (
 )
 from django.http import HttpResponseServerError, HttpResponseBadRequest
 from django.utils.http import urlencode
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 from django.utils.encoding import smart_str
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -40,7 +40,7 @@ from django.http import (
 from django.views.decorators.http import require_POST
 from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.decorators import method_decorator
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 from django.conf import settings
 from wsgiref.util import FileWrapper
 from omero.rtypes import rlong, unwrap

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -49,7 +49,7 @@ from .util import points_string_to_XY_list, xy_list_to_bbox
 from .plategrid import PlateGrid
 from omeroweb.version import omeroweb_buildyear as build_year
 from .marshal import imageMarshal, shapeMarshal, rgb_int2rgba
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.views.generic import View
 from django.shortcuts import render
 from omeroweb.webadmin.forms import LoginForm

--- a/omeroweb/webredirect/views.py
+++ b/omeroweb/webredirect/views.py
@@ -29,7 +29,7 @@ or a redirect, or the 404 and 500 error, or an XML document, or an image...
 or anything."""
 
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from omeroweb.feedback.views import handlerInternalError
 import logging
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         # requires Ice (use wheel for faster installs)
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
-        "Django>=2.0,<3.0",
+        "Django>=3.0,<3.1",
         "django-pipeline==1.6.14",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
         "Django>=3.1,<3.2",
-        "django-pipeline==1.7.0",
+        "django-pipeline==2.0.5",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",
         "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         # requires Ice (use wheel for faster installs)
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
-        "Django>=1.11,<2.0",
+        "Django>=2.0,<2.2",
         "django-pipeline==1.6.14",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         # requires Ice (use wheel for faster installs)
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
-        "Django>=2.0,<2.2",
+        "Django>=2.0,<3.0",
         "django-pipeline==1.6.14",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         # requires Ice (use wheel for faster installs)
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
-        "Django>=3.1,<3.2",
+        "Django>=3.2,<4.0",
         "django-pipeline==2.0.5",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
         "Django>=3.2,<4.0",
-        "django-pipeline==2.0.5",
+        "django-pipeline==2.0.7",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",
         "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
         "Django>=3.0,<3.1",
-        "django-pipeline==1.6.14",
+        "django-pipeline==1.7.0",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",
         "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         # requires Ice (use wheel for faster installs)
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
-        "Django>=3.0,<3.1",
+        "Django>=3.1,<3.2",
         "django-pipeline==1.7.0",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -25,7 +25,7 @@ Simple unit tests for the "webclient_utils" module.
 import pytest
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from omeroweb.utils import reverse_with_params, sort_properties_to_tuple
 from omeroweb.webclient.webclient_utils import formatPercentFraction


### PR DESCRIPTION
## Introduction

This PR is a follow on from the Django 2.2.x upgrade WIP #200. The great initial work on that PR is unfortunately insufficient to bring us up to scratch with Django LTS versions; Django 2.2.x leaves LTS in just a few months in April 2022 [^1]. Django 3.2.x will remain in LTS until April 2024 [^2]:.

Furthermore, the strategy followed in this PR is slightly different: make the minimum number of changes required to maintain OMERO.web functionality and leave potential Django infrastructure modernisation to other follow up PRs.

Release notes for the major versions between our current 1.11.x and the 3.2.x target:

* https://docs.djangoproject.com/en/4.0/releases/2.0/
* https://docs.djangoproject.com/en/4.0/releases/2.1/
* https://docs.djangoproject.com/en/4.0/releases/2.2/
* https://docs.djangoproject.com/en/4.0/releases/3.0/
* https://docs.djangoproject.com/en/4.0/releases/3.1/
* https://docs.djangoproject.com/en/4.0/releases/3.2/

The `django-pipeline` dependency has been updated to nearly the latest version in order to support Django 3.2.x. All other dependencies have been left alone.

__NOTE:__ The supported Python versions for Django 3.2.x are currently 3.6, 3.7, 3.8, 3.9, and 3.10. This PR does not currently contain the requisite changes for Python 3.10 support.

## Proposed path to release

1. Decide on the new target version; I've selected 6.0.0 for the purposes of discussion
2. Release new versions of several OMERO.web plugins/applications with version pinning of `omero-web` to `<6.0.0`
3. Publicly announce that `omero-web` 6.0.0 __will__ include an upgrade to Django 3.2.x and publish the ideal timeline
4. Make whatever changes to this PR are required in order to have a test candidate; testing will need to be __extensive__ and __thorough__ as there's no telling what subtle bugs may be introduced
5. Deploy the test candidate and iterate until we are comfortable enough to publish a release candidate for community consumption
6. Continue to iterate, publishing new release candidates if required, until we are comfortable enough to make a release; this may include being comfortable with a subset of Django 3.2.x compliant OMERO.web plugins/applications
7. Make new releases of compliant OMERO.web plugins with version pinning of `omero-web` to `>=6.0.0`

## Per-version specific concerns

### Django 2.0.x / 2.1.x

* `django.core.urlresolvers` removal (deprecated since 1.10) [^3]:
* Removal of case insensitive URL matching and simplified URL routing syntax (deprecated since 1.1.1) [^4][^5][^6]
* Small adjustments to the Server model to operate like a QuerySet due to changes in the form an choice APIs

### Django 3.0.x

* Use the new static templatetags package (deprecated since 2.1) [^7]:
* Updates to the new field ordering style for models [^8]:

### Django 3.1.x

* Update to the new internal settings cleansing API
* Use the new package for empty value definitions

### Django 3.2.x

[^1]: https://docs.djangoproject.com/en/4.0/releases/3.2/#django-3-2-release-notes
[^2]: https://www.djangoproject.com/download/#supported-versions
[^3]: https://docs.djangoproject.com/en/4.0/releases/1.10/#id3
[^4]: https://docs.djangoproject.com/en/4.0/releases/1.11/#id2
[^5]: https://docs.djangoproject.com/en/4.0/releases/2.0/#simplified-url-routing-syntax
[^6]: https://code.djangoproject.com/ticket/31099
[^7]: https://docs.djangoproject.com/en/4.0/releases/2.1/#id2
[^8]: https://docs.djangoproject.com/en/3.0/ref/forms/api/#notes-on-field-ordering
