### PR TITLE
omero table sticky header

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/omero_table.html
+++ b/omeroweb/webclient/templates/webclient/annotations/omero_table.html
@@ -13,6 +13,14 @@
                 border-collapse: collapse;
                 border-spacing: 0;
             }
+            th {
+                /* border-bottom is lost in scrolling: use gradient instead */
+                background: linear-gradient(to top,#ddd, #ddd 1px, #ffffff 1px, #ffffff 100%);;
+                position: sticky;
+                top: 0;
+                border-bottom: solid #ddd 1px;
+                padding: 5px;
+            }
             td {
                 border: solid #ddd 1px;
                 padding: 5px;


### PR DESCRIPTION
Simple fix to a problem I recently had checking OMERO.table data in IDR: When you scroll the table, the header gets lost so you don't know which columns are which.
This makes the header "sticky" so that it isn't scrolled off the top of the page.

To test:
 - Open a large table in web, e.g (random data): https://merge-ci.openmicroscopy.org/web/webclient/omero_table/1508508/ (linked to Plate https://merge-ci.openmicroscopy.org/web/webclient/?show=plate-13855) - user-3.
 - Scroll the page, header should remain visible at the top of the page:

![Screenshot 2022-08-24 at 12 55 31](https://user-images.githubusercontent.com/900055/186412332-b3bea98e-a5ab-462d-a718-d0d86f56ebf8.png)

cc @muhanadz 