### PR TITLE
Handle chgrp dry-run LogicalChannel[ID] to show images

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -151,7 +151,14 @@ $(function() {
                                 var id = imageId.replace("Image[", "").replace("]", "");
                                 return "<a href='" + webindex_url + "?show=image-" + id + "'>" + imageId + "</a>";
                             };
-                            errHtml += errMsg.replace(/Image\[([0-9]*)\]/g, getLinkHtml);
+                            var getLogicalChannelLink = function(lcId) {
+                                var id = lcId.replace("LogicalChannel[", "").replace("]", "");
+                                return "<a target='_blank' href='" + webindex_url + "logical_channel/" + id + "/'>" + lcId + "</a>";
+                            };
+                            errMsg = errMsg.replace(/Image\[([0-9]*)\]/g, getLinkHtml);
+                            errMsg = errMsg.replace(/LogicalChannel\[([0-9]*)\]/g, getLogicalChannelLink);
+                            console.log('errMsg', errMsg);
+                            errHtml += errMsg;
                             $dryRunSpinner.html(errHtml);
                             $okbtn.hide();
                             return;

--- a/omeroweb/webclient/templates/webclient/activities/logical_channel.html
+++ b/omeroweb/webclient/templates/webclient/activities/logical_channel.html
@@ -1,0 +1,25 @@
+
+<html>
+    <head>
+        <style>
+            body {
+                font-family: 'Arial';
+            }
+        </style>
+
+    </head>
+
+    <body>
+        <h1>Logical Channel linked to the following Images:</h1>
+
+        <ul>
+        {% for image in data %}
+            <li>
+                <a target="_blank" href="{% url 'webindex' %}?show=image-{{ image.id }}">
+                    {{ image.Name }}
+                </a>
+            </li>
+        {% endfor %}
+        </ul>
+    </body>
+</html>

--- a/omeroweb/webclient/urls.py
+++ b/omeroweb/webclient/urls.py
@@ -152,6 +152,18 @@ urlpatterns = [
         views.edit_channel_names,
         name="edit_channel_names",
     ),
+    url(
+        r"^logical_channel/(?P<id>[0-9]+)/images/$",
+        views.logical_channel_images,
+        name="logical_channel"
+    ),
+    url(
+        r"^logical_channel/(?P<id>[0-9]+)/$",
+        views.logical_channel_images,
+        {"template": "webclient/activities/logical_channel.html"},
+        name="logical_channel"
+    ),
+
     # image webgateway extention
     url(
         r"^(?:(?P<share_id>[0-9]+)/)?render_image_region/"

--- a/omeroweb/webclient/urls.py
+++ b/omeroweb/webclient/urls.py
@@ -155,15 +155,14 @@ urlpatterns = [
     url(
         r"^logical_channel/(?P<id>[0-9]+)/images/$",
         views.logical_channel_images,
-        name="logical_channel"
+        name="logical_channel",
     ),
     url(
         r"^logical_channel/(?P<id>[0-9]+)/$",
         views.logical_channel_images,
         {"template": "webclient/activities/logical_channel.html"},
-        name="logical_channel"
+        name="logical_channel",
     ),
-
     # image webgateway extention
     url(
         r"^(?:(?P<share_id>[0-9]+)/)?render_image_region/"

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2827,13 +2827,15 @@ def logical_channel_images(request, id, conn=None, **kwargs):
 
     params = omero.sys.ParametersI()
     params.addId(id)
-    
+
     queryService = conn.getQueryService()
-    query = ("select i from Image i "
-                 "left outer join fetch i.pixels as p "
-                 "join fetch p.channels as c "
-                 "join fetch c.logicalChannel as lc "
-                 "where lc.id = :id")
+    query = (
+        "select i from Image i "
+        "left outer join fetch i.pixels as p "
+        "join fetch p.channels as c "
+        "join fetch c.logicalChannel as lc "
+        "where lc.id = :id"
+    )
     result = queryService.findAllByQuery(query, params, conn.SERVICE_OPTS)
 
     json_rsp = []
@@ -2841,8 +2843,8 @@ def logical_channel_images(request, id, conn=None, **kwargs):
         encoder = get_encoder(image.__class__)
         if encoder is not None:
             img_json = encoder.encode(image)
-            if kwargs.get('template') is not None:
-                img_json['id'] = img_json['@id']
+            if kwargs.get("template") is not None:
+                img_json["id"] = img_json["@id"]
             json_rsp.append(img_json)
 
     return {"data": json_rsp}


### PR DESCRIPTION
See #376 

This handles the chgrp dry-run error message "cannot   LogicalChannel[ID] " by creating a link to a simply page that lists the problematic images linked to that LogicalChannel.

TODO: improve the UI as on issue above.