### PR TITLE
Detect and display non-zero returncode from scripts

### DIFF
--- a/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
+++ b/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
@@ -230,7 +230,7 @@
 
 
 
-                <!-- Status -->
+                <!-- Scripts -->
                 {% ifequal j.job_type "script" %}
                     <tr id="{{ j.id }}" class="script{% if j.new %} new_result{% endif %}{% ifequal j.status 'in progress' %} in_progress{% endifequal %}">
 						
@@ -241,21 +241,8 @@
                             
 							{% else %} 
 								{% if j.error %} 
-                                <div class='script_error' title="{{ j.error }}">
+                                <div class='script_error' title="Script failed. Please see error logs">
                                     <img alt="Failed to run script properly" src="{% static "webgateway/img/failed.png" %}" />
-								
-									
-                                    {% comment %}
-                                    <!-- Don't allow submitting now. TODO: launch submit page -->
-                                    <img src="{% static "webclient/image/info16.png" %}"/>
-                                    <input type='submit' title="Send Error as Feeback to the OME team" jobKey="{{ j.key }}"
-                                    {% if j.error_sent %}
-                                        value='Thank you' disabled='true'
-                                    {% else %}
-                                        value='Submit Feedback'
-                                    {% endif %} />
-                                    {% endcomment %}
-									
                                 </div>
 								{% else %}
 								<img alt="Success" src="{% static "webgateway/img/success.png" %}" />

--- a/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
+++ b/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
@@ -230,7 +230,7 @@
 
 
 
-                <!-- Scripts -->
+                <!-- Status -->
                 {% ifequal j.job_type "script" %}
                     <tr id="{{ j.id }}" class="script{% if j.new %} new_result{% endif %}{% ifequal j.status 'in progress' %} in_progress{% endifequal %}">
 						

--- a/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
+++ b/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
@@ -240,7 +240,7 @@
 								<img alt="Running Script" src="{% static "webgateway/img/spinner.gif" %}" />
                             
 							{% else %} 
-								{% if j.error %} 
+								{% if j.returncode and j.returncode > 0 %}
                                 <div class='script_error' title="Script failed. Please see error logs">
                                     <img alt="Failed to run script properly" src="{% static "webgateway/img/failed.png" %}" />
                                 </div>

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3814,7 +3814,7 @@ def activities(request, conn=None, **kwargs):
                         # we can only retrieve this ONCE - must save results
                         results = proc.getResults(0, conn.SERVICE_OPTS)
                         kwargs = {
-                            "status": ("finished" if cb.returncode == 0 else "failed"),
+                            "status": "finished",
                             "failure": cb.returncode,
                         }
                         if cb.returncode != 0:

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3522,6 +3522,14 @@ def update_callback(request, cbString, **kwargs):
         request.session["callback"][cbString][key] = value
 
 
+# Subclass to handle returncode
+class ScriptsCallback(omero.scripts.ProcessCallbackI):
+
+    def processFinished(self, returncode, current=None):
+        super().processFinished(returncode, current)
+        self.returncode = returncode
+
+
 @login_required()
 @render_response()
 def activities(request, conn=None, **kwargs):
@@ -3797,14 +3805,22 @@ def activities(request, conn=None, **kwargs):
                         error=1,
                     )
                     continue
-                cb = omero.scripts.ProcessCallbackI(conn.c, proc)
+                cb = ScriptsCallback(conn.c, proc)
                 # check if we get something back from the handle...
                 if cb.block(0):  # ms.
                     cb.close()
                     try:
                         # we can only retrieve this ONCE - must save results
                         results = proc.getResults(0, conn.SERVICE_OPTS)
-                        update_callback(request, cbString, status="finished")
+                        kwargs = {
+                            "status": ("finished" if cb.returncode == 0 else "failed"),
+                            "failure": cb.returncode,
+                        }
+                        if cb.returncode != 0:
+                            # This 'error' shows failure icon
+                            kwargs["error"] = 1
+                            kwargs["Message"] = "Script failed with Exception"
+                        update_callback(request, cbString, **kwargs)
                         new_results.append(cbString)
                     except Exception:
                         update_callback(

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3818,7 +3818,7 @@ def activities(request, conn=None, **kwargs):
                         if cb.returncode != 0:
                             # This 'error' shows failure icon
                             kwargs["error"] = 1
-                            kwargs["Message"] = "Script failed with Exception"
+                            kwargs["Message"] = f"Script exited with failure. (returncode={ cb.returncode })"
                         update_callback(request, cbString, **kwargs)
                         new_results.append(cbString)
                     except Exception:

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3818,7 +3818,9 @@ def activities(request, conn=None, **kwargs):
                         if cb.returncode != 0:
                             # This 'error' shows failure icon
                             kwargs["error"] = 1
-                            kwargs["Message"] = f"Script exited with failure. (returncode={ cb.returncode })"
+                            kwargs[
+                                "Message"
+                            ] = f"Script exited with failure. (returncode={ cb.returncode })"
                         update_callback(request, cbString, **kwargs)
                         new_results.append(cbString)
                     except Exception:

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3815,11 +3815,9 @@ def activities(request, conn=None, **kwargs):
                         results = proc.getResults(0, conn.SERVICE_OPTS)
                         kwargs = {
                             "status": "finished",
-                            "failure": cb.returncode,
+                            "returncode": cb.returncode,
                         }
                         if cb.returncode != 0:
-                            # This 'error' shows failure icon
-                            kwargs["error"] = 1
                             kwargs["Message"] = (
                                 f"Script exited with failure."
                                 f" (returncode={ cb.returncode })"

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3818,10 +3818,10 @@ def activities(request, conn=None, **kwargs):
                         if cb.returncode != 0:
                             # This 'error' shows failure icon
                             kwargs["error"] = 1
-                            kwargs[
-                                "Message"
-                            ] = (f"Script exited with failure."
-                                 f" (returncode={ cb.returncode })")
+                            kwargs["Message"] = (
+                                f"Script exited with failure."
+                                f" (returncode={ cb.returncode })"
+                            )
                         update_callback(request, cbString, **kwargs)
                         new_results.append(cbString)
                     except Exception:

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3820,7 +3820,8 @@ def activities(request, conn=None, **kwargs):
                             kwargs["error"] = 1
                             kwargs[
                                 "Message"
-                            ] = f"Script exited with failure. (returncode={ cb.returncode })"
+                            ] = (f"Script exited with failure."
+                                 f" (returncode={ cb.returncode })")
                         update_callback(request, cbString, **kwargs)
                         new_results.append(cbString)
                     except Exception:

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3524,7 +3524,6 @@ def update_callback(request, cbString, **kwargs):
 
 # Subclass to handle returncode
 class ScriptsCallback(omero.scripts.ProcessCallbackI):
-
     def processFinished(self, returncode, current=None):
         super().processFinished(returncode, current)
         self.returncode = returncode


### PR DESCRIPTION
This uses the `returncode` returned from running scripts to show the Error icon in Activities dialog:

Feature requested at https://forum.image.sc/t/omero-scripts-fail-icon/81495

To test:
 - Run a script that throws an Exception *after* setting message, e.g. `client.setOutput("Message", rstring("OK so far..."))`
   - The Message will be shown, along with Error status (first result below)
 - Run a script that throws an Exception without setting "Message" (typical behaviour)
   - This will display a message including the `returncode` from the failure.
 - Otherwise working scripts should behave as before (2 other examples below)

![Screenshot 2023-10-18 at 10 24 08](https://github.com/ome/omero-web/assets/900055/be3e6a96-67e7-4e6b-a59f-0d5d403096a9)

The `context` used to render the html page in the example above looks like this:

```
{
  "sizeOfJobs": 4,
  "jobs": [
    {
      "job_type": "script",
      "job_name": "Images From ROIs",
      "start_time": "datetime.datetime(2023, 10, 18, 10, 15, 20, 121058)",
      "status": "finished",
      "returncode": 1,
      "Message": "OK so far...",
      "stderr": 3725,
      "results": {},
      "id": "52dd4857-9ca1-4dd1-ad0b-5a78d3fdd235",
      "key": "ProcessCallback/52dd4857-9ca1-4dd1-ad0b-5a78d3fdd235 -t -e 1.1:tcp -h 172.19.0.4 -p 37387 -t 60000",
      "new": true
    },
    {
      "job_type": "script",
      "job_name": "Dataset To Plate",
      "start_time": "datetime.datetime(2023, 10, 18, 10, 16, 0, 665853)",
      "status": "finished",
      "returncode": 1,
      "Message": "Script exited with failure. (returncode=1)",
      "stderr": 3724,
      "results": {},
      "id": "087c20ed-0617-4931-9ef4-91046bd1181e",
      "key": "ProcessCallback/087c20ed-0617-4931-9ef4-91046bd1181e -t -e 1.1:tcp -h 172.19.0.4 -p 37387 -t 60000"
    },
    {
      "job_type": "script",
      "job_name": "Dataset To Plate",
      "start_time": "datetime.datetime(2023, 10, 18, 10, 15, 20, 121058)",
      "status": "finished",
      "returncode": 0,
      "Message": " New plate created: From_ROIs but could not be attached.",
      "results": {
        "New_Object": {
          "id": 101,
          "type": "Plate",
          "browse_url": "/webclient/userdata/?show=plate-101",
          "name": "From_ROIs"
        }
      },
      "id": "e31c309c-947c-4fa7-a8ff-1471f31a52d1",
      "key": "ProcessCallback/e31c309c-947c-4fa7-a8ff-1471f31a52d1 -t -e 1.1:tcp -h 172.19.0.4 -p 37387 -t 60000"
    },
    {
      "job_type": "script",
      "job_name": "Channel Offsets",
      "start_time": "datetime.datetime(2023, 10, 18, 10, 10, 54, 262510)",
      "status": "finished",
      "returncode": 0,
      "Message": "New image created: P-TRE_10_R3D_D3D.dv_0_offsets.",
      "stdout": 3719,
      "results": {
        "Image": {
          "id": 751,
          "type": "Image",
          "browse_url": "/webclient/userdata/?show=image-751",
          "name": "P-TRE_10_R3D_D3D.dv_0_offsets"
        }
      },
      "id": "6447e666-fc04-42ff-955c-d1cfe2e23035",
      "key": "ProcessCallback/6447e666-fc04-42ff-955c-d1cfe2e23035 -t -e 1.1:tcp -h 172.19.0.4 -p 37387 -t 60000"
    }
  ],
  "inprogress": 0,
  "new_results": 1,
  "new_errors": true,
  "failure": 0
}
```