### PR TITLE
Allow a non-public user to get their event context

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3344,6 +3344,7 @@ class LoginView(View):
         """
         error = None
         form = self.form_class(request.POST.copy())
+        userip = get_client_ip(request)
         if form.is_valid():
             username = form.cleaned_data["username"]
             password = form.cleaned_data["password"]
@@ -3363,7 +3364,7 @@ class LoginView(View):
                 and compatible
             ):
                 conn = connector.create_connection(
-                    self.useragent, username, password, userip=get_client_ip(request)
+                    self.useragent, username, password, userip=userip
                 )
                 if conn is not None:
                     try:
@@ -3396,6 +3397,24 @@ class LoginView(View):
                     )
                 else:
                     error = settings.LOGIN_INCORRECT_CREDENTIALS_TEXT
+        elif "connector" in request.session:
+            # If we appear to already be logged in and the form we've been
+            # provided is not valid repeat the "logged in" behaviour so a user
+            # can get their event context.
+            connector = request.session["connector"]
+            # Do not allow retrieval of the event context of the public user
+            if not connector.is_public:
+                conn = connector.join_connection(self.useragent, userip)
+                # Connection is None if it could not be successfully joined
+                # and any omero.client objects will have had close() called
+                # on them.
+                if conn is not None:
+                    try:
+                        return self.handle_logged_in(request, conn, connector)
+                    except Exception:
+                        pass
+                    finally:
+                        conn.close(hard=False)
         return self.handle_not_logged_in(request, error, form)
 
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3397,12 +3397,16 @@ class LoginView(View):
                     )
                 else:
                     error = settings.LOGIN_INCORRECT_CREDENTIALS_TEXT
-        elif "connector" in request.session and len(form.data) == 1:
+        elif "connector" in request.session and (
+            len(form.data) == 0
+            or ("csrfmiddlewaretoken" in form.data and len(form.data) == 1)
+        ):
             # If we appear to already be logged in and the form we've been
             # provided is empty repeat the "logged in" behaviour so a user
             # can get their event context.  A form with length 1 is considered
             # empty as a valid CSRF token is required to even get into this
-            # method.
+            # method.  The CSRF token may also have been provided via HTTP
+            # header in which case the form length will be 0.
             connector = request.session["connector"]
             # Do not allow retrieval of the event context of the public user
             if not connector.is_public:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3397,10 +3397,12 @@ class LoginView(View):
                     )
                 else:
                     error = settings.LOGIN_INCORRECT_CREDENTIALS_TEXT
-        elif "connector" in request.session:
+        elif "connector" in request.session and len(form.data) == 1:
             # If we appear to already be logged in and the form we've been
-            # provided is not valid repeat the "logged in" behaviour so a user
-            # can get their event context.
+            # provided is empty repeat the "logged in" behaviour so a user
+            # can get their event context.  A form with length 1 is considered
+            # empty as a valid CSRF token is required to even get into this
+            # method.
             connector = request.session["connector"]
             # Do not allow retrieval of the event context of the public user
             if not connector.is_public:


### PR DESCRIPTION
It's very useful for a non-public user to be able to retrieve the current event context at any time rather than just at login; particularly so for scenarios where API access is being done by OMERO session key. This is especially important when using OMERO session creation strategies such as single sign on (SSO) or other login view plugin. Otherwise, retrieving the current OMERO session key, knowing one's current groups, etc. is currently impossible from OMERO.web APIs.

The requirement for `POST`, where the request is subject to all the standard CSRF protection criteria enforced by Django, is to prevent session hijacking via clickjacking or similar attacks.

To test, simply open your browser developer tools to the network tab and log in to OMERO.web. Really any request will do but the initial one to `/webclient/` is usually the easiest to handle. You will want to copy the entirety of the `Cookie:` header, for example:

```
csrftoken=ZJ6JVp6ngjvMVtaTQAzR97lRd4CWlE7flaUbtx3N2kJ0Mk18RYOyeUZzeNl3mEXI; sessionid=q264uf0l6qatjn1da76cd0ny9xo29l27
```

You can then craft a suitable request to `/api/v0/login/` via `curl` to ensure the event context can be retrieved. For example:

```
curl -X POST \
    -H 'Referrer: http://localhost/api/v0/login/' \
    -H 'Cookie: csrftoken=ZJ6JVp6ngjvMVtaTQAzR97lRd4CWlE7flaUbtx3N2kJ0Mk18RYOyeUZzeNl3mEXI; sessionid=q264uf0l6qatjn1da76cd0ny9xo29l27' \
    -d 'csrfmiddlewaretoken=ZJ6JVp6ngjvMVtaTQAzR97lRd4CWlE7flaUbtx3N2kJ0Mk18RYOyeUZzeNl3mEXI' \
        http://localhost/api/v0/login/
````

Where the value for the `Cookie:` is what you copied from your network tab and the value of `csrfmiddlewaretoken` is the same as the `csrftoken` from your cookie. `Referrer:` is essential if you are using HTTPS; the same URL you are sending the `POST` to.

The response should look something like:

```
{
  "success": true,
  "eventContext": {
    "sessionId": 12126,
    "sessionUuid": "bc307c16-cbf7-4329-b0e2-5ea75d8cce70",
    "userId": 0,
    "userName": "root",
    "groupId": 0,
    "groupName": "system",
    "isAdmin": true,
    "eventId": -1,
    "eventType": "User",
    "memberOfGroups": [
      0,
      1
    ],
    "leaderOfGroups": [
      0
    ]
  }
}
```

You can then destroy your session via the `omero-py` CLI:

```
$ omero -s localhost -k 'bc307c16-cbf7-4329-b0e2-5ea75d8cce70' shell --login
Joined session for root@localhost :4064. Idle timeout: 10 min. Current group: system
Python 3.10.6 (main, Nov  2 2022, 18:53:38) [GCC 11.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: client.destroySession('bc307c16-cbf7-4329-b0e2-5ea75d8cce70')
Out[1]: 1
```

and ensure the regular behaviour is present by re-executing your `curl` crafted as above where you will get a response like:

```
{
  "message": "Username: This field is required. Password: This field is required. Server: This field is required."
}
```