### PR TITLE
Thumbnail zooming

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1582,6 +1582,17 @@
         position: relative;
         width: 100%;
     }
+    #dataIcons li {
+        width: var(--iconSize);
+        height: var(--iconSize);
+    }
+    #dataIcons img{
+        width: 100%;
+        height: 100%;
+        /* fit the image to container, regardless of aspect ratio */
+        object-fit: contain;
+        object-position: center top;
+    }
 
     #dataIcons .ratingFilter_hidden {
         display: none;

--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1671,15 +1671,6 @@
     .tableLayout li.thead {
         height: 30px;
     }
-    .table_caption {
-        display: none;
-        padding: 10px;
-        text-align: right;
-        font-size: 14px;
-    }
-    .tableLayout .table_caption {
-        display: table-caption;
-    }
     .element_sorter .clickable {
         cursor: pointer;
         background: url("../image/table_arrow_up_down.png") no-repeat scroll center left transparent;

--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1582,7 +1582,7 @@
         position: relative;
         width: 100%;
     }
-    #dataIcons li {
+    #dataIcons div.image {
         width: var(--iconSize);
         height: var(--iconSize);
     }
@@ -1670,6 +1670,15 @@
     }
     .tableLayout li.thead {
         height: 30px;
+    }
+    .table_caption {
+        display: none;
+        padding: 10px;
+        text-align: right;
+        font-size: 14px;
+    }
+    .tableLayout .table_caption {
+        display: table-caption;
     }
     .element_sorter .clickable {
         cursor: pointer;

--- a/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -513,6 +513,10 @@ $(function() {
 
                 // Extra data needed for showing thumbs in centre panel
                 if (node.type === 'dataset' || node.type === 'orphaned' || node.type === 'tag') {
+                    if ($('#dataTree').data("layout") === "table") {
+                        // Only need to display sizes in table layout
+                        payload['sizeXYZ'] = true;
+                    }
                     payload['date'] = true;
                 }
 

--- a/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -513,7 +513,6 @@ $(function() {
 
                 // Extra data needed for showing thumbs in centre panel
                 if (node.type === 'dataset' || node.type === 'orphaned' || node.type === 'tag') {
-                    payload['sizeXYZ'] = true;
                     payload['date'] = true;
                 }
 

--- a/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -513,10 +513,7 @@ $(function() {
 
                 // Extra data needed for showing thumbs in centre panel
                 if (node.type === 'dataset' || node.type === 'orphaned' || node.type === 'tag') {
-                    if ($('#dataTree').data("layout") === "table") {
-                        // Only need to display sizes in table layout
-                        payload['sizeXYZ'] = true;
-                    }
+                    payload['sizeXYZ'] = true;
                     payload['date'] = true;
                 }
 

--- a/omeroweb/webclient/templates/webclient/data/icon_header_underscore.html
+++ b/omeroweb/webclient/templates/webclient/data/icon_header_underscore.html
@@ -1,8 +1,8 @@
 
 <div id="center_toolbar" class="toolbar">
     <div id="layout_chooser">
-        <button id="icon_layout" title="View as Thumbnails" class="<% if (layout === 'icon') print('checked') %>"></button>
-        <button id="table_layout" title="View as List" class="<% if (layout === 'table') print('checked') %>"></button>
+        <button id="icon_layout" title="View as Thumbnails" class="<% if (layout === 'icon') print('checked') %>">
+        </button><button id="table_layout" title="View as List" class="<% if (layout === 'table') print('checked') %>"></button>
     </div>
     <div class="search filtersearch" id="filtersearch">
         <select id="choosefilter">

--- a/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -12,11 +12,6 @@
         <div class='sort-numeric'>Size T</div>
     </li>
 
-    <!-- If the images were loaded *before* switching to table layout, they won't have sizes -->
-    <% if (images.length > 0 && !images[0].data.obj.sizeX) { %>
-    <div class="table_caption">Please refresh the data to load image sizes in table layout</div>
-    <% }%>
-
     <% _.each(images, function(img) { %>
         <li class="row <% if(img.selected) {print ('ui-selected')} %>
             <% if(img.fsSelected) {print ('fs-selected')} %> "

--- a/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -24,12 +24,11 @@
             <% if(img.shareId) { %> data-share="<%- img.shareId %>" <% }%>
             data-owned="">
 
-            <div class="image">
                 <!-- we wrap img with <a> so you can right-click -> open link in new tab -->
                 <a href="<%= webindex %><% if(img.shareId) {print( img.shareId + '/')} %>img_detail/<%- img.id %>/<% if (dataset) print('?dataset=' + dataset) %>" >
                     <img/>
                 </a>
-            </div>
+
             <!-- NB: '#image_icon-123 div.desc' etc is used to update name when changed in right panel via "editinplace" -->
             <div class="desc" valign="middle">
                  <%- img.name %>

--- a/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -13,7 +13,7 @@
     </li>
 
     <!-- If the images were loaded *before* switching to table layout, they won't have sizes -->
-    <% if (!images[0].data.obj.sizeX) { %>
+    <% if (images.length > 0 && !images[0].data.obj.sizeX) { %>
     <div class="table_caption">Please refresh the data to load image sizes in table layout</div>
     <% }%>
 

--- a/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -12,6 +12,11 @@
         <div class='sort-numeric'>Size T</div>
     </li>
 
+    <!-- If the images were loaded *before* switching to table layout, they won't have sizes -->
+    <% if (!images[0].data.obj.sizeX) { %>
+    <div class="table_caption">Please refresh the data to load image sizes in table layout</div>
+    <% }%>
+
     <% _.each(images, function(img) { %>
         <li class="row <% if(img.selected) {print ('ui-selected')} %>
             <% if(img.fsSelected) {print ('fs-selected')} %> "
@@ -24,11 +29,13 @@
             <% if(img.shareId) { %> data-share="<%- img.shareId %>" <% }%>
             data-owned="">
 
+            <!-- This div is the first column in table layout -->
+            <div class="image">
                 <!-- we wrap img with <a> so you can right-click -> open link in new tab -->
                 <a href="<%= webindex %><% if(img.shareId) {print( img.shareId + '/')} %>img_detail/<%- img.id %>/<% if (dataset) print('?dataset=' + dataset) %>" >
                     <img/>
                 </a>
-
+            </div>
             <!-- NB: '#image_icon-123 div.desc' etc is used to update name when changed in right panel via "editinplace" -->
             <div class="desc" valign="middle">
                  <%- img.name %>

--- a/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -882,8 +882,6 @@ $(document).ready(function() {
             $("#dataIcons").removeClass("iconLayout");
             $("#dataIcons").addClass("tableLayout");
         }
-        // allow jsTree to read this state
-        $('#dataTree').data("layout", layout);
         // on larger pages, may need to scroll to show selected thumbnail again
         focusThumbnail();
     }

--- a/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -72,6 +72,10 @@ $(document).ready(function() {
         day: "numeric", hour: "2-digit", minute: "2-digit"
     };
 
+    var setIconSize = function() {
+        $("#dataIcons").get(0).style.setProperty("--iconSize", iconSize + "px");
+    }
+
     // Start listening for Node Loading events on the tree...
     // If a node loads and it's selected, update_thumbs...
     $("#dataTree").on('load_node.jstree', function(event, data){
@@ -290,6 +294,8 @@ $(document).ready(function() {
 
         var html = iconTmpl(json);
         $("#icon_table").html(html);
+        // intial size
+        setIconSize();
 
         // load thumbnails in a batches
         thumbnailsBatch = {{ thumbnails_batch|default:50|json_dumps|safe }};
@@ -310,9 +316,6 @@ $(document).ready(function() {
             thumbUrl, iids, thumbnailsBatch,
             "{% static 'webgateway/img/image128.png' %}"
         );
-
-        // populate arrays etc for speedy icon zooming
-        setupIconZooming();
 
         // setup quicksearch filtering of images
         setupFiltering();
@@ -721,16 +724,7 @@ $(document).ready(function() {
 
         // It is possible to select the image itself or its individual container
         // Handle that here
-        var $targetIcon;
-        if (event.target.nodeName.toLowerCase() == 'li') {
-            $targetIcon = $(event.target);
-        } else if (event.target.nodeName.toLowerCase() == 'img') {
-            $targetIcon = $(event.target).parent().parent().parent();
-        } else if (event.target.nodeName.toLowerCase() == 'a') {
-            $targetIcon = $(event.target).parent().parent();
-        } else {
-            $targetIcon = $(event.target).parent();
-        }
+        var $targetIcon = $(event.target).closest(".row");
 
         var imageId = $targetIcon.attr('data-id');
 
@@ -875,47 +869,6 @@ $(document).ready(function() {
         $selectee.removeClass('fs-selected');
         for (var fsid in fsIds) {
             $selectee.filter("[data-fileset='"+ fsid + "']").addClass('fs-selected');
-        }
-    }
-
-    // Handle zooming of thumbnails with jQuery slider
-    var setupIconZooming = function() {
-        icon_styles = [];
-        li_styles = [];
-        aspect_ratios = [];
-        // manipulate thumbnail styles directly (approx 2x faster than using jQuery)
-        $("#dataIcons img").each(function(){
-            icon_styles.push(this.style);
-        });
-
-        var sizeX, sizeY;
-        $("#dataIcons li").each(function(){
-            if (! $(this).hasClass('thead')) {
-                li_styles.push(this.style);
-                sizeX = $(".sizeX", $(this)).text();
-                sizeY = $(".sizeY", $(this)).text();
-                aspect_ratios.push(parseFloat(sizeX) / parseFloat(sizeY));
-            }
-        });
-
-        setIconSize();
-    }
-
-    var setIconSize = function(icon_size) {
-        var icon_size = iconSize;
-        for (var s=0; s<icon_styles.length; s++) {
-            if (aspect_ratios[s] < 1) {
-                icon_styles[s].width = Math.round(icon_size * aspect_ratios[s]) + 1 + "px";
-                icon_styles[s].height = icon_size + "px";
-            } else if (aspect_ratios[s] > 1) {
-                icon_styles[s].height = Math.round(icon_size / aspect_ratios[s]) + 1 + "px";
-                icon_styles[s].width = icon_size + "px";
-            } else {
-                icon_styles[s].width = icon_size + "px";
-                icon_styles[s].height = icon_size + "px";
-            }
-            li_styles[s].width = icon_size + "px";
-            li_styles[s].height = icon_size + "px";
         }
     }
 

--- a/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -882,6 +882,8 @@ $(document).ready(function() {
             $("#dataIcons").removeClass("iconLayout");
             $("#dataIcons").addClass("tableLayout");
         }
+        // allow jsTree to read this state
+        $('#dataTree').data("layout", layout);
         // on larger pages, may need to scroll to show selected thumbnail again
         focusThumbnail();
     }


### PR DESCRIPTION
This PR cleans-up the thumbnail zooming logic in webclient.

Instead of using the sizeX and sizeY values to calculate the aspect ratio for every thumbnail and JavaScript sets the width and height on the fly while dragging the thumbnail slider, we now use CSS to do achieve the same effect which is much simpler and might be faster/smoother.

To test:
 - Should see no change in behaviour for thumbnail zooming
 - The table layout icon has a small fix (see screenshots below)

NB: Previously this PR didn't load sizeXYZ values from OMERO until the user clicked on table layout to display them, but this was added complexity for negligible performance gain so it has been removed.
