### PR TITLE
Fix zoom buttons overlaying popups

### DIFF
--- a/omeroweb/webgateway/static/webgateway/css/ome.viewport.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.viewport.css
@@ -140,7 +140,7 @@ div.weblitz-viewport-tiles img {
 
 .wb_zoomIn, .wb_zoom11, .wb_zoomOut {
   position: absolute;
-  z-index: 10;
+  z-index: 1;
   left: 10px;
   width: 20px;
 }


### PR DESCRIPTION
This fixes a bug observed by @pwalczysko and others where the Preview image viewer zoom buttons appear on top of other popup menus (scripts menu or Activities panel):

![Screenshot 2022-08-02 at 13 37 45](https://user-images.githubusercontent.com/900055/182376740-df7289e1-f66e-42ef-abb8-17dd14e193c3.png)

This should be fixed in this PR.