### PR TITLE
Temp setGroupForSession to edit current group

### DIFF
--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -1477,6 +1477,16 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
         """
 
+        temp_switch = False
+        if self.getEventContext().groupId == group.id:
+            # can't update current group
+            temp_switch = True
+            # find a group to temp switch to...
+            gids = [gid for gid in self.getEventContext().memberOfGroups if (gid != 0 and gid != group.id)]
+            if len(gids) == 0:
+                return ["You can't edit your current group!"]
+            self.setGroupForSession(gids[0])
+
         up_gr = group._obj
         up_gr.name = rstring(str(name))
         up_gr.description = (
@@ -1493,6 +1503,9 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             err = self.updatePermissions(group, permissions)
             if err is not None:
                 msgs.append(err)
+
+        if temp_switch:
+            self.revertGroupForSession()
         return msgs
 
     def updateMyAccount(

--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -1482,7 +1482,11 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
             # can't update current group
             temp_switch = True
             # find a group to temp switch to...
-            gids = [gid for gid in self.getEventContext().memberOfGroups if (gid != 0 and gid != group.id)]
+            gids = [
+                gid
+                for gid in self.getEventContext().memberOfGroups
+                if (gid != 0 and gid != group.id)
+            ]
             if len(gids) == 0:
                 return ["You can't edit your current group!"]
             self.setGroupForSession(gids[0])

--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -1480,16 +1480,12 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         temp_switch = False
         if self.getEventContext().groupId == group.id:
             # we can't update the current group
-            # find a group to temp switch to...
-            gids = [
-                gid
-                for gid in self.getEventContext().memberOfGroups
-                if (gid != 0 and gid != group.id)
-            ]
-            if len(gids) == 0:
-                return ["You can't edit your current group!"]
-            self.setGroupForSession(gids[0])
-            temp_switch = True
+            # unless it's the system group (form won't include name change)
+            sys_id = self.getAdminService().getSecurityRoles().systemGroupId
+            if self.getEventContext().groupId != sys_id:
+                # otherwise, temp switch to allow editing of 'current' group
+                self.setGroupForSession(sys_id)
+                temp_switch = True
 
         msgs = []
         try:


### PR DESCRIPTION
Fixes #163.

This uses `setGroupForSession()` to temporarily switch to a different group if a user tries to edit their current group.

To test:
 - To find your default group, use the command line `omero login` as an Admin which will show the name of your current group
 - Log In to web admin, try to edit the name of that group
 - Should work without error