### PR TITLE
Download as mimetype fix

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -168,7 +168,10 @@ Download files
 
             $("#downloadForm").hide();
             $(".downloading").show();
-            window.location.href = "{{ url|safe }}&zipname=" + zipName;
+            let url = "{{ url }}?zipname=" + zipName;
+            url += "{% for id in ids %}&{{id}}{% endfor %}";
+            {% if format %}url += '&format={{ format }}';{% endif %}
+            window.location.href = url;
         }
 
         return false;

--- a/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
+++ b/omeroweb/webclient/templates/webclient/annotations/download_placeholder.html
@@ -168,7 +168,7 @@ Download files
 
             $("#downloadForm").hide();
             $(".downloading").show();
-            window.location.href = "{{ url }}&zipname=" + zipName;
+            window.location.href = "{{ url|safe }}&zipname=" + zipName;
         }
 
         return false;

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3419,14 +3419,13 @@ def download_placeholder(request, conn=None, **kwargs):
         # E.g. JPEG/PNG - 1 file per image
         fileCount = len(ids)
 
-    query = "&".join([_id.replace("-", "=") for _id in ids])
-    download_url = download_url + "?" + query
-    if format is not None:
-        download_url = download_url + "&format=%s" % format
+    ids = [_id.replace("-", "=") for _id in ids]
 
     context = {
         "template": "webclient/annotations/download_placeholder.html",
         "url": download_url,
+        "format": format,
+        "ids": ids,
         "defaultName": defaultName,
         "fileLists": fileLists,
         "fileCount": fileCount,

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2494,14 +2494,8 @@ def download_as(request, iid=None, conn=None, **kwargs):
         return HttpResponseServerError(msg)
 
     if len(images) == 1:
-        jpeg_data = images[0].renderJpeg()
-        if jpeg_data is None:
-            raise Http404
-        rsp = HttpResponse(jpeg_data, mimetype="image/jpeg")
-        rsp["Content-Length"] = len(jpeg_data)
-        rsp["Content-Disposition"] = "attachment; filename=%s.jpg" % (
-            images[0].getName().replace(" ", "_")
-        )
+        # not expected, as download_placeholder is for multiple images
+        return render_image(request, images[0].id, conn=conn, download=True)
     else:
         temp = tempfile.NamedTemporaryFile(suffix=".download_as")
 


### PR DESCRIPTION
Fixed a couple of issues discovered due to bug report at https://www.openmicroscopy.org/qa2/qa/feedback/30974/

To test zip creation:
 - Select multiple (e.g. 3, non-Big) images and choose "Export as PNG" from the Download menu
 - Click "Create ZIP" -> Should get a zip downloaded with pngs.
