### PR TITLE
Add additional CSRF setting

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -562,6 +562,16 @@ CUSTOM_SETTINGS_MAPPINGS = {
             "CSRF session cookie impossible."
         ),
     ],
+    "omero.web.csrf_trusted_origins": [
+        "CSRF_TRUSTED_ORIGINS",
+        "[]",
+        json.loads,
+        (
+            "A list of hosts which are trusted origins for unsafe requests. "
+            "When starting with '.', all subdomains are included. "
+            """Example: '[".example.com", "another.example.net"]'"""
+        ),
+    ],
     "omero.web.session_cookie_samesite": [
         "SESSION_COOKIE_SAMESITE",
         "Lax",


### PR DESCRIPTION
Following #471, this PR adds another required setting to make CSRF requests work:

```
omero config set omero.web.csrf_trusted_origins '[".example.com"]'
```

Without this setting, it is not possible to perform cross-domain unsafe HTTP requests (`POST`, `PUT`, and `DELETE`), even if cookies etc. are configured correctly.

Reference:

- https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins