### PR TITLE
activities panel word break

### DIFF
--- a/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -765,6 +765,9 @@ li.menu_back a {
 				color: #333;
 				color: rgba(0,0,0,.7);
 				text-shadow:0 1px 0 white;
+				/* https://github.com/ome/omero-web/issues/377 */
+				word-wrap: break-word;
+				max-width: 330px;
 			}
 		
 			.notifier {


### PR DESCRIPTION
Fixes #377.

To test:
- Need to run a script that has a very long message, with no spaces or even `-`.
- E.g. rename an Image with a very long name (alpha-numeric and `_` only). Then choose this image for Batch_Image_Export script
- The Activities dialog shouldn't appear broken (see screenshots on #377).


![Screenshot 2022-06-16 at 10 35 50](https://user-images.githubusercontent.com/900055/174041835-678b4f38-4b3d-40f8-9680-3adf013bc81e.png)

