### PR TITLE
Deprecate omeroweb.custom_forms.NonASCIIForm

### DIFF
--- a/omeroweb/custom_forms.py
+++ b/omeroweb/custom_forms.py
@@ -19,6 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import warnings
 from past.builtins import basestring
 from django import forms
 from django.utils.encoding import smart_str
@@ -26,9 +27,14 @@ from django.utils.encoding import smart_str
 from django.forms.utils import ErrorDict, ValidationError
 from django.forms.fields import FileField, CharField
 
+DEPRECATION_MESSAGE = (
+    "This form is deprecated as of OMERO.web 5.21.0. Use Django's" "forms.Form instead."
+)
+
 
 class NonASCIIForm(forms.Form):
     def __init__(self, *args, **kwargs):
+        warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
         super(NonASCIIForm, self).__init__(*args, **kwargs)
 
     def full_clean(self):

--- a/omeroweb/webadmin/forms.py
+++ b/omeroweb/webadmin/forms.py
@@ -33,8 +33,6 @@ from django.forms.widgets import Textarea
 
 from omeroweb.connector import Server
 
-from omeroweb.custom_forms import NonASCIIForm
-
 from .custom_forms import ServerModelChoiceField, GroupModelChoiceField
 from .custom_forms import GroupModelMultipleChoiceField, OmeNameField
 from .custom_forms import ExperimenterModelMultipleChoiceField, MultiEmailField
@@ -45,7 +43,7 @@ logger = logging.getLogger(__name__)
 # Non-model Form
 
 
-class LoginForm(NonASCIIForm):
+class LoginForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(LoginForm, self).__init__(*args, **kwargs)
         self.fields["server"] = ServerModelChoiceField(Server, empty_label=None)
@@ -67,7 +65,7 @@ class LoginForm(NonASCIIForm):
         return self.cleaned_data["username"]
 
 
-class ForgottonPasswordForm(NonASCIIForm):
+class ForgottonPasswordForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(ForgottonPasswordForm, self).__init__(*args, **kwargs)
         self.fields["server"] = ServerModelChoiceField(Server, empty_label=None)
@@ -88,7 +86,7 @@ ROLE_CHOICES = (
 )
 
 
-class ExperimenterForm(NonASCIIForm):
+class ExperimenterForm(forms.Form):
     def __init__(
         self,
         name_check=False,
@@ -324,7 +322,7 @@ PERMISSION_CHOICES = (
 )
 
 
-class GroupForm(NonASCIIForm):
+class GroupForm(forms.Form):
     def __init__(
         self,
         name_check=False,
@@ -448,7 +446,7 @@ class GroupOwnerForm(forms.Form):
     )
 
 
-class MyAccountForm(NonASCIIForm):
+class MyAccountForm(forms.Form):
     def __init__(self, email_check=False, *args, **kwargs):
         super(MyAccountForm, self).__init__(*args, **kwargs)
         self.email_check = email_check
@@ -510,7 +508,7 @@ class MyAccountForm(NonASCIIForm):
         return self.cleaned_data.get("email")
 
 
-class ContainedExperimentersForm(NonASCIIForm):
+class ContainedExperimentersForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(ContainedExperimentersForm, self).__init__(*args, **kwargs)
 
@@ -550,7 +548,7 @@ class UploadPhotoForm(forms.Form):
         return self.cleaned_data.get("photo")
 
 
-class ChangePassword(NonASCIIForm):
+class ChangePassword(forms.Form):
     old_password = forms.CharField(
         max_length=50,
         widget=forms.PasswordInput(attrs={"size": 30, "autocomplete": "off"}),
@@ -581,13 +579,13 @@ class ChangePassword(NonASCIIForm):
                 return self.cleaned_data.get("password")
 
 
-class EnumerationEntry(NonASCIIForm):
+class EnumerationEntry(forms.Form):
     new_entry = forms.CharField(
         max_length=250, widget=forms.TextInput(attrs={"size": 30})
     )
 
 
-class EnumerationEntries(NonASCIIForm):
+class EnumerationEntries(forms.Form):
     def __init__(self, entries, *args, **kwargs):
         super(EnumerationEntries, self).__init__(*args, **kwargs)
         for i, e in enumerate(entries):

--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -32,7 +32,6 @@ from django import forms
 from django.forms.formsets import formset_factory
 from django.urls import reverse
 
-from omeroweb.custom_forms import NonASCIIForm
 from .custom_forms import MetadataModelChoiceField
 from .custom_forms import MultipleFileField
 from .custom_forms import AnnotationModelMultipleChoiceField
@@ -67,11 +66,11 @@ help_expire = (
 # Non-model Form
 
 
-class GlobalSearchForm(NonASCIIForm):
+class GlobalSearchForm(forms.Form):
     search_query = forms.CharField(widget=forms.TextInput(attrs={"size": 25}))
 
 
-class ShareForm(NonASCIIForm):
+class ShareForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(ShareForm, self).__init__(*args, **kwargs)
 
@@ -126,7 +125,7 @@ class ShareForm(NonASCIIForm):
         return self.cleaned_data["expiration"]
 
 
-class ContainerForm(NonASCIIForm):
+class ContainerForm(forms.Form):
     name = forms.CharField(max_length=250, widget=forms.TextInput(attrs={"size": 45}))
     description = forms.CharField(
         widget=forms.Textarea(attrs={"rows": 2, "cols": 49}), required=False
@@ -134,17 +133,17 @@ class ContainerForm(NonASCIIForm):
     owner = forms.CharField(widget=forms.HiddenInput, required=False)
 
 
-class ContainerNameForm(NonASCIIForm):
+class ContainerNameForm(forms.Form):
     name = forms.CharField(max_length=250, widget=forms.TextInput(attrs={"size": 45}))
 
 
-class ContainerDescriptionForm(NonASCIIForm):
+class ContainerDescriptionForm(forms.Form):
     description = forms.CharField(
         widget=forms.Textarea(attrs={"rows": 3, "cols": 39}), required=False
     )
 
 
-class BaseAnnotationForm(NonASCIIForm):
+class BaseAnnotationForm(forms.Form):
     """
     This is the superclass of the various forms used for annotating single or
     multiple objects.


### PR DESCRIPTION
Fixes #468 

The original intent of the NonASCIIForm was to support Unicode strings by overriding the CharField validation. Unicode is now natively supported by the Python/Django stack. This commit proposes to drop our intermediate custom class in favor of upstream `django.forms.Form`. This should incidentally reduce the maintenance burden     when upgrading between Django major versions.
Testing:

All places using the legacy base form should be reviewed with this change using both ASCII strings and Unicode strings as inputs. Below is a list of  endpoints to review

- webadmin:
  -  `/webclient/login/`
  - `/webadmin/forgottenpassword/`  
  - `/webadmin/myaccount/`
  - `/webadmin/experimenter/new`
  - `/webadmin/experimenter/edit/{id}` (including `Change User's Password`)
  - `/webadmin/group/new
  - `/webadmin/group/edit/{id}`
  - `/webclient/search/`
- webclient:
  - container edition (name, description)
  - object annotations (tags, key/value, comment, 