### PR TITLE
Avoid the creation of empty file annotations

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2399,7 +2399,9 @@ def annotate_file(request, conn=None, **kwargs):
 
     if request.method == "POST":
         # handle form submission
-        form_file = FilesAnnotationForm(initial=initial, data=request.POST.copy())
+        form_file = FilesAnnotationForm(
+            initial=initial, data=request.POST.copy(), files=request.FILES
+        )
         if form_file.is_valid():
             # Link existing files...
             files = form_file.cleaned_data["files"]

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
         "concurrent-log-handler>=0.9.20",
-        "Django>=3.2.18,<4.0",
+        "Django==3.2.18,<4.0",
         "django-pipeline==2.0.7",
         "django-cors-headers==3.7.0",
         "whitenoise>=5.3.0",


### PR DESCRIPTION
Related to #464 

## Summary 

The default contract of the `FileField` used in the files annotation form is to "validate that non-empty file data has been bound to the form." - see https://docs.djangoproject.com/en/3.2/ref/forms/fields/#django.forms.FileField
Interestingly this check is not happening when adding file annotations. However, the emptiness of the file is definitely checked when uploading a photo in the user settings.

The difference comes from the fact the uploaded files are not bound to the files annotation form. Thus the is_valid() check is largely a no-op and this UI can create annotations with empty files.

This PR fixes this issue by properly binding the uploaded files to the form - see https://docs.djangoproject.com/en/3.2/ref/forms/api/#binding-uploaded-files

## Testing

There are a few scenarios to test here:
- using OMERO.web 5.19.0 and Django 3.2.18, it should be possible to create empty file annotation using the UI. This can be done using the file attachment form and selecting one of multiple files. The annotation should display `0B`
- using this PR and Django 3.2.18, attaching empty files via the dialog UI should be:
   * disallowed when selecting single files
   * disallowed when selecting multiple files with the last selected file being empty
   * allowed when selecting multiple files with the last selected file being non empty - see https://www.djangoproject.com/weblog/2023/may/03/security-releases/.
- using this PR, #465 and Django 3.2.19, the creation of empty file annotations should be disallowed in all cases
