### PR TITLE
add packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Pillow",
         "pytz",
         "portalocker",
+        "packaging",
     ],
     include_package_data=True,
     tests_require=["pytest"],


### PR DESCRIPTION
The dependency must have been removed from a package omero-web already depends on. 
Without packaging, the installation of web apps failed.
The change was made in the job but we might consider adding the dependency at the omero-web level
