### PR TITLE
Disable submit and show spinner while editing channels

### DIFF
--- a/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/omeroweb/webclient/static/webclient/css/dusty.css
@@ -225,8 +225,14 @@ button::-moz-focus-inner {
         display: none;
     }
 	#channel_names_edit.in_progress button[type='submit'] {
+		/* Show a spinner while saving channels */
 		background: url('../../webgateway/img/spinner.gif') center center no-repeat;
 		color: transparent;
+	}
+
+	#channel_names_edit.in_progress button[type='reset'] {
+		/* Don't show Cancel button during Save as it does nothing */
+		visibility: hidden;
 	}
 
     .channel_rename_spinner {

--- a/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/omeroweb/webclient/static/webclient/css/dusty.css
@@ -217,7 +217,25 @@ button::-moz-focus-inner {
         left: 2%;
     }
 
-	
+	/* Channel edit form */
+    #channel_names_edit button {
+        height: 20px;
+    }
+    .confirmButtons {
+        display: none;
+    }
+	#channel_names_edit.in_progress button[type='submit'] {
+		background: url('../../webgateway/img/spinner.gif') center center no-repeat;
+		color: transparent;
+	}
+
+    .channel_rename_spinner {
+        height: 12px;
+        vertical-align: middle;
+        /* hide initially */
+        display: none;
+    }
+        
 
 /*
 	------------------------------------------------

--- a/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -86,16 +86,22 @@
                         <!-- hidden input for 'apply to dataset' options -->
                         <input type="text" name="parentId" size=5 style="display:none" />
                         <!-- buttons -->
-                        <span class="originalButtons">
-                            <button name="save" type="submit" value="save" title="Save channel names">Save</button>
-                            <button name="apply" title="Save and apply to all images">Apply to All</button>
-                        </span>
-                        <span class="confirmButtons" style="display:none">
-                            <div>Update channel names for all images 
+                        <div class="buttons">
+                            <button class="originalButtons" name="save" type="submit" value="save" title="Save channel names">
+                                Save
+                            </button>
+                            <button class="originalButtons" name="apply" title="Save and apply to all images">
+                                Apply to All
+                            </button>
+                            <div class="confirmButtons">Update channel names for all images 
                                 in the <span class="ptype"></span>? <br />This cannot be undone.</div>
-                            <button name="confirm_apply" type="submit" value="apply" title="Save and apply to all Images">Continue</button>
-                        </span>
-                        <button type="reset" name="cancel" title="Cancel">Cancel</button>
+                            <button class="confirmButtons" name="confirm_apply" type="submit" value="apply" title="Save and apply to all Images">
+                                Continue
+                            </button>
+                            <button type="reset" name="cancel" title="Cancel">
+                                Cancel
+                            </button>
+                        </div>
                     </form>
                     {% if image.canEdit %}
                         <button id="editChannelNames" class="btn silver btn_edit" 

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -296,6 +296,8 @@
                     $chNameForm.find(".confirmButtons").hide();
                     $("#channel_names_display").show();
                     $("#editChannelNames").show();
+                    $("button[type='submit']", $chNameForm).removeAttr('disabled');
+                    $chNameForm.removeClass("in_progress");  // hide spinner
                     $chNameForm.hide();
                 }
                 // Workflow starts by displaying the form
@@ -321,6 +323,10 @@
                 // Form handled by AJAX
                 $chNameForm.ajaxForm({
                     dataType:  'json',
+                    beforeSubmit: function() {
+                        $("button[type='submit']", $chNameForm).attr('disabled', true);
+                        $chNameForm.addClass("in_progress"); // shows spinner
+                    },
                     success: function(data) {
                         var cnames = data.channelNames;
                         // update the channel names, and ititial values in form


### PR DESCRIPTION
Fixes #304.

There were 2 problems with channel editing previously:
 - It took a long time (fixed by https://github.com/ome/omero-py/pull/331)
 - User could hit 'submit' twice since it wasn't disabled when first clicked (fixed by this PR).

To test:
 - Edit channel names (either a single image or multiple Images in a Dataset or Plate)
 - On clicking 'Save' or 'Confirm', the button will be disabled and show a spinner while saving to server.
 - Clicking twice shouldn't submit more than once (can check the Network tab in dev tools to confirm)
 - Cancel will reset the form.

