### PR TITLE
Only show hierarchy button when Image is selected

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -360,9 +360,11 @@
       </button>
     {% endif %}
 
+      {% if image %}
       <button id="show_image_hierarchy" class="btn silver btn_hierarchy" title="Show parent Projects & Datasets">
         <span></span>
       </button>
+      {% endif %}
     {% endif %}
     {% endif %}
 


### PR DESCRIPTION
Fixes #405. 

The hierarchy button that loads Projects and Datasets for an Image has never worked with other types of objects OR with multiple objects (see issue above).
This PR simply hides the button unless an Image is selected.

To test:
 - Select 1 image - button is visible and works (NB: also shown for a Well, although it reports 'Not in Projects/Datasets - no change in behaviour here).
 - Select multiple images or other objects - button is not shown