### PR TITLE
Update to a suitable version of the concurrent-log-handler

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -87,7 +87,7 @@ FULL_REQUEST_LOGFORMAT = (
     " HTTP %(status_code)d %(request)s"
 )
 
-LOGGING_CLASS = "omero_ext.cloghandler.ConcurrentRotatingFileHandler"
+LOGGING_CLASS = "concurrent_log_handler.ConcurrentRotatingFileHandler"
 LOGSIZE = 500000000
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         # requires Ice (use wheel for faster installs)
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
+        "concurrent-log-handler>=0.9.20",
         "Django>=3.2,<4.0",
         "django-pipeline==2.0.7",
         "django-cors-headers==3.7.0",


### PR DESCRIPTION
We have a vendored version of ConcurrentLogHandler 0.9.1 [^1] from omero-py that we use.  This version is from 2013, has a few bugs, and doesn't work properly with the encoding changes [^2][^3] made in Python 3.10.

A new version [^4] whose lineage is that of the now unmaintained ConcurrentLogHandler is now available which resolves several of the aforementioned bugs, supports Python 3.10, and is drop in replacement API compatible with the previous version.  This commit adds a dependency for this new version and swaps the default logger class for it in configuration.

  [^1]: https://pypi.org/project/ConcurrentLogHandler/
  [^2]: https://peps.python.org/pep-0597/
  [^3]: https://github.com/python/cpython/pull/19481
  [^4]: https://pypi.org/project/concurrent-log-handler/