### PR TITLE
Expand description of default_user and default_group search configurations

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -972,13 +972,22 @@ CUSTOM_SETTINGS_MAPPINGS = {
         "SEARCH_DEFAULT_USER",
         0,
         int,
-        ("ID of user to pre-select in search form."),
+        (
+            "ID of the user to pre-select in search form. "
+            "A value of 0 pre-selects the logged in user. "
+            "A value of -1 pre-selects All Users if "
+            "the search is across all groups or All Members "
+            "if the search is within a specific group."
+        ),
     ],
     "omero.web.search.default_group": [
         "SEARCH_DEFAULT_GROUP",
         0,
         int,
-        ("ID of group to pre-select in search form."),
+        (
+            "ID of the group to pre-select in search form. "
+            "A value of 0 or -1 pre-selects All groups."
+        ),
     ],
     "omero.web.ui.top_links": [
         "TOP_LINKS",


### PR DESCRIPTION
Clarify the expectations when setting the special values of 0 (default) and -1 for the `omero.web.search.default_user` and `omeor-web.search.default_group` properties introduced in #297

Additionally, this reveals a lack of symmetry between default user where `0` == `current user` and `-1` == `all users/members` and the default group where both `0` and `-1` are all groups. I assume in an upcoming breaking change, the logic could be reviewed so that `0` could select the current group.