### PR TITLE
Key value pairs height

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -1009,7 +1009,6 @@
 
     .mapAnnContainer {
         position: relative;
-        max-height: 250px;
         overflow-y: auto;
     }
     .keyValueTable {

--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -553,8 +553,6 @@
         top:6px ;bottom:0px; left:0px; right:0px;
         position: absolute;
         font-size:1.1em;
-        //border-left: solid 1px hsl(210,10%,85%);
-        min-width:240px;
     }
 
     #preview_tab .right_tab_inner {

--- a/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_comment.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_comment.html
@@ -51,4 +51,3 @@
             <div id="comments_container" class="lncomments"></div>
     </div>
     </div>
-    <div class="clear"></div>


### PR DESCRIPTION
See https://forum.image.sc/t/expansion-height-for-key-value-pairs/81548

The removes the restriction on height of the Key-Value Pairs panel, allowing it to expand to show all its content.

Before: (e.g. https://idr.openmicroscopy.org/webclient/?show=image-1884807)

![Screenshot 2023-05-25 at 12 50 11](https://github.com/ome/omero-web/assets/900055/878d01ae-9362-472b-a819-2bfe10083e9a)

After: (e.g. https://merge-ci.openmicroscopy.org/web/webclient/?show=image-18188)

![Screenshot 2023-05-25 at 12 51 05](https://github.com/ome/omero-web/assets/900055/0f17a046-8a66-4401-accc-9de996f7c318)

Also cleaned some commented/invalid CSS and removed an unnecessary element that causes a gap after the Comments pane (see Before screenshot above).

