### PR TITLE
Rdef query checks

### DIFF
--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -110,7 +110,7 @@ Params in render_image/<iid>/<z>/<t>/ are:
 render_image_rdef = url(
     r"^render_image_rdef/(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$",
     views.render_image_rdef,
-    name="webgateway_render_image",
+    name="webgateway_render_image_rdef",
 )
 """
 Returns a jpeg of the OMERO image. See L{views.render_image}. Rendering
@@ -125,7 +125,7 @@ Params in render_image/<iid>/<z>/<t>/ are:
 render_image_region_rdef = url(
     r"^render_image_region_rdef/(?P<iid>[0-9]+)/(?P<z>[0-9]+)/(?P<t>[0-9]+)/$",
     views.render_image_region_rdef,
-    name="webgateway_render_image_region",
+    name="webgateway_render_image_region_rdef",
 )
 """
 Returns a jpeg of the OMERO image, rendering only a region specified in query

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -107,6 +107,38 @@ Params in render_image/<iid>/<z>/<t>/ are:
     - t:    T index
 """
 
+render_image_rdef = url(
+    r"^render_image_rdef/(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$",
+    views.render_image_rdef,
+    name="webgateway_render_image",
+)
+"""
+Returns a jpeg of the OMERO image. See L{views.render_image}. Rendering
+settings MUST be specified in the request parameters. See
+L{views.getImgDetailsFromReq} for details.
+Params in render_image/<iid>/<z>/<t>/ are:
+    - iid:  Image ID
+    - z:    Z index
+    - t:    T index
+"""
+
+render_image_region_rdef = url(
+    r"^render_image_region_rdef/(?P<iid>[0-9]+)/(?P<z>[0-9]+)/(?P<t>[0-9]+)/$",
+    views.render_image_region_rdef,
+    name="webgateway_render_image_region",
+)
+"""
+Returns a jpeg of the OMERO image, rendering only a region specified in query
+string as region=x,y,width,height. E.g. region=0,512,256,256 See
+L{views.render_image_region}.
+Rendering settings MUST be specified in the request parameters.
+Params in render_image/<iid>/<z>/<t>/ are:
+    - iid:  Image ID
+    - z:    Z index
+    - t:    T index
+"""
+
+
 render_split_channel = url(
     r"^render_split_channel/(?P<iid>[0-9]+)/(?P<z>[0-9]+)/(?P<t>[0-9]+)/$",
     views.render_split_channel,
@@ -568,6 +600,8 @@ urlpatterns = [
     webgateway,
     render_image,
     render_image_region,
+    render_image_rdef,
+    render_image_region_rdef,
     render_split_channel,
     render_row_plot,
     render_col_plot,

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -236,7 +236,7 @@ def validate_rdef_query(func):
 
         if "c" not in r:
             return HttpResponseBadRequest(
-                "Rendering settings must specify " + " channels as c"
+                "Rendering settings must specify channels as c"
             )
         channels, windows, colors = _split_channel_info(r["c"])
         # Need the same number of channels, windows, and colors
@@ -246,15 +246,15 @@ def validate_rdef_query(func):
             # Validation requires windows to be specified
             if window[0] is None or window[1] is None:
                 return HttpResponseBadRequest(
-                    "Must specify window for" + " each channel"
+                    "Must specify window for each channel"
                 )
             if colors[i] is None:
                 return HttpResponseBadRequest(
-                    "Must specify color for" + " each channel"
+                    "Must specify color for each channel"
                 )
         if "m" not in r or r["m"] not in ["g", "c"]:
             return HttpResponseBadRequest(
-                'Query parameter "m" must be' + ' present with value either "g" or "c"'
+                'Query parameter "m" must be present with value either "g" or "c"'
             )
         # TODO: What to do about z, t, and p?
         if "maps" in r:
@@ -269,7 +269,7 @@ def validate_rdef_query(func):
             rchannels = r["c"].split(",")
             if len(map_json) != len(rchannels):
                 return HttpResponseBadRequest(
-                    'Number of "maps" must' + " match number of channels"
+                    'Number of "maps" must match number of channels'
                 )
         return func(request, *args, **kwargs)
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -901,14 +901,13 @@ def _get_prepared_image(
                 totalChannels = img.getSizeC()
                 channelIndices = [abs(int(ch)) - 1 for ch in requestedChannels]
                 qm = [m.get("quantization") for m in json.loads(r["maps"])]
-                if len(channelIndices) != len(qm):
-                    raise Exception("Maps and channels numbers don't match")
                 allMaps = [None] * totalChannels
                 for i in range(0, len(channelIndices)):
-                    allMaps[channelIndices[i]] = qm[i]
+                    if i < len(qm):
+                        allMaps[channelIndices[i]] = qm[i]
                 img.setQuantizationMaps(allMaps)
-            except Exception as ex:
-                logger.error("Failed to set quantization maps", ex)
+            except Exception:
+                logger.info("Failed to set quantization maps")
         allChannels = range(1, img.getSizeC() + 1)
         # If saving, apply to all channels
         if saveDefs and not img.setActiveChannels(
@@ -1102,10 +1101,10 @@ def render_image(request, iid, z=None, t=None, conn=None, **kwargs):
     """
     server_id = request.session["connector"].server_id
 
-#    if not validateRdefQuery(request):
-#        return HttpResponseBadRequest(
-#            "Must provide the same number of maps and channels or no maps"
-#        )
+    if not validateRdefQuery(request):
+        return HttpResponseBadRequest(
+            "Must provide the same number of maps and channels or no maps"
+        )
 
     pi = _get_prepared_image(request, iid, server_id=server_id, conn=conn)
     if pi is None:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -946,7 +946,7 @@ def validateRdefQuery(request):
     if "maps" in r:
         map_json = r["maps"]
         # If coming from request string, need to load -> json
-        if isinstance(map_json, (unicode, str)):
+        if isinstance(map_json, str):
             map_json = json.loads(map_json)
         if "c" not in r:
             return False

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -229,7 +229,6 @@ def validate_rdef_query(func):
     def wrapper_validate(request, *args, **kwargs):
         r = None
         try:
-            logger.info(request)
             r = request.GET
         except Exception:
             return HttpResponseServerError("Endpoint improperly configured")

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -905,8 +905,8 @@ def _get_prepared_image(
                 for i in range(0, len(channelIndices)):
                     allMaps[channelIndices[i]] = qm[i]
                 img.setQuantizationMaps(allMaps)
-            except Exception:
-                logger.info("Failed to set quantization maps")
+            except Exception as ex:
+                logger.error("Failed to set quantization maps", ex)
         allChannels = range(1, img.getSizeC() + 1)
         # If saving, apply to all channels
         if saveDefs and not img.setActiveChannels(
@@ -978,7 +978,7 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
 
     if not validateRdefQuery(request):
         return HttpResponseBadRequest(
-            "Must provide the same number of " + "maps and channels or no maps"
+            "Must provide the same number of maps and channels or no maps"
         )
     # if the region=x,y,w,h is not parsed correctly to give 4 ints then we
     # simply provide whole image plane.
@@ -1099,6 +1099,12 @@ def render_image(request, iid, z=None, t=None, conn=None, **kwargs):
     @return:            http response wrapping jpeg
     """
     server_id = request.session["connector"].server_id
+
+    if not validateRdefQuery(request):
+        return HttpResponseBadRequest(
+            "Must provide the same number of maps and channels or no maps"
+        )
+
     pi = _get_prepared_image(request, iid, server_id=server_id, conn=conn)
     if pi is None:
         raise Http404

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -245,13 +245,9 @@ def validate_rdef_query(func):
             # Unspecified windows and colors are returned as None
             # Validation requires windows to be specified
             if window[0] is None or window[1] is None:
-                return HttpResponseBadRequest(
-                    "Must specify window for each channel"
-                )
+                return HttpResponseBadRequest("Must specify window for each channel")
             if colors[i] is None:
-                return HttpResponseBadRequest(
-                    "Must specify color for each channel"
-                )
+                return HttpResponseBadRequest("Must specify color for each channel")
         if "m" not in r or r["m"] not in ["g", "c"]:
             return HttpResponseBadRequest(
                 'Query parameter "m" must be present with value either "g" or "c"'

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -837,29 +837,29 @@ def _get_inverted_enabled(request):
                     corresponding channel is inverted
     """
 
-    codomains = None
+    inversions = None
     if "maps" in request:
         map_json = request["maps"]
-        codomains = []
-        # If coming from request string, need to load -> json
-        if isinstance(map_json, (unicode, str)):
-            map_json = json.loads(map_json)
+        inversions = []
         try:
-            for quant_map in map_json:
+            # If coming from request string, need to load -> json
+            if isinstance(map_json, str):
+                map_json = json.loads(map_json)
+            for codomain_map in map_json:
                 enabled = False
                 # 'reverse' is now deprecated (5.4.0). Check for 'inverted'
                 #  first. inverted is True if 'inverted' OR 'reverse' is enabled
-                m = quant_map.get("inverted")
+                m = codomain_map.get("inverted")
                 if m is None:
-                    m = quant_map.get("reverse")
+                    m = codomain_map.get("reverse")
                 # If None, no change to saved status
                 if m is not None:
                     enabled = m.get("enabled") in (True, "true")
-                codomains.append(enabled)
+                inversions.append(enabled)
         except Exception:
             logger.debug("Invalid json for query ?maps=%s" % map_json)
-            codomains = None
-    return codomains
+            inversions = None
+    return inversions
 
 
 def _get_prepared_image(
@@ -2297,7 +2297,7 @@ def copy_image_rdef_json(request, conn=None, **kwargs):
         return rv
 
     def applyRenderingSettings(image, rdef):
-        invert_flags = _get_inverted_enabled(rdef, "inverted", image.getSizeC())
+        invert_flags = _get_inverted_enabled(rdef)
         channels, windows, colors = _split_channel_info(rdef["c"])
         # also prepares _re
         image.setActiveChannels(channels, windows, colors, invert_flags)

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -945,9 +945,13 @@ def validateRdefQuery(request):
     r = request.GET
     if "maps" in r:
         map_json = r["maps"]
-        # If coming from request string, need to load -> json
-        if isinstance(map_json, str):
-            map_json = json.loads(map_json)
+        try:
+            # If coming from request string, need to load -> json
+            if isinstance(map_json, str):
+                map_json = json.loads(map_json)
+        except Exception:
+            log.warn("Failed to parse maps JSON")
+            return False
         if "c" not in r:
             return False
         rchannels = r["c"].split(",")

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3370,6 +3370,7 @@ class LoginView(View):
         """
         error = None
         form = self.form_class(request.POST.copy())
+        userip = get_client_ip(request)
         if form.is_valid():
             username = form.cleaned_data["username"]
             password = form.cleaned_data["password"]
@@ -3389,7 +3390,7 @@ class LoginView(View):
                 and compatible
             ):
                 conn = connector.create_connection(
-                    self.useragent, username, password, userip=get_client_ip(request)
+                    self.useragent, username, password, userip=userip
                 )
                 if conn is not None:
                     try:
@@ -3422,6 +3423,30 @@ class LoginView(View):
                     )
                 else:
                     error = settings.LOGIN_INCORRECT_CREDENTIALS_TEXT
+        elif "connector" in request.session and (
+            len(form.data) == 0
+            or ("csrfmiddlewaretoken" in form.data and len(form.data) == 1)
+        ):
+            # If we appear to already be logged in and the form we've been
+            # provided is empty repeat the "logged in" behaviour so a user
+            # can get their event context.  A form with length 1 is considered
+            # empty as a valid CSRF token is required to even get into this
+            # method.  The CSRF token may also have been provided via HTTP
+            # header in which case the form length will be 0.
+            connector = request.session["connector"]
+            # Do not allow retrieval of the event context of the public user
+            if not connector.is_public:
+                conn = connector.join_connection(self.useragent, userip)
+                # Connection is None if it could not be successfully joined
+                # and any omero.client objects will have had close() called
+                # on them.
+                if conn is not None:
+                    try:
+                        return self.handle_logged_in(request, conn, connector)
+                    except Exception:
+                        pass
+                    finally:
+                        conn.close(hard=False)
         return self.handle_not_logged_in(request, error, form)
 
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -286,7 +286,7 @@ def redirect_explicit_rdef(func):
         rdef['maps'] = json.dumps(rdef['maps'])
         # QueryDict immutable by default, need a copy
         queryDict = request.GET.copy()
-        allQueryParams = queryDict.update(rdef)
+        queryDict.update(rdef)
         queryStr = queryDict.urlencode()
         return HttpResponseRedirect("{}?{}".format(request.path, queryStr))
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1012,25 +1012,6 @@ def _get_prepared_image(
     return (img, compress_quality)
 
 
-def validateRdefQuery(request):
-    r = request.GET
-    if "maps" in r:
-        map_json = r["maps"]
-        try:
-            # If coming from request string, need to load -> json
-            if isinstance(map_json, str):
-                map_json = json.loads(map_json)
-        except Exception:
-            logger.warn("Failed to parse maps JSON")
-            return False
-        if "c" not in r:
-            return False
-        rchannels = r["c"].split(",")
-        if len(map_json) != len(rchannels):
-            return False
-    return True
-
-
 @login_required()
 @redirect_explicit_rdef
 @validate_rdef_query
@@ -2120,6 +2101,7 @@ def search_json(request, conn=None, **kwargs):
 
 @require_POST
 @login_required()
+@validate_rdef_query
 def save_image_rdef_json(request, iid, conn=None, **kwargs):
     """
     Requests that the rendering defs passed in the request be set as the
@@ -2133,11 +2115,6 @@ def save_image_rdef_json(request, iid, conn=None, **kwargs):
     @return:            http response 'true' or 'false'
     """
     server_id = request.session["connector"].server_id
-
-    if not validateRdefQuery(request):
-        return HttpResponseBadRequest(
-            "Must provide the same number of maps and channels or no maps"
-        )
 
     pi = _get_prepared_image(
         request, iid, server_id=server_id, conn=conn, saveDefs=True

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -232,8 +232,6 @@ def validate_rdef_query(func):
             logger.info(request)
             r = request.GET
         except Exception:
-            logger.info("Function {} wrapped with validate_rdef_query"
-                + " but first arg is not a request".format(str(func)))
             return HttpResponseServerError("Endpoint improperly configured")
 
         if "c" not in r:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -950,7 +950,7 @@ def validateRdefQuery(request):
             if isinstance(map_json, str):
                 map_json = json.loads(map_json)
         except Exception:
-            log.warn("Failed to parse maps JSON")
+            logger.warn("Failed to parse maps JSON")
             return False
         if "c" not in r:
             return False

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1170,13 +1170,13 @@ def render_image(request, iid, z=None, t=None, conn=None, **kwargs):
 @login_required()
 @validate_rdef_query
 def render_image_rdef(request, iid, z=None, t=None, conn=None, **kwargs):
-    return render_image(request, iid, **kwargs)
+    return render_image(request, iid, z=z, t=t, conn=conn, **kwargs)
 
 
 @login_required()
 @validate_rdef_query
 def render_image_region_rdef(request, iid, z=None, t=None, conn=None, **kwargs):
-    return render_image_region(request, iid, z, t, **kwargs)
+    return render_image_region(request, iid, z, t, conn=conn, **kwargs)
 
 
 @login_required()

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -413,3 +413,34 @@ class TestViews(object):
         }
         inverses = views._get_inverted_enabled(mockRequest)
         assert inverses == [False, True, True]
+
+
+    def testValidateRdefQuery(self):
+        class MockRequest(object):
+            def __init__(self, data):
+                self.GET = data
+
+        request = MockRequest({
+            "c": '1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF',
+            "maps": '[{"inverted": {"enabled": "true"}},\
+            {"inverted": {"enabled": "false"}},\
+            {"inverted": {"enabled": "false"}}]'
+        })
+        validated = views.validateRdefQuery(request)
+        assert validated == True
+        #Wrong number of maps
+        request = MockRequest({
+            "c": '1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF',
+            "maps": '[{"inverted": {"enabled": "true"}},\
+            {"inverted": {"enabled": "false"}}]'
+        })
+        validated = views.validateRdefQuery(request)
+        assert validated == False
+        #Malformed maps JSON
+        request = MockRequest({
+            "c": '1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF',
+            "maps": '[{"inverted}": {"enabled": "true"}},\
+            {"inverted": {"enabled": "false"}}]'
+        })
+        validated = views.validateRdefQuery(request)
+        assert validated == False

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -435,7 +435,7 @@ class TestViews(object):
             }
         )
 
-        assert wrapped_fake_view(request) is 1
+        assert wrapped_fake_view(request) == 1
 
         # Unsupported rendering model
         request = MockRequest(

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -399,19 +399,19 @@ class TestViews(object):
             "maps": '[{"inverted": {"enabled": "true"}},\
             {"inverted": {"enabled": "false"}}]'
         }
-        inverses = views._get_inverted_enabled(mockRequest)
-        assert inverses == [True, False]
+        inverses = views._get_inverted_enabled(mockRequest, 3)
+        assert inverses == [True, False, None]
         mockRequest = {
             "maps": '[{}, {"inverted": {"enabled": "true"}},\
             {"inverted": {"enabled": true}}]'
         }
-        inverses = views._get_inverted_enabled(mockRequest)
+        inverses = views._get_inverted_enabled(mockRequest, 3)
         assert inverses == [False, True, True]
         mockRequest = {
             "maps": '[{}, {"reverse": {"enabled": "true"}},\
             {"inverted": {"enabled": true}}]'
         }
-        inverses = views._get_inverted_enabled(mockRequest)
+        inverses = views._get_inverted_enabled(mockRequest, 3)
         assert inverses == [False, True, True]
 
     def testValidateRdefQuery(self):

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -393,3 +393,14 @@ class TestViews(object):
         data = views.rowsToByteArray(rows)
         assert data[0] == 97  # 01100001 First, Second and 7th bits
         assert data[1] == 24  # 00011000 11th and 12th bits
+
+    def testGetInvertedEnabled(self):
+        mockRequest = {'maps': '[{"inverted": {"enabled": "true"}}, {"inverted": {"enabled": "false"}}]'}
+        inverses = views._get_inverted_enabled(mockRequest)
+        assert inverses == [True, False]
+        mockRequest = {'maps': '[{}, {"inverted": {"enabled": "true"}}, {"inverted": {"enabled": true}}]'}
+        inverses = views._get_inverted_enabled(mockRequest)
+        assert inverses == [False, True, True]
+        mockRequest = {'maps': '[{}, {"reverse": {"enabled": "true"}}, {"inverted": {"enabled": true}}]'}
+        inverses = views._get_inverted_enabled(mockRequest)
+        assert inverses == [False, True, True]

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -395,12 +395,15 @@ class TestViews(object):
         assert data[1] == 24  # 00011000 11th and 12th bits
 
     def testGetInvertedEnabled(self):
-        mockRequest = {'maps': '[{"inverted": {"enabled": "true"}}, {"inverted": {"enabled": "false"}}]'}
+        mockRequest = {'maps': '[{"inverted": {"enabled": "true"}},\
+            {"inverted": {"enabled": "false"}}]'}
         inverses = views._get_inverted_enabled(mockRequest)
         assert inverses == [True, False]
-        mockRequest = {'maps': '[{}, {"inverted": {"enabled": "true"}}, {"inverted": {"enabled": true}}]'}
+        mockRequest = {'maps': '[{}, {"inverted": {"enabled": "true"}},\
+            {"inverted": {"enabled": true}}]'}
         inverses = views._get_inverted_enabled(mockRequest)
         assert inverses == [False, True, True]
-        mockRequest = {'maps': '[{}, {"reverse": {"enabled": "true"}}, {"inverted": {"enabled": true}}]'}
+        mockRequest = {'maps': '[{}, {"reverse": {"enabled": "true"}},\
+            {"inverted": {"enabled": true}}]'}
         inverses = views._get_inverted_enabled(mockRequest)
         assert inverses == [False, True, True]

--- a/test/unit/test_webgateway.py
+++ b/test/unit/test_webgateway.py
@@ -427,7 +427,7 @@ class TestViews(object):
             {"inverted": {"enabled": "false"}}]'
         })
         validated = views.validateRdefQuery(request)
-        assert validated == True
+        assert validated is True
         #Wrong number of maps
         request = MockRequest({
             "c": '1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF',
@@ -435,7 +435,7 @@ class TestViews(object):
             {"inverted": {"enabled": "false"}}]'
         })
         validated = views.validateRdefQuery(request)
-        assert validated == False
+        assert validated is False
         #Malformed maps JSON
         request = MockRequest({
             "c": '1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF',
@@ -443,4 +443,4 @@ class TestViews(object):
             {"inverted": {"enabled": "false"}}]'
         })
         validated = views.validateRdefQuery(request)
-        assert validated == False
+        assert validated is False


### PR DESCRIPTION
Add a decorator `validate_rdef_query` which checks the validity of the query parameters supplied to a decorated endpoint. Decorated endpoints will be require the presence and (to a degree) correctness of rendering def-related query parameters or the client will receive a 400 error with a description of how to fix the request. Tries to manage some of the issues raised in #440. For backwards compatibility, two new endpoints `/webgateway/render_image_rdef` and `/webgateway/render_image_region_rdef` are created and the new decorator applied to them. Old endpoints have no behavior change.