### PR TITLE
Allow multiple file-annotations to be uploaded

### DIFF
--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -338,7 +338,10 @@ class FilesAnnotationForm(BaseAnnotationForm):
             required=False,
         )
 
-    annotation_file = forms.FileField(required=False)
+    annotation_file = forms.FileField(
+        widget=forms.ClearableFileInput(attrs={'multiple': True}),
+        required=False
+    )
 
 
 class CommentAnnotationForm(BaseAnnotationForm):

--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -339,8 +339,7 @@ class FilesAnnotationForm(BaseAnnotationForm):
         )
 
     annotation_file = forms.FileField(
-        widget=forms.ClearableFileInput(attrs={'multiple': True}),
-        required=False
+        widget=forms.ClearableFileInput(attrs={"multiple": True}), required=False
     )
 
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2410,14 +2410,10 @@ def annotate_file(request, conn=None, **kwargs):
             added_files = []
             if files is not None and len(files) > 0:
                 added_files = manager.createAnnotationsLinks("file", files, oids)
-            # upload new file
-            fileupload = (
-                "annotation_file" in request.FILES
-                and request.FILES["annotation_file"]
-                or None
-            )
-            if fileupload is not None and fileupload != "":
-                newFileId = manager.createFileAnnotations(fileupload, oids)
+            # upload new files
+            files = request.FILES.getlist("annotation_file")
+            for f in files:
+                newFileId = manager.createFileAnnotations(f, oids)
                 added_files.append(newFileId)
             return JsonResponse({"fileIds": added_files})
         else:


### PR DESCRIPTION
See https://forum.image.sc/t/add-multiple-attachments-at-once-on-omero/72026

To test:
 - When creating a File-Annotation from a local file, the file chooser now allows multiple files
 - choose multiple files and multiple annotations should be created at once