### PR TITLE
Use server=1 in login_required if only 1 server

### DIFF
--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -37,7 +37,7 @@ from django.urls import reverse, resolve, NoReverseMatch
 from django.core.cache import cache
 
 from omeroweb.utils import reverse_with_params
-from omeroweb.connector import Connector
+from omeroweb.connector import Connector, Server
 from omero.gateway.utils import propertiesToDict
 from omero import ApiUsageException
 
@@ -416,8 +416,14 @@ class login_required(object):
                 try:
                     server_id = request["server"]
                 except Exception:
-                    logger.debug("No Server ID available.")
-                    return None
+                    # If only 1 server, use server=1
+                    server_keys = list(Server._registry.keys())
+                    if len(server_keys) == 1:
+                        server_id = server_keys[0]
+                        logger.debug("No Server ID available: using %s" % server_id)
+                    else:
+                        logger.debug("No Server ID available.")
+                        return None
 
         # If we have an OMERO session key in our request variables attempt
         # to make a connection based on those credentials.


### PR DESCRIPTION
See https://github.com/ome/omero-web/issues/379#issuecomment-1175236423

To test:

- Setup: you need an omero-web where only 1 server is configured. TODO: update merge-ci config temporarily to only show 1 server
- look up an Image ID on the server (e.g. via Insight or webclient in another brower)
- Get a session ID, e.g via cli to the server above:

```
$ omero login
$ omero sessions list
```

- Make sure you are not logged in to webclient
- Go to: https://merge-ci.openmicroscopy.org/web/webclient/img_detail/IMAGE_ID/?bsession=SESSION_ID

You should be able to see the image.