### PR TITLE
right panel title

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/includes/name.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/name.html
@@ -18,6 +18,10 @@
 -->
 {% endcomment %}
 
+<!-- allow apps to include custom html -->
+{% block right_panel_title %}
+{% endblock %}
+
 {% if obj.canEdit and not manager.well %}
     <div class="data_heading" id="{{ manager.obj_type }}name-{{ manager.obj_id }}">
         <div>


### PR DESCRIPTION
This allows the right panel of webclient to be customised adding content at the top.

Used by https://github.com/ome/omero-mapr/pull/79