### PR TITLE
Declare portalocker as external dependency

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -40,8 +40,8 @@ import pytz
 import random
 import string
 from builtins import str as text
+import portalocker
 
-from omero_ext import portalocker
 from omero.util.concurrency import get_event
 from omeroweb.utils import sort_properties_to_tuple
 from omeroweb.connector import Server

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",
         "Pillow",
+        "portalocker",
     ],
     include_package_data=True,
     tests_require=["pytest"],


### PR DESCRIPTION
Companion PR to https://github.com/ome/omero-py/pull/370

This should fix the nightly CI builds (see e.g. [log](https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-web/1639/console)) by replacing the dependency on `omero_ext.portalocker` (which is currently proposed for removal in the PR above) by the upstream `portalocker` package.
