### PR TITLE
OME.formatDate handles null input

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -732,6 +732,9 @@ OME.handleDelete = function(deleteUrl, filesetCheckUrl, userId) {
 
 // Format a date like "2015-06-15 12:08:01"
 OME.formatDate = function formatDate(date) {
+    if (!date) {
+        return "";
+    }
     function padZero(number) {
         var n = "" + number;
         if (n.length < 2) {


### PR DESCRIPTION
Fixes #461.

To test:

 Check various Runs on merge-ci for start/end times. Shouldn't see any `NaN` as in screenshot on issue above.

