### PR TITLE
Update channels in batches for Dataset, show progress

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -96,6 +96,8 @@
                             <button name="confirm_apply" type="submit" value="apply" title="Save and apply to all Images">Continue</button>
                         </span>
                         <button type="reset" name="cancel" title="Cancel">Cancel</button>
+                        <div id="channel_edit_progress_label" style="display:none">Renaming images...</div>
+                        <progress id="channel_edit_progress" max="100" value="20" style="width:100%; display:none">20%</progress>
                     </form>
                     {% if image.canEdit %}
                         <button id="editChannelNames" class="btn silver btn_edit" 

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -296,6 +296,8 @@
                     $chNameForm.find(".confirmButtons").hide();
                     $("#channel_names_display").show();
                     $("#editChannelNames").show();
+                    $("#channel_edit_progress").hide();
+                    $("#channel_edit_progress_label").hide();
                     $chNameForm.hide();
                 }
                 // Workflow starts by displaying the form
@@ -318,23 +320,56 @@
                         resetChForm();
                     }
                 });
+
+                function batchChannelEdit(formData, url) {
+                    // recursive function to update images in batches via pagination
+                    formData.limit = 5;
+                    $.ajax({
+                        type: "POST", url: url, data: formData, dataType: 'json',
+                        success: function(rsp){
+                            console.log(rsp);
+                            formData.offset += formData.limit
+                            percent = (formData.offset / rsp.totalImages) * 100;
+                            $("#channel_edit_progress").attr("value", percent)
+                            if (rsp.totalImages && rsp.totalImages > formData.offset) {
+                                // if more to process, go again...
+                                batchChannelEdit(formData, url);
+                            } else {
+                                // udpate channel names when done
+                                $("#channel_names_display span").each(function(i){
+                                    if (formData.hasOwnProperty("channel"+i)) {
+                                        $(this).text(formData["channel"+i]);
+                                    }
+                                });
+                                resetChForm();
+                            }
+                        }
+                    });
+                }
+
                 // Form handled by AJAX
                 $chNameForm.ajaxForm({
                     dataType:  'json',
+                    beforeSubmit: function(data, $form) {
+                        // Show 'in-progress' state...
+                        $chNameForm.find(".originalButtons").hide();
+                        $chNameForm.find(".confirmButtons").hide();
+                        $("#channel_edit_progress_label").show();
+                        $("#channel_edit_progress").show().attr("value", 2)
+
+                        let submitData = {};
+                        data.forEach(keyval => {
+                            submitData[keyval.name] = keyval.value;
+                        })
+                        submitData.offset = 0;
+                        // use this for single Image OR for Dataset/Plate
+                        batchChannelEdit(submitData, $form.attr("action"));
+
+                        // false: cancel submit - since we handle this manually above
+                        return false;
+                    },
                     success: function(data) {
-                        var cnames = data.channelNames;
-                        // update the channel names, and ititial values in form
-                        $("#channel_names_display span").each(function(i){
-                            if (cnames.hasOwnProperty("channel"+i)) {
-                                $(this).text(cnames["channel"+i]);
-                            }
-                        });
-                        $chNameForm.find("input").each(function(i){
-                            if (cnames.hasOwnProperty( $(this).attr('name') )) {
-                                $(this).attr('value', cnames["channel"+i]);
-                            }
-                        });
-                        resetChForm();
+                        // Not used - handled above.
                     }
                 });
 

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -306,6 +306,7 @@
                     $("#editChannelNames").hide();
                     $chNameForm.show();
                 });
+                let cancelChannelRename = false;
                 // Handling of all form buttons. NB: save & apply_confirm buttons submit
                 $chNameForm.find("button").on('click', function(event){
                     var name = $(this).attr('name');
@@ -317,6 +318,7 @@
                         return false;
                     } else if (name === "cancel") {
                         // cancel - hide and don't submit
+                        cancelChannelRename = true;
                         resetChForm();
                     }
                 });
@@ -329,9 +331,16 @@
                         success: function(rsp){
                             console.log(rsp);
                             formData.offset += formData.limit
+                            let msg = `Editing channels... (${formData.offset}/${rsp.totalImages}`;
+                            if (formData?.parentId.includes('dataset')) {
+                                msg += " images)";
+                            } else if (formData?.parentId.includes('plate')) {
+                                msg += " wells)";
+                            }
+                            $("#channel_edit_progress_label").html(msg);
                             percent = (formData.offset / rsp.totalImages) * 100;
                             $("#channel_edit_progress").attr("value", percent)
-                            if (rsp.totalImages && rsp.totalImages > formData.offset) {
+                            if (!cancelChannelRename && rsp.totalImages && rsp.totalImages > formData.offset) {
                                 // if more to process, go again...
                                 batchChannelEdit(formData, url);
                             } else {
@@ -354,7 +363,7 @@
                         // Show 'in-progress' state...
                         $chNameForm.find(".originalButtons").hide();
                         $chNameForm.find(".confirmButtons").hide();
-                        $("#channel_edit_progress_label").show();
+                        $("#channel_edit_progress_label").html("Editing channels...").show();
                         $("#channel_edit_progress").show().attr("value", 2)
 
                         let submitData = {};
@@ -363,6 +372,7 @@
                         })
                         submitData.offset = 0;
                         // use this for single Image OR for Dataset/Plate
+                        cancelChannelRename = false;
                         batchChannelEdit(submitData, $form.attr("action"));
 
                         // false: cancel submit - since we handle this manually above

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2811,15 +2811,24 @@ def edit_channel_names(request, imageId, conn=None, **kwargs):
             offset = request.POST.get("offset", None)
             limit = request.POST.get("limit", None)
             if offset is not None and limit is not None:
-                opts = {"dataset": pid, "order_by": "obj.name", "limit": limit, "offset": offset}
+                opts = {
+                    "dataset": pid,
+                    "order_by": "obj.name",
+                    "limit": limit,
+                    "offset": offset,
+                }
                 img_ids = [img.id for img in conn.getObjects("Image", opts=opts)]
                 print("img_ids", img_ids)
-                counts = conn.setChannelNames("Image", img_ids, nameDict, channelCount=sizeC)
+                counts = conn.setChannelNames(
+                    "Image", img_ids, nameDict, channelCount=sizeC
+                )
 
                 totalImages = get_child_counts(conn, "DatasetImageLink", [pid])[pid]
                 rv["totalImages"] = totalImages
             else:
-                counts = conn.setChannelNames(ptype, [pid], nameDict, channelCount=sizeC)
+                counts = conn.setChannelNames(
+                    ptype, [pid], nameDict, channelCount=sizeC
+                )
     else:
         counts = conn.setChannelNames("Image", [image.getId()], nameDict)
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2817,22 +2817,33 @@ def edit_channel_names(request, imageId, conn=None, **kwargs):
                 img_ids = []
                 if ptype == "dataset":
                     # For Dataset, paginate by images (ordered by name)
-                    opts = {"dataset": pid, "order_by": "obj.name", "limit": limit, "offset": offset}
+                    opts = {
+                        "dataset": pid,
+                        "order_by": "obj.name",
+                        "limit": limit,
+                        "offset": offset,
+                    }
                     img_ids = [img.id for img in conn.getObjects("Image", opts=opts)]
-                    rv["totalImages"] = get_child_counts(conn, "DatasetImageLink", [pid])[pid]
+                    rv["totalImages"] = get_child_counts(
+                        conn, "DatasetImageLink", [pid]
+                    )[pid]
                 elif ptype == "plate":
                     # For Plates, paginate by Wells. Load all then slice for page
                     opts = {"plate": pid, "order_by": "obj.id"}
                     wells = list(conn.getObjects("Well", opts=opts))
                     rv["totalImages"] = len(wells)
                     img_ids = []
-                    for well in wells[offset: offset + limit]:
+                    for well in wells[offset : offset + limit]:
                         for ws in well.listChildren():
                             img_ids.append(ws.getImage().id)
                 if len(img_ids) > 0:
-                    counts = conn.setChannelNames("Image", img_ids, nameDict, channelCount=sizeC)
+                    counts = conn.setChannelNames(
+                        "Image", img_ids, nameDict, channelCount=sizeC
+                    )
             else:
-                counts = conn.setChannelNames(ptype.title(), [pid], nameDict, channelCount=sizeC)
+                counts = conn.setChannelNames(
+                    ptype.title(), [pid], nameDict, channelCount=sizeC
+                )
     else:
         counts = conn.setChannelNames("Image", [image.getId()], nameDict)
 


### PR DESCRIPTION
Fixes long-standing issues with updating channel names: https://github.com/ome/omero-web/issues/304

 - Hide the 'submit' button so users can't make synchronous calls (causes exceptions above)
 - Update Images in batches, instead of whole Plate/Dataset in one call (which often times-out for web)
 - Show a progress bar
 - Support Cancel during update

<img width="367" alt="Screenshot 2022-09-01 at 23 07 12" src="https://user-images.githubusercontent.com/900055/188021380-d107152d-08fc-41ed-bb5d-98031f785abc.png">

To test:
 - Compare renaming of channels with / without this PR
 - Rename single Images, Dataset, Plate
 - Test that Cancel button interrupts renaming
