### PR TITLE
Right panel spinner

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -319,7 +319,19 @@
 	        }
         
         
-
+    .right_panel_spinner {
+        text-align: center;
+        margin-top: 25px;
+        font-size: 18px;
+        /* transition: opacity 2s; */
+        display: none;
+    }
+    /* .right_panel_spinner.fade {
+        opacity: 1;
+    } */
+    .right_panel_spinner span {
+        opacity: 0.5;
+    }
     
 	
 	    

--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -1192,3 +1192,11 @@ jQuery.fn.tooltip_init = function() {
     });
   return this;
 };
+
+OME.fadeInSpinner = function fadeInSpinner($element) {
+    // Use base64 spinner.gif to avoid loading delay
+    $(`<div class="right_panel_spinner">
+            <img class="loader" alt="Loading" src="data:image/gif;base64,R0lGODlhEAAQAPIAAP///zxKW9HU2G95hjxKW4eQmqCnr6yyuSH5BAkKAAAAIf4aQ3JlYXRlZCB3aXRoIGFqYXhsb2FkLmluZm8AIf8LTkVUU0NBUEUyLjADAQAAACwAAAAAEAAQAAADMwi63P4wyklrE2MIOggZnAdOmGYJRbExwroUmcG2LmDEwnHQLVsYOd2mBzkYDAdKa+dIAAAh+QQJCgAAACwAAAAAEAAQAAADNAi63P5OjCEgG4QMu7DmikRxQlFUYDEZIGBMRVsaqHwctXXf7WEYB4Ag1xjihkMZsiUkKhIAIfkECQoAAAAsAAAAABAAEAAAAzYIujIjK8pByJDMlFYvBoVjHA70GU7xSUJhmKtwHPAKzLO9HMaoKwJZ7Rf8AYPDDzKpZBqfvwQAIfkECQoAAAAsAAAAABAAEAAAAzMIumIlK8oyhpHsnFZfhYumCYUhDAQxRIdhHBGqRoKw0R8DYlJd8z0fMDgsGo/IpHI5TAAAIfkECQoAAAAsAAAAABAAEAAAAzIIunInK0rnZBTwGPNMgQwmdsNgXGJUlIWEuR5oWUIpz8pAEAMe6TwfwyYsGo/IpFKSAAAh+QQJCgAAACwAAAAAEAAQAAADMwi6IMKQORfjdOe82p4wGccc4CEuQradylesojEMBgsUc2G7sDX3lQGBMLAJibufbSlKAAAh+QQJCgAAACwAAAAAEAAQAAADMgi63P7wCRHZnFVdmgHu2nFwlWCI3WGc3TSWhUFGxTAUkGCbtgENBMJAEJsxgMLWzpEAACH5BAkKAAAALAAAAAAQABAAAAMyCLrc/jDKSatlQtScKdceCAjDII7HcQ4EMTCpyrCuUBjCYRgHVtqlAiB1YhiCnlsRkAAAOw==" />
+            <span>Loading...</span>
+        </div>`).appendTo($element).fadeIn(2000);
+}

--- a/omeroweb/webclient/templates/webclient/data/includes/right_plugin.acquisition.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/right_plugin.acquisition.js.html
@@ -35,7 +35,7 @@ $(document).ready(function() {
             if (well_index > 0) {
                 url = url + '?index='+well_index;
             }
-            $(this).html("<h1 style='padding: 20px 15px'><img src='{% static 'webgateway/img/spinner.gif' %}'/>Loading metadata...</h1>");
+            OME.fadeInSpinner($(this));
             $(this).load(url);
         },
         supported_obj_types: ['image']

--- a/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -43,6 +43,11 @@ $(function () {
         if(selected.length == 0) {
             return;
         }
+        // Don't load if not visible or content aleady loaded (when moving between tabs)
+        if (!$metadata_general.is(":visible") || !$metadata_general.is(":empty")) {
+            return;
+        }
+
         if (selected.length > 1) {
             // handle batch annotation...
             var productListQuery = new Array();
@@ -91,52 +96,48 @@ $(function () {
         } else {
             $("#annotation_tabs").tabs("enable", general_tab_index);    // always want metadata_general enabled
             var url = null;
-            //var oid = selected.attr('id');
-            //var orel = selected[0].attr('rel');
             var oid = selected[0]["id"];
             var orel = oid.split("-")[0];
             if (typeof oid =="undefined" || oid==false) return;
             
-            // handle loading of GENERAL tab
-            if ($metadata_general.is(":visible") && $metadata_general.is(":empty")) {
-                // orphaned
-                if (oid.indexOf("orphaned")>=0) {
-                    $metadata_general.html('<div class="right_tab_inner"><p class="description">{{ ui.orphans.description }}</p></div>');
-                    //return;
-                // experimenter
-                } else if (oid.indexOf("experimenter")>=0) {
-                    //$metadata_general.html('<p>'+selected.children().eq(1).text()+'</p>');
-                // everything else
-                } else {
-                    if(orel=="image") {
-                        if (selected[0]["shareId"]) {
-                            url = prefix+'metadata_details/'+orel+'/'+oid.split("-")[1]+'/'+selected[0]["shareId"]+'/';
-                        } else {
-                            url = prefix+'metadata_details/'+orel+'/'+oid.split("-")[1]+'/';
-                        }
-                    } else if(orel=="well"){
-                        var well_index = selected[0]["index"] || 0;
-                        url = '{% url 'load_metadata_details' %}well/'+oid.split('-')[1]+'/?index='+ well_index;
+            // handle loading of GENERAL tab...
+            // orphaned
+            if (oid.indexOf("orphaned")>=0) {
+                $metadata_general.html('<div class="right_tab_inner"><p class="description">{{ ui.orphans.description }}</p></div>');
+                //return;
+            // experimenter
+            } else if (oid.indexOf("experimenter")>=0) {
+                //$metadata_general.html('<p>'+selected.children().eq(1).text()+'</p>');
+            // everything else
+            } else {
+                if(orel=="image") {
+                    if (selected[0]["shareId"]) {
+                        url = prefix+'metadata_details/'+orel+'/'+oid.split("-")[1]+'/'+selected[0]["shareId"]+'/';
                     } else {
                         url = prefix+'metadata_details/'+orel+'/'+oid.split("-")[1]+'/';
                     }
+                } else if(orel=="well"){
+                    var well_index = selected[0]["index"] || 0;
+                    url = '{% url 'load_metadata_details' %}well/'+oid.split('-')[1]+'/?index='+ well_index;
+                } else {
+                    url = prefix+'metadata_details/'+orel+'/'+oid.split("-")[1]+'/';
                 }
-                if (url !== null) {
-                    // We are effectively doing $metadata_general.load(url) BUT we need to check that selection
-                    // is still correct (hasn't changed during the AJAX call);
-                    OME.fadeInSpinner($metadata_general);
-                    $.ajax({
-                        url: url,
-                        dataType: "html",
-                        success: function(data) {
-                            var selected_id = $("body").data("selected_objects.ome")[0].id;
-                            var oid = $(data).filter("#object-id").text();
-                            if (oid === selected_id) {
-                                $metadata_general.html(data);
-                            }
+            }
+            if (url !== null) {
+                // We are effectively doing $metadata_general.load(url) BUT we need to check that selection
+                // is still correct (hasn't changed during the AJAX call);
+                OME.fadeInSpinner($metadata_general);
+                $.ajax({
+                    url: url,
+                    dataType: "html",
+                    success: function(data) {
+                        var selected_id = $("body").data("selected_objects.ome")[0].id;
+                        var oid = $(data).filter("#object-id").text();
+                        if (oid === selected_id) {
+                            $metadata_general.html(data);
                         }
-                    });
-                }
+                    }
+                });
             }
         }
     }

--- a/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -56,6 +56,7 @@ $(function () {
                 query += "&index=" + well_index;
             }
             // Load right hand panel...
+            OME.fadeInSpinner($metadata_general);
             $.ajax({
                 url: query,
                 dataType: "html",
@@ -123,6 +124,7 @@ $(function () {
                 if (url !== null) {
                     // We are effectively doing $metadata_general.load(url) BUT we need to check that selection
                     // is still correct (hasn't changed during the AJAX call);
+                    OME.fadeInSpinner($metadata_general);
                     $.ajax({
                         url: url,
                         dataType: "html",

--- a/omeroweb/webclient/templates/webclient/data/includes/right_plugin.preview.js.html
+++ b/omeroweb/webclient/templates/webclient/data/includes/right_plugin.preview.js.html
@@ -55,7 +55,7 @@ $(document).ready(function() {
             if (well_index > 0) {
                 url = url + '?index='+well_index;
             }
-            //$this.html("<h1 style='padding: 20px 15px'>Loading...</h1>");
+            OME.fadeInSpinner($(this));
             $(this).load(url);
         },
         supported_obj_types: ['image', 'well']


### PR DESCRIPTION
Fixes #400 

This adds a spinner to the "General" right hand panel and the "Preview" panel, and updates the one on "Acquisition" panel to look the same.

The spinner fades in over 2 seconds, so that if the panel content loads quickly you won't see it (avoids an ugly "flash" of spinner).

To test:

 - Select single objects/images or multiple objects/images and move between right tabs. Spinner should fade in when loading.