### PR TITLE
bump to allow Django 4.0

### DIFF
--- a/omero/plugins/web.py
+++ b/omero/plugins/web.py
@@ -76,7 +76,7 @@ def config_required(func):
                 import django  # NOQA
             except Exception:
                 self.ctx.die(681, "ERROR: Django not installed!")
-            if django.VERSION < (3, 2) or django.VERSION >= (3, 3):
+            if django.VERSION < (3, 2) or django.VERSION >= (4, 1):
                 self.ctx.err(
                     "ERROR: Django version %s is not "
                     "supported!" % django.get_version()

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "omero-py>=5.7.0",
         # minimum requirements for `omero web start`
         "concurrent-log-handler>=0.9.20",
-        "Django>=3.2.19,<4.0",
+        "Django>=3.2.19,<4.1",
         "django-pipeline==2.0.7",
         "django-cors-headers==3.7.0",
         "whitenoise>=5.3.0",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         # minimum requirements for `omero web start`
         "concurrent-log-handler>=0.9.20",
         "Django>=3.2.19,<4.1",
-        "django-pipeline==2.0.7",
+        "django-pipeline==2.1.0",
         "django-cors-headers==3.7.0",
         "whitenoise>=5.3.0",
         "gunicorn>=19.3",


### PR DESCRIPTION
Allow Django 4.0.

This should install Django 4.0 on merge-ci to allow testing of all the web apps.