### PR TITLE
Bump minimum Django version to 3.2.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
         "concurrent-log-handler>=0.9.20",
-        "Django>=3.2,<4.0",
+        "Django>=3.2.18,<4.0",
         "django-pipeline==2.0.7",
         "django-cors-headers==3.7.0",
         "whitenoise>=5.3.0",


### PR DESCRIPTION
Includes the security fixes from
https://www.djangoproject.com/weblog/2023/feb/14/security-releases/ and https://www.djangoproject.com/weblog/2023/feb/01/security-releases/

Fixes #447 