### PR TITLE
Show spinner while loading and saving Comments

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1056,7 +1056,6 @@
 	#add_comment_form {
 		overflow:hidden;
 		clear:left;
-		margin-bottom:20px;
 	}
 	
 	#add_comment_form textarea {
@@ -1153,9 +1152,12 @@
 			overflow: hidden;
 		}
 			
-		
+		#comments_spinner {
+            display: none;
+        }
+
 		#comments_container	{
-			margin-top:5px;
+			margin-top:10px;
 		}
 					
 

--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1152,7 +1152,7 @@
 			overflow: hidden;
 		}
 			
-		#comments_spinner {
+		.hidden_spinner {
             display: none;
         }
 

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_comments_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_comments_pane.js
@@ -65,6 +65,8 @@ var CommentsPane = function CommentsPane($element, opts) {
     // handle submit of Add Comment form
     $("#add_comment_form").ajaxForm({
         beforeSubmit: function(data, $form, options) {
+            $("#add_comment_form input[type='submit']").hide();
+            $("#comments_spinner").show();
             var textArea = $('#add_comment_form textarea');
             if (textArea.val().trim().length === 0) return false;
             // here we specify what objects are to be annotated
@@ -85,7 +87,7 @@ var CommentsPane = function CommentsPane($element, opts) {
         if ($comments_container.is(":visible")) {
 
             if ($comments_container.is(":empty")) {
-                $comments_container.html("Loading comments...");
+                $("#comments_spinner").show();
             }
 
             var request = objects.map(function(o){
@@ -131,6 +133,7 @@ var CommentsPane = function CommentsPane($element, opts) {
                                           'static': WEBCLIENT.URLS.static_webclient,
                                           'webindex': WEBCLIENT.URLS.webindex});
                 }
+                $("#comments_spinner").hide();
                 $comments_container.html(html);
 
                 // Finish up...

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_ratings_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_ratings_pane.js
@@ -64,6 +64,8 @@ var RatingsPane = function RatingsPane($element, opts) {
     });
 
     var setRating = function(rating, $rating) {
+        // show spinner
+        $("#ratings_spinner").show();
         // update rating
         if ($rating) {
             var rating_src = WEBCLIENT.URLS.static_webclient + "image/rating" + rating + ".png";
@@ -91,9 +93,7 @@ var RatingsPane = function RatingsPane($element, opts) {
 
         if ($rating_annotations.is(":visible")) {
 
-            if ($rating_annotations.is(":empty")) {
-                $rating_annotations.html("Loading ratings...");
-            }
+            $("#ratings_spinner").show();
 
             $.getJSON(WEBCLIENT.URLS.webindex + "api/annotations/?type=rating&" + request, function(data){
 
@@ -112,6 +112,7 @@ var RatingsPane = function RatingsPane($element, opts) {
                                          'average': average,
                                          'count': anns.length,
                                          'static': WEBCLIENT.URLS.static_webclient});
+                $("#ratings_spinner").hide();
                 $rating_annotations.html(html);
 
                 // Finish up...

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_ratings_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_ratings_pane.js
@@ -42,7 +42,8 @@ var RatingsPane = function RatingsPane($element, opts) {
             var expanded = !$header.hasClass('closed');
             OME.setPaneExpanded('ratings', expanded);
 
-            if (expanded && $rating_annotations.is(":empty")) {
+            let isEmpty = $(".lnfiles", $rating_annotations).length == 0;
+            if (expanded && isEmpty) {
                 this.render();
             }
         }.bind(this));

--- a/omeroweb/webclient/templates/webclient/annotations/includes/mapannotations.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/mapannotations.html
@@ -92,7 +92,7 @@
 
             var annId = $table.attr('data-annId'),
                 url = "{% url 'annotate_map' %}",
-                $mapAnnotationSpinner = $(".mapAnnotationSpinner", $table.parent()),
+                $mapAnnotationSpinner = $(".mapAnnotationSpinner", $table.parents(".annotations_section")),
                 tableData = [],
                 // objIds = {'project': [1, 2]}
                 data = Object.assign({}, $("#mapAnnContainer").data('objIds'));
@@ -418,9 +418,9 @@
 
 <div style="position: relative">
     <ul class="toolbar mapAnnToolbar">
-        <!-- not really a button - just a handy place to put a spinner -->
+        <!-- first item is just a spinner -->
         <li class="mapAnnotationSpinner" style="display:none">
-            <input class="button" type="image"
+            <img class="button" type="image" style="margin-top: 7px;"
               src="{% static "webgateway/img/spinner.gif" %}" title="Saving to server..." /></li>
         <li><input class="button button-disabled" type="image"
             src="{% static "webclient/image/icon_toolbar_add.png" %}"

--- a/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_comment.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_comment.html
@@ -44,7 +44,7 @@
             </table>
             </form>
             {% endif %}
-            <div id="comments_spinner">
+            <div id="comments_spinner" class="hidden_spinner">
                 <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
                 Loading...
             </div>

--- a/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_comment.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_comment.html
@@ -44,7 +44,10 @@
             </table>
             </form>
             {% endif %}
-
+            <div id="comments_spinner">
+                <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
+                Loading...
+            </div>
             <div id="comments_container" class="lncomments"></div>
     </div>
     </div>

--- a/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_rating.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_rating.html
@@ -26,11 +26,17 @@
     </h1>
     <div class="annotations_section" style="display: none">
         <!-- If we're in 'batch annotate' (obj_string) use annotationBlocked -->
-        <div id="rating_annotations"
+        <div id="rating_annotations" style="float: left"
           {% if obj_string and not annotationBlocked %}
               class="canAnnotate"
           {% elif manager.canAnnotate %}
               class="canAnnotate"
-          {% endif %}></div>
+          {% endif %}>
+        </div>
+        <div id="ratings_spinner" class="hidden_spinner" style="margin-top: 10px;">
+            <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
+            Loading...
+        </div>
+        <div style="clear:left"></div>
      </div>
      </div>


### PR DESCRIPTION
Fixes #401, Fixes #402

Show a spinner when adding comments, ratings and key-value pairs.

Spinner for KV-pairs was already added but not working. Existing spinner is working for Tags.

To test:

 - When loading and updating Comments, Rating or KV pairs a "Loading..." message (and/or spinner) is shown.
 - Expected to work with 1 or multiple objects
