### PR TITLE
Fix Connector from session constructor

### DIFF
--- a/omeroweb/connector.py
+++ b/omeroweb/connector.py
@@ -281,6 +281,8 @@ class Connector(object):
         v = request.session.get("connector", None)
         if v is None:
             return None
+        if isinstance(v, Connector):
+            return v
         return Connector(**v)
 
     def to_session(self, request):


### PR DESCRIPTION
In some race condition, seems the session.get return the Connector instance, not a serialize version of the instance.

Fix https://github.com/ome/omero-web/issues/459