### PR TITLE
Add MultipleFileField to handle and clean multiple files

### DIFF
--- a/omeroweb/webclient/custom_forms.py
+++ b/omeroweb/webclient/custom_forms.py
@@ -379,3 +379,23 @@ class ObjectModelMultipleChoiceField(ObjectModelChoiceField):
                 else:
                     final_values.append(val)
         return final_values
+
+
+# Custom widget and validation for multiple file uploads
+# See https://docs.djangoproject.com/en/3.2/topics/http/file-uploads/#uploading-multiple-files
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+
+class MultipleFileField(forms.FileField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            result = [single_file_clean(d, initial) for d in data]
+        else:
+            result = single_file_clean(data, initial)
+        return result

--- a/omeroweb/webclient/custom_forms.py
+++ b/omeroweb/webclient/custom_forms.py
@@ -382,7 +382,8 @@ class ObjectModelMultipleChoiceField(ObjectModelChoiceField):
 
 
 # Custom widget and validation for multiple file uploads
-# See https://docs.djangoproject.com/en/3.2/topics/http/file-uploads/#uploading-multiple-files
+# See https://docs.djangoproject.com/en/3.2/topics/http/
+# file-uploads/#uploading-multiple-files
 class MultipleFileInput(forms.ClearableFileInput):
     allow_multiple_selected = True
 

--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -63,6 +63,27 @@ help_expire = (
 
 
 #################################################################
+# Custom widget and validation for multiple file uploads
+
+class MultipleFileInput(forms.ClearableFileInput):
+        allow_multiple_selected = True
+
+
+class MultipleFileField(forms.FileField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            result = [single_file_clean(d, initial) for d in data]
+        else:
+            result = single_file_clean(data, initial)
+        return result
+
+
+#################################################################
 # Non-model Form
 
 
@@ -334,9 +355,7 @@ class FilesAnnotationForm(BaseAnnotationForm):
             required=False,
         )
 
-    annotation_file = forms.FileField(
-        widget=forms.ClearableFileInput(attrs={"multiple": True}), required=False
-    )
+    annotation_file = MultipleFileField(required=False)
 
 
 class CommentAnnotationForm(BaseAnnotationForm):

--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -65,8 +65,9 @@ help_expire = (
 #################################################################
 # Custom widget and validation for multiple file uploads
 
+
 class MultipleFileInput(forms.ClearableFileInput):
-        allow_multiple_selected = True
+    allow_multiple_selected = True
 
 
 class MultipleFileField(forms.FileField):

--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -34,6 +34,7 @@ from django.urls import reverse
 
 from omeroweb.custom_forms import NonASCIIForm
 from .custom_forms import MetadataModelChoiceField
+from .custom_forms import MultipleFileField
 from .custom_forms import AnnotationModelMultipleChoiceField
 from .custom_forms import ObjectModelMultipleChoiceField
 from omeroweb.webadmin.custom_forms import ExperimenterModelMultipleChoiceField
@@ -60,28 +61,6 @@ help_expire = (
     " when the share will stop being available. Date format:"
     ' YYYY-MM-DD."><img src="%s" /></span>'
 ) % help_button
-
-
-#################################################################
-# Custom widget and validation for multiple file uploads
-
-
-class MultipleFileInput(forms.ClearableFileInput):
-    allow_multiple_selected = True
-
-
-class MultipleFileField(forms.FileField):
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("widget", MultipleFileInput())
-        super().__init__(*args, **kwargs)
-
-    def clean(self, data, initial=None):
-        single_file_clean = super().clean
-        if isinstance(data, (list, tuple)):
-            result = [single_file_clean(d, initial) for d in data]
-        else:
-            result = single_file_clean(data, initial)
-        return result
 
 
 #################################################################

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
         "concurrent-log-handler>=0.9.20",
-        "Django>=3.2.18,<4.0",
+        "Django>=3.2.19,<4.0",
         "django-pipeline==2.0.7",
         "django-cors-headers==3.7.0",
         "whitenoise>=5.3.0",


### PR DESCRIPTION
Fixes #464

This adds the update suggested at the last link below to conform to the security release below:

https://github.com/ome/omero-web/pull/410
https://www.djangoproject.com/weblog/2023/may/03/security-releases/
https://github.com/django/django/commit/eed53d0011622e70b936e203005f0e6f4ac48965

To test:
 - Build should be green (using latest Django 3.2.19)
 - Multiple file upload should still be working
 - When uploading multiple files to file annotations, ALL files should be validated (e.g. to prevent empty files to be uploaded) instead of only the last file being validated.