### PR TITLE
OMERO.web search: fix handling of server errors

### DIFF
--- a/omeroweb/webclient/controller/search.py
+++ b/omeroweb/webclient/controller/search.py
@@ -157,17 +157,29 @@ class BaseSearch(BaseController):
         except Exception as x:
             logger.info("Search Exception: %s" % x.message)
             if isinstance(x, omero.ServerError):
-                # Only show message to user if we can be helpful
+                # Handle known server exceptions and return useful messages to
+                # the user
                 if "TooManyClauses" in x.message:
                     self.searchError = (
                         "Please try to narrow down your query. The wildcard"
                         " matched too many terms."
                     )
-                elif ":" in query:
-                    self.searchError = (
-                        "There was an error parsing your query."
-                        " Colons ':' are reserved for searches of"
-                        " key-value annotations in the form: 'key:value'."
+                elif "caused a parse exception" in x.message:
+                    # Handle ParseException errors sent by FullText
+                    self.searchError = "There was an error parsing your query."
+                    if ":" in query:
+                        self.searchError += (
+                            " Colons ':' are reserved for searches of"
+                            " key-value annotations in the form: 'key:value'."
+                        )
+                    self.searchError += (
+                        " Please refer to https://omero-guides.readthedocs.io/en/"
+                        "latest/introduction/docs/search-omero.html "
+                        "for more information."
                     )
+                else:
+                    # For all other server errors, raise a QA form with the stack
+                    # trace rather than returning No results
+                    raise x
 
         self.c_size = resultCount


### PR DESCRIPTION
Partly reverts the changes from https://github.com/ome/openmicroscopy/pull/3726 which aimed at improving the user experience by not displaying the server error stack trace in the centre pane, notably for malformed search queries. As per the current implementation, all server errors that either did not contain a `Too Many clauses` message or came from a query containing a `:` character will currently produce `No results found` in the centre panel.

The primary downside of this logic is that legitimate server errors are completely hidden. Taking for instance the scenario of a corrupted index, which was the driver for the initial investigation, the search result will currently display either `No results found` or `There was an error parsing your query` depending on the query. Both outcomes are particularly deceiving as they  incorrectly suggest either a formatting error or a genuine lack of results and completely hide the underlying issue.
A secondary issue is that other malformed queries which will also currently result in `No results found`.

To illustrate the scenarios above, the following OMERO.web search queries were executed against a server with a functional Indexer. The expectation was derived from running `omero search` with the same query as the CLI returns the stack trace if there is a server error.

|                  | Current behavior            | Expectation                 |
|------------------|-----------------------------|-----------------------------|
| `<key>:<value>`    |             list of results |             list of results |
| `:<value>`         | Query parsing error message | Query parsing error message |
| `<key>:`           | Query parsing error message | Query parsing error message |
| `<key>::<value>`   | Query parsing error message | Query parsing error message |
| `<key>":<value>`  | Query parsing error message | Query parsing error message |
| `<key>*:<value>`  | Query parsing error message | Query parsing error message |
| `<key>?:<value>`   | Query parsing error message | Query parsing error message |
| `<valid_term>`     |             list of results |             list of results |
| `AND <valid_term>` | No results found            | Query parsing error message |

To test the scenario of server errors, a broken Indexer was artificially created by deleting `segments*` under `FullText` and the same queries were executed

|                  | Current behavior            | Expectation                 |
|------------------|-----------------------------|-----------------------------|
| `<key>:<value>`    | Query parsing error message |     Server error |
| `:<value>`         | Query parsing error message | Query parsing error message |
| `<key>:`           | Query parsing error message | Query parsing error message |
| `<key>::<value>`   | Query parsing error message | Query parsing error message |
| `"<key>":<value>`  | Query parsing error message | Query parsing error message |
| `<key>*:<value>`   | Query parsing error message | Query parsing error message |
| `<key>?:<value>`   | Query parsing error message | Query parsing error message |
| `<valid_term>`     |            No results found |     Server error  |
| `AND <valid_term>` | No results found            | Query parsing error message |


This PR proposes to amend the current OMERO.web search error handling as follows:

- the handling of server errors containing `Too many clauses` is unchanged
- query parsing errors are detected by looking for the `caused a parse exception` clause in the server message as per https://github.com/ome/omero-server/blob/5960bc983dd59f165efaa5742126bc340d3881a3/src/main/java/ome/services/search/FullText.java#L163. In these cases, the centre panel should display a user-friendly message linking to the guide page. Additionally, if a `:` character is detected in the query, the current error message pointing at malformed K/V pairs will be added to the message.
- for all other server errors, a QA error form should be displayed allowing the users to report the underlying issue to their administrators

With these changes the set of cases mentioned above should now behave consistently with the output of the CLI, both in the case of a functional and broken Indexer.
