### PR TITLE
Clean up favicon references

### DIFF
--- a/omeroweb/feedback/templates/base_error.html
+++ b/omeroweb/feedback/templates/base_error.html
@@ -10,11 +10,6 @@
     {% trans "OMERO.web - support" %}
 {% endblock %}
 
-{% block head %}
-    {{ block.super }}
-    {% include "webgateway/base/includes/shortcut_icon.html" %}
-{% endblock %}
-
 {% block body %}
 <div class="bodyWrapper">
     <div><h1>

--- a/omeroweb/feedback/templates/disabled.html
+++ b/omeroweb/feedback/templates/disabled.html
@@ -10,11 +10,6 @@
     {% trans "OMERO.web - support" %}
 {% endblock %}
 
-{% block head %}
-    {{ block.super }}
-    {% include "webgateway/base/includes/shortcut_icon.html" %}
-{% endblock %}
-
 {% block body %}
 <div class="bodyWrapper">
     <div><h1>

--- a/omeroweb/feedback/templates/error.html
+++ b/omeroweb/feedback/templates/error.html
@@ -10,11 +10,6 @@
     {% trans "Web - Internal Error" %}
 {% endblock %}
 
-{% block head %}
-    {{ block.super }}
-    {% include "webgateway/base/includes/shortcut_icon.html" %}
-{% endblock %}
-
 {% block body %}
 
 <div class="error">

--- a/omeroweb/feedback/templates/thanks.html
+++ b/omeroweb/feedback/templates/thanks.html
@@ -10,11 +10,6 @@
     {% trans "OMERO.web - support" %}
 {% endblock %}
 
-{% block head %}
-    {{ block.super }}
-    {% include "webgateway/base/includes/shortcut_icon.html" %}
-{% endblock %}
-
 {% block body %}
 <div class="bodyWrapper">
     <div><h1>

--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -119,7 +119,7 @@ urlpatterns += [
     url(
         r"^favicon\.ico$",
         lambda request: redirect("%s%s" % (settings.STATIC_URL, settings.FAVICON_URL)),
-        name="favicon"
+        name="favicon",
     ),
     url(r"^webgateway/", include("omeroweb.webgateway.urls")),
     url(r"^webadmin/", include("omeroweb.webadmin.urls")),

--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -119,6 +119,7 @@ urlpatterns += [
     url(
         r"^favicon\.ico$",
         lambda request: redirect("%s%s" % (settings.STATIC_URL, settings.FAVICON_URL)),
+        name="favicon"
     ),
     url(r"^webgateway/", include("omeroweb.webgateway.urls")),
     url(r"^webadmin/", include("omeroweb.webadmin.urls")),

--- a/omeroweb/webadmin/templates/webadmin/forgotten_password.html
+++ b/omeroweb/webadmin/templates/webadmin/forgotten_password.html
@@ -42,9 +42,7 @@
 
 {% block head %}
     {{ block.super }}
-	
-    {% include "webgateway/base/includes/shortcut_icon.html" %}
-	
+
 	<script type="text/javascript" charset="utf-8">
 		$(function(){ $("label").inFieldLabels(); });
 	</script>

--- a/omeroweb/webclient/templates/webclient/login.html
+++ b/omeroweb/webclient/templates/webclient/login.html
@@ -69,8 +69,6 @@
 {% block head %}
     {{ block.super }}
 	
-    {% include "webgateway/base/includes/shortcut_icon.html" %}
-	
 	<script type="text/javascript" charset="utf-8">
 			$(function(){ $("label").inFieldLabels(); });
 		</script>

--- a/omeroweb/webgateway/templates/webgateway/base/includes/shortcut_icon.html
+++ b/omeroweb/webgateway/templates/webgateway/base/includes/shortcut_icon.html
@@ -18,5 +18,5 @@
 -->
 {% endcomment %}
 
-<link rel="shortcut icon" href="{% static 'webgateway/img/ome.ico' %}" type="image/x-icon" />
+<link rel="icon" href="/favicon.ico" type="image/x-icon" />
 

--- a/omeroweb/webgateway/templates/webgateway/base/includes/shortcut_icon.html
+++ b/omeroweb/webgateway/templates/webgateway/base/includes/shortcut_icon.html
@@ -18,5 +18,5 @@
 -->
 {% endcomment %}
 
-<link rel="icon" href="/favicon.ico" type="image/x-icon" />
+<link rel="icon" href="{% url "favicon" %}" type="image/x-icon" />
 


### PR DESCRIPTION
* Removes duplicate `<link>` entry from `login.html` template
* Change link URL from `.../ome.ico` to the standard `/favicon.ico`, which then gets redirected to the configured icon (or default `ome.ico`)

Discussion on favicon links:
https://stackoverflow.com/questions/10218178/necessary-to-add-link-tag-for-favicon-ico

Potential remaining issues:
* Running OMERO.web below the web server root, since the `/favicon.ico` URL then no longer is at the root.  Supporting this would likely require changes to the nginx configuration.

@emilroz The previous PR #311 allowing customizing the icon did not change the `<link>` in the HTML templates and therefore relied on the browser default behavior of requesting `/favicon.ico` (unless I am missing something)