### PR TITLE
Type error fix(?) for WSGI threads

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1236,7 +1236,7 @@ def check_worker_class(c):
 
 
 def check_threading(t):
-    t=int(t)
+    t = int(t)
     if t > 1:
         try:
             import concurrent.futures  # NOQA

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1236,6 +1236,7 @@ def check_worker_class(c):
 
 
 def check_threading(t):
+    t=int(t)
     if t > 1:
         try:
             import concurrent.futures  # NOQA
@@ -1243,7 +1244,7 @@ def check_threading(t):
             raise ImportError(
                 "You are using sync workers with " "multiple threads. Install futures"
             )
-    return int(t)
+    return t
 
 
 # DEVELOPMENT_SETTINGS_MAPPINGS - WARNING: For each setting developer MUST open


### PR DESCRIPTION
When trying to set omero.web.wsgi_threads in docker it seems to pass a string instead of an integer, causing a type error (new to python3 I think?) I haven't pulled this or tested it but I don't see why this wouldn't fix it :p