### PR TITLE
Add Python 3.10 to the testing matrix

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,8 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
-    runs-on: ubuntu-18.04
+          - '3.10'
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4

--- a/test/unit/test_settings.py
+++ b/test/unit/test_settings.py
@@ -40,12 +40,11 @@ class TestServerModel(object):
             Server()
         except TypeError as te:
             found = str(te)
-            python2 = "__new__() takes at least 3 arguments (1 given)"
-            python3 = (
+            error_message = (
                 "__new__() missing 2 required positional arguments:"
                 " 'host' and 'port'"
             )
-            assert found in (python2, python3)
+            assert found.endswith(error_message)
 
     def test_get_and_find(self):
         Server.reset()

--- a/tox.ini
+++ b/tox.ini
@@ -18,10 +18,10 @@ deps =
     # https://github.com/pytest-dev/pytest-xdist/issues/585
     pytest-xdist < 2
     restructuredtext-lint
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.6"
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.7"
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
+    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.7"
+    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
+    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
+    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
 
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Default tox environment when run without `-e`
-envlist = py36, py37, py38
+envlist = py36, py37, py38, py39, py310
 
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Default tox environment when run without `-e`
-envlist = py36, py37, py38, py39, py310
+envlist = py37, py38, py39, py310
 
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel


### PR DESCRIPTION
As OMERO.web is starting to be deployed on distributions like Ubuntu 22.04 where Python 3.10 is the default Python version,  this proposes to add this environment to  the testing matrix so that we have some minimal coverage.

Proposed changes:
- updates the Tox dependencies to consumes the artifacts of https://github.com/ome/zeroc-ice-py-github-ci/releases/tag/0.2.0
- adds Python 3.10 to the Tox configuration as well as the GitHub workflow configuration
- fixes an unit test failing on Python 3.10

Incidentally, this makes a few updates/deprecations:
- the base OS under which the workflow is executed is upgraded to Ubuntu 20.04 (Ubuntu 18.04 is going EOL in April 2023)
- Python 3.6 (EOL since December 2021) is removed from the Tox configuration