### PR TITLE
Mark unused templates as deprecated

### DIFF
--- a/omeroweb/webclient/templates/webclient/base/base.html
+++ b/omeroweb/webclient/templates/webclient/base/base.html
@@ -26,6 +26,12 @@
 
 
 {% block script %}
+    <!--
+        This template is no-longer used by omero-web
+        Since it will be removed soon, we need to be sure that any users are warned:
+    -->
+    <script>alert("WARNING: Django template webclient/base/base.html has been deprecated")</script>
+
     {{ block.super }}
     <!-- required for the script_launch html below -->
     {% include "webclient/base/includes/script_launch_head.html" %}

--- a/omeroweb/webclient/templates/webclient/index/index.html
+++ b/omeroweb/webclient/templates/webclient/index/index.html
@@ -27,6 +27,13 @@
 {% endblock %}
 
 {% block script %}
+
+    <!--
+        This template is no-longer used by omero-web
+        Since it will be removed soon, we need to be sure that any users are warned:
+    -->
+    <script>alert("WARNING: Django template webclient/index/index.html has been deprecated")</script>
+
     {{ block.super }}
     
     <script type="text/javascript">

--- a/omeroweb/webclient/templates/webclient/index/index_last_imports.html
+++ b/omeroweb/webclient/templates/webclient/index/index_last_imports.html
@@ -1,5 +1,10 @@
 {% load i18n %}
 
+<!--
+  This template is no-longer used by omero-web
+  Since it will be removed soon, we need to be sure that any users are warned:
+-->
+<script>alert("WARNING: Django template webclient/base/base.html has been deprecated")</script>
 
 {% comment %}
 <!--

--- a/omeroweb/webclient/templates/webclient/index/index_most_recent.html
+++ b/omeroweb/webclient/templates/webclient/index/index_most_recent.html
@@ -1,5 +1,10 @@
 {% load i18n %}
 
+<!--
+  This template is no-longer used by omero-web
+  Since it will be removed soon, we need to be sure that any users are warned:
+-->
+<script>alert("WARNING: Django template webclient/index/index_most_recent.html has been deprecated")</script>
 
 {% comment %}
 <!--

--- a/omeroweb/webclient/templates/webclient/index/index_tag_cloud.html
+++ b/omeroweb/webclient/templates/webclient/index/index_tag_cloud.html
@@ -1,5 +1,10 @@
 {% load i18n %}
 
+<!--
+  This template is no-longer used by omero-web
+  Since it will be removed soon, we need to be sure that any users are warned:
+-->
+<script>alert("WARNING: Django template webclient/index/index_tag_cloud.html has been deprecated")</script>
 
 {% comment %}
 <!--

--- a/omeroweb/webgateway/templates/webgateway/base/container2.html
+++ b/omeroweb/webgateway/templates/webgateway/base/container2.html
@@ -33,6 +33,12 @@
 {% endblock %}
 
 {% block script %}
+    <!--
+        This template is no-longer used by omero-web
+        Since it will be removed soon, we need to be sure that any users are warned:
+    -->
+    <script>alert("WARNING: Django template webgateway/base/container2.html has been deprecated")</script>
+
     {{ block.super }}
     <script type="text/javascript" src="{% static "webgateway/js/ome.nav.js"|add:url_suffix %}"></script> <!-- handles expand  / collapse columns -->
     


### PR DESCRIPTION
This PR deletes a bunch of old templates used for the old home page which showed a tag cloud and recent imports.

Not used in a LONG time. Also duplicates a lot of code. Good to clean up.