### PR TITLE
Remove outdated Python version warning

### DIFF
--- a/omero/plugins/web.py
+++ b/omero/plugins/web.py
@@ -29,15 +29,11 @@ except ImportError:
 from pkg_resources import resource_string
 
 from omero.install.windows_warning import windows_warning, WINDOWS_WARNING
-from omero.install.python_warning import py27_only, PYTHON_WARNING
 
 HELP = "OMERO.web configuration/deployment tools"
 
 if platform.system() == "Windows":
     HELP += "\n\n%s" % WINDOWS_WARNING
-
-if not py27_only():
-    HELP += "\n\nERROR: %s" % PYTHON_WARNING
 
 LONGHELP = """OMERO.web configuration/deployment tools
 
@@ -76,8 +72,6 @@ def config_required(func):
     def import_django_settings(func):
         @windows_warning
         def wrapper(self, *args, **kwargs):
-            # if not py27_only():
-            #     self.ctx.die(681, "ERROR: %s" % PYTHON_WARNING)
             try:
                 import django  # NOQA
             except Exception:


### PR DESCRIPTION
Running omero web -h currently displays a warning about unsupported Python 3.x versions which is obviously incorrect since version 5.6.0