### PR TITLE
Add change log for 5.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+5.19.0 (March 2023)
+-------------------
+
+## Features
+
+- New cacheable web API calls to render images or image regions [#443](https://github.com/ome/omero-web/pull/443)
+
+## Other changes
+
+- UI activity indicator [426](https://github.com/ome/omero-web/pull/426)
+
+## Bug fixes
+
+- Fix search server errors [446](https://github.com/ome/omero-web/pull/446)
+
 5.18.0 (February 2023)
 ----------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Features
 
 - New cacheable web API calls to render images or image regions [#443](https://github.com/ome/omero-web/pull/443)
+  Also see notes in UPGRADING.md.
 
 ## Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ## Other changes
 
 - UI activity indicator [426](https://github.com/ome/omero-web/pull/426)
+- Thumbnail zooming [411](https://github.com/ome/omero-web/pull/411)
+- Indicate split view not supported for big images [412](https://github.com/ome/omero-web/pull/412)
 
 ## Bug fixes
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,18 @@ This document highlights steps that may need to be taken by developers
 when upgrading OMERO.web to ensure plugins or other customizations
 continue to function as expected.
 
+## OMERO.web 5.19.0
+
+### Partial channel lists in render_image and render_image_region web API calls
+
+When requesting images via the render_image and render_image_region web API
+calls, the desired channel rendering settings may be omitted (to use the
+default rendering settings), fully specified (to use custom settings), or 
+partially specified (to combine custom settings with default rendering 
+settings).  The latter method of partially specifying channel rendering settings
+is now considered deprecated and should not be used in any new or updated
+applications and plugins.
+
 ## OMERO.web 5.18.0
 
 ### Connector storage in Django sessions

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,13 +8,20 @@ continue to function as expected.
 
 ### Partial channel lists in render_image and render_image_region web API calls
 
-When requesting images via the render_image and render_image_region web API
+When requesting images via the `render_image` and `render_image_region` web API
 calls, the desired channel rendering settings may be omitted (to use the
 default rendering settings), fully specified (to use custom settings), or 
 partially specified (to combine custom settings with default rendering 
 settings).  The latter method of partially specifying channel rendering settings
 is now considered deprecated and should not be used in any new or updated
 applications and plugins.
+
+New API calls for requesting images using fully specified channel rendering
+settings are now available as `render_image_rdef` and 
+`render_image_region_rdef`.
+
+Documentation for these API calls is available at
+https://omero.readthedocs.io/en/latest/developers/Web/WebGateway.html.
 
 ## OMERO.web 5.18.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,7 +21,7 @@ settings are now available as `render_image_rdef` and
 `render_image_region_rdef`.
 
 Documentation for these API calls is available at
-https://omero.readthedocs.io/en/latest/developers/Web/WebGateway.html.
+https://omero.readthedocs.io/en/stable/developers/Web/WebGateway.html.
 
 ## OMERO.web 5.18.0
 


### PR DESCRIPTION
Started work on the change log and upgrading info for 5.19.0.

I think we should mention the "deprecation" of part of the `render_image` call and would appreciate feedback on how to describe our recommendations (see https://github.com/ome/omero-web/compare/master...knabar:maint-changelog-5.19.0?expand=1#diff-f411a5009131db5a6c7242b49ca78488f2d274ef9e5e5f4de9262a42108a5386).

Similar text should go into the documentation as well, see issue https://github.com/ome/omero-documentation/issues/2299.

See https://github.com/ome/omero-documentation/pull/2301