### PR TITLE
Show fileset ID

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -355,7 +355,7 @@
     {% if not share %}
     {% if image.showOriginalFilePaths %}
       <!-- show original file paths -->
-      <button id="show_fs_files_btn" class="btn silver btn_fspath" title="Show file paths on server">
+      <button id="show_fs_files_btn" class="btn silver btn_fspath" title="Show Fileset ID and file paths on server">
         <span></span>
       </button>
     {% endif %}

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -149,7 +149,8 @@
                                 var repo = data.repo,
                                     client = data.client,
                                     html = "";
-                                $panel_title.html(repo.length + " Image file" + (repo.length>1 ? "s:" : ":"));
+                                let title = `Fileset ID: <strong>${data.fileset.id}</strong> contains ${repo.length} Image file${ repo.length>1 ? "s" : ""}:`
+                                $panel_title.html(title);
 
                                 if (importTransfer) {
                                     html += "<p>Imported with <strong>--transfer="+ importTransfer;

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -149,12 +149,14 @@
                                 var repo = data.repo,
                                     client = data.client,
                                     html = "";
-                                let title = `Fileset ID: <strong>${data.fileset.id}</strong> contains ${repo.length} Image file${ repo.length>1 ? "s" : ""}:`
-                                $panel_title.html(title);
+                                $panel_title.html("Fileset Info");
+
+                                html += `<p>Fileset ID: <strong>${data.fileset.id}</strong></p>`
+
+                                html += `<p>File count: <strong>${repo.length}</strong></p>`
 
                                 if (importTransfer) {
-                                    html += "<p>Imported with <strong>--transfer="+ importTransfer;
-                                    html += "</strong></p><hr/>";
+                                    html += "<p>Imported with: <strong>--transfer="+ importTransfer + "</strong></p>";
                                 }
 
                                 html += "<p>Imported from:</p>";

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2686,7 +2686,12 @@ def original_file_paths(request, iid, conn=None, **kwargs):
     if image is None:
         raise Http404
     paths = image.getImportedImageFilePaths()
-    return {"repo": paths["server_paths"], "client": paths["client_paths"]}
+    fileset_id = image.fileset.id.val
+    return {
+        "repo": paths["server_paths"],
+        "client": paths["client_paths"],
+        "fileset": {"id": fileset_id}
+    }
 
 
 @login_required()

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2690,7 +2690,7 @@ def original_file_paths(request, iid, conn=None, **kwargs):
     return {
         "repo": paths["server_paths"],
         "client": paths["client_paths"],
-        "fileset": {"id": fileset_id}
+        "fileset": {"id": fileset_id},
     }
 
 


### PR DESCRIPTION
See https://github.com/ome/omero-cli-zarr/pull/123#pullrequestreview-1032712957

It is useful for webclient users to see the Fileset ID for a selected Image.
We already load fileset info (file paths) in a file-paths info panel, so this seems a logical place to load and display fileset ID:

The tooltip for the button that launches this panel also mentions Fileset ID.

<img width="361" alt="Screenshot 2022-07-22 at 12 04 40" src="https://user-images.githubusercontent.com/900055/180426616-35a5882a-d83a-45c3-b1d3-32292b239585.png">

