### PR TITLE
Allow the JSONSerializer to be used as a session serializer

### DIFF
--- a/omeroweb/connector.py
+++ b/omeroweb/connector.py
@@ -130,12 +130,19 @@ class Connector(object):
 
     SERVER_VERSION_RE = re.compile("^.*?[-]?(\\d+[.]\\d+([.]\\d+)?)[-]?.*?$")
 
-    def __init__(self, server_id, is_secure):
+    def __init__(
+        self,
+        server_id,
+        is_secure,
+        is_public=False,
+        omero_session_key=None,
+        user_id=None,
+    ):
         self.server_id = server_id
         self.is_secure = is_secure
-        self.is_public = False
-        self.omero_session_key = None
-        self.user_id = None
+        self.is_public = is_public
+        self.omero_session_key = omero_session_key
+        self.user_id = user_id
 
     def lookup_host_and_port(self):
         server = Server.get(self.server_id)
@@ -265,3 +272,19 @@ class Connector(object):
         if client_version[0] == "5" and int(client_version[1]) >= 6:
             return int(server_version[1]) >= 5
         return server_version[:2] == client_version[:2]
+
+    @staticmethod
+    def from_session(request):
+        """
+        Creates a new Connector from metadata in the current session.
+        """
+        v = request.session.get("connector", None)
+        if v is None:
+            return None
+        return Connector(**v)
+
+    def to_session(self, request):
+        """
+        Writes Connector metadata to the current session.
+        """
+        request.session["connector"] = self.__dict__

--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -82,7 +82,7 @@ def is_public_user(request):
 
     Returns None if no connector found
     """
-    connector = request.session.get("connector")
+    connector = Connector.from_session(request)
     if connector is not None:
         return connector.is_public
 
@@ -352,7 +352,7 @@ class login_required(object):
                 )
                 connection = public_user_connector.join_connection(self.useragent)
                 if connection is not None:
-                    request.session["connector"] = public_user_connector
+                    public_user_connector.to_session(request)
                     logger.debug(
                         "Attempt to use cached OMERO.web public "
                         "session key successful!"
@@ -372,7 +372,7 @@ class login_required(object):
                 is_public=True,
                 userip=get_client_ip(request),
             )
-            request.session["connector"] = connector
+            connector.to_session(request)
             # Clear any previous context so we don't try to access this
             # NB: we also do this in WebclientLoginView.handle_logged_in()
             if "active_group" in request.session:
@@ -399,11 +399,9 @@ class login_required(object):
         # TODO: Handle previous try_super logic; is it still needed?
 
         userip = get_client_ip(request)
-        session = request.session
-        request = request.GET
         is_secure = settings.SECURE
         logger.debug("Is SSL? %s" % is_secure)
-        connector = session.get("connector", None)
+        connector = Connector.from_session(request)
         logger.debug("Connector: %s" % connector)
 
         if server_id is None:
@@ -414,7 +412,7 @@ class login_required(object):
                 server_id = connector.server_id
             else:
                 try:
-                    server_id = request["server"]
+                    server_id = request.GET["server"]
                 except Exception:
                     # If only 1 server, use it
                     servers = list(Server)
@@ -428,7 +426,7 @@ class login_required(object):
         # If we have an OMERO session key in our request variables attempt
         # to make a connection based on those credentials.
         try:
-            omero_session_key = request["bsession"]
+            omero_session_key = request.GET["bsession"]
             connector = Connector(server_id, is_secure)
         except KeyError:
             # We do not have an OMERO session key in the current request.
@@ -442,7 +440,7 @@ class login_required(object):
             connector.user_id = None
             connector.omero_session_key = omero_session_key
             connection = connector.join_connection(self.useragent, userip)
-            session["connector"] = connector
+            connector.to_session(request)
             return connection
 
         # An OMERO session is not available, we're either trying to service
@@ -450,8 +448,8 @@ class login_required(object):
         username = None
         password = None
         try:
-            username = request["username"]
-            password = request["password"]
+            username = request.GET["username"]
+            password = request.GET["password"]
         except KeyError:
             if connector is None:
                 logger.debug("No username or password in request, exiting.")
@@ -470,7 +468,7 @@ class login_required(object):
             connection = connector.create_connection(
                 self.useragent, username, password, userip=userip
             )
-            session["connector"] = connector
+            connector.to_session(request)
             return connection
 
         logger.debug("Django session connector: %r" % connector)
@@ -485,10 +483,10 @@ class login_required(object):
             # be invalid and we may have other credentials as request
             # variables.
             logger.debug("Connector is no longer valid, destroying...")
-            del session["connector"]
+            del request.session["connector"]
             return None
 
-        session["connector"] = connector
+        connector.to_session(request)
         return None
 
     def __call__(ctx, f):

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -594,6 +594,17 @@ CUSTOM_SETTINGS_MAPPINGS = {
             "https://docs.gunicorn.org/en/stable/settings.html#timeout"
         ),
     ],
+    "omero.web.session_serializer": [
+        "SESSION_SERIALIZER",
+        "django.contrib.sessions.serializers.PickleSerializer",
+        str,
+        (
+            "You can use the this setting to customize the session "
+            "serialization format. See :djangodoc:`Django session "
+            "serialization documentation <topics/http/sessions/"
+            "#session-serialization>` for more details."
+        ),
+    ],
     # Public user
     "omero.web.public.enabled": [
         "PUBLIC_ENABLED",
@@ -1697,11 +1708,6 @@ DEFAULT_USER = os.path.join(
 # broken-link notifications when
 # SEND_BROKEN_LINK_EMAILS=True.
 MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
-
-# https://docs.djangoproject.com/en/1.6/releases/1.6/#default-session-serialization-switched-to-json
-# JSON serializer, which is now the default, cannot handle
-# omeroweb.connector.Connector object
-SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 
 # Load custom settings from etc/grid/config.xml
 # Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228


### PR DESCRIPTION
### Outline

As of Django 4.1 [^1], the `PickleSerializer` has been deprecated and will be
removed in Django 5.0.  The next Django LTS (4.2) which we would likely support
is scheduled to be released in April 2023.  In order for the `JSONSerializer` to be used,
get ahead of this deprecation and prepare our userbase for the change we need
to avoid persisting objects, like the `Connector`, directly in the session.

This PR transitions use of the `Connector` to a persist and
rehydration strategy similar to how the Django authentication
middleware handles model objects.  It is also consistent with how we
handle our own `Server` pseudo model object.

In addition, the `SESSION_SERIALIZER` Django setting has been moved
to an OMERO.web configuration property (`omero.web.session_serializer`) and
left defaulting to the `PickleSerializer`. When using Redis via the cached session
engine the `PickleSerializer` is used by default regardless of what
`SESSION_SERIALIZER` is set to.

### Testing

OMERO.web in its default configuration (`SESSION_ENGINE=omeroweb.filesessionstore`
and `SESSION_SERIALIZER=django.contrib.sessions.serializers.PickleSerializer`)
functionality should remain completely unchanged. Particular attention should be
paid to the login, public user, and `bsession` workflows.

With `SESSION_SERIALIZER=django.contrib.sessions.serializers.JSONSerializer`
functionality should remain completely unchanged.

With `SESSION_ENGINE=django.contrib.sessions.backends.cache`
and `SESSION_SERIALIZER=django.contrib.sessions.serializers.PickleSerializer` again
functionality should remain completely unchanged.

With `SESSION_ENGINE=django.contrib.sessions.backends.cache`
and `SESSION_SERIALIZER=django.contrib.sessions.serializers.JSONSerializer` the
cache itself will need to be configured to use a JSON serializer separately.
For `django-redis` this can be achieved by configuration such as:

```
{
  "default": {
    "BACKEND": "django_redis.cache.RedisCache",
    "LOCATION": "redis://127.0.0.1:6379",
    "OPTIONS": {
      "SERIALIZER": "django_redis.serializers.json.JSONSerializer"
    }
  }
}
```

[^1]: https://docs.djangoproject.com/en/4.1/releases/4.1/#id2