### PR TITLE
Map contributors to use canonical real names and email addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,9 +9,9 @@ Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <andrew@f08c0cc7-402c-0410-8265-edbaffadc9ce>
-Andrii Iudin <andrii@ebi.ac.uk>
-Brian Loranger <bwzloranger@lifesci.dundee.ac.uk>
-Carlos Neves <carlos@glencoesoftware.com>
+Andrii Iudin <andrii@ebi.ac.uk> andreyyudin <andrii@ebi.ac.uk>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> bwzloranger <bwzloranger@lifesci.dundee.ac.uk>
+Carlos Neves <carlos@glencoesoftware.com> cneves <carlos@glencoesoftware.com>
 Carlos Neves <carlos@glencoesoftware.com> <cneves-x@05709c45-44f0-0310-885b-81a1db45b4a6>
 Carlos Neves <carlos@glencoesoftware.com> <carlos@05709c45-44f0-0310-885b-81a1db45b4a6>
 Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
@@ -20,41 +20,42 @@ Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-8
 Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
 David Stirling <dstirling@glencoesoftware.com> <daves1990@hotmail.co.uk>
-Dominik Lindner <d.lindner@dundee.ac.uk>
+Dominik Lindner <d.lindner@dundee.ac.uk> dominikl <d.lindner@dundee.ac.uk>
 Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@05709c45-44f0-0310-885b-81a1db45b4a6>
-Douglas Russell <douglas.russell@bioch.ox.ac.uk>
+Douglas Russell <douglas.russell@bioch.ox.ac.uk> dpwrussell <douglas.russell@bioch.ox.ac.uk>
 Douglas Russell <douglas.russell@bioch.ox.ac.uk> <douglas_russell@hms.harvard.edu>
 Harald Waxenegger <h.waxenegger@dundee.ac.uk> <harald.waxenegger@gmail.com>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
-Jean-Marie Burel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> Jean-marie Burel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> jburel <j.burel@dundee.ac.uk>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
 Josh Moore <josh@openmicroscopy.org> <josh@05709c45-44f0-0310-885b-81a1db45b4a6>
 Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
 Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
 Josh Moore <josh@openmicroscopy.org> <jmoore@05709c45-44f0-0310-885b-81a1db45b4a6>
-Joshua Ballanco <jballanc@glencoesoftware.com>
-Kenneth Gillen <k.h.gillen@dundee.ac.uk>
-Kyle Balis-West <kyle@glencoesoftware.com>
-Liza Unson <lunson@glencoesoftware.com>
+Joshua Ballanco <jballanc@glencoesoftware.com> Josh Ballanco <jballanc@glencoesoftware.com>
+Kenny Gillen <k.h.gillen@dundee.ac.uk> Kenneth Gillen <k.h.gillen@dundee.ac.uk>
+Kyle Balis-West <kyle@glencoesoftware.com> kyleBalisWest <kyle@glencoesoftware.com>
+Liza Unson <lunson@glencoesoftware.com> Liza <lunson@glencoesoftware.com>
 Luca Lianas <luca.lianas@crs4.it> <lianas@crs4.it>
 Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
 Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
 Muhanad Zahra <muhanad@glencoesoftware.com> <Muhanad.Zahra@outlook.com>
 Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
 Michael Barrett <mtbarrett@mcw.edu> <103449618+barrettMCW@users.noreply.github.com>
-Paul van Schayck <polleke@gmail.com>
-Petr Walczysko <p.walczysko@dundee.ac.uk>
+Paul van Schayck <polleke@gmail.com> pvc-local <polleke@gmail.com>
+Petr Walczysko <p.walczysko@dundee.ac.uk> pwalczysko <p.walczysko@dundee.ac.uk>
 Riad Gozim <r.gozim@dundee.ac.uk> <rgozim@users.noreply.github.com>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@dundee.ac.uk>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@codelibre.net>
 Scott Littlewood <sylittlewood@dundee.ac.uk> <scottlittlewood@gmail.com>
 Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
-Sébastien Simard <ssimard@pasteur.fr>
+Sébastien Simard <ssimard@pasteur.fr> ssimard <ssimard@pasteur.fr>
 Simon Li <spli@dundee.ac.uk> <orpheus+devel@gmail.com>
 Simone Leo <s.z.leo@dundee.ac.uk> <simleo@crs4.it>
-Will Moore <w.moore@dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> William Moore <w.moore@dundee.ac.uk>
 Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>
 Will Moore <w.moore@dundee.ac.uk> <wmoore@05709c45-44f0-0310-885b-81a1db45b4a6>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,60 @@
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk> 
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <aleksandrat@lifesci.dundee.ac.uk> 
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <atarkowska@lifesci.dundee.ac.uk>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <atarkowska@05709c45-44f0-0310-885b-81a1db45b4a6>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@05709c45-44f0-0310-885b-81a1db45b4a6>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <aleksandra-tarkowska@users.noreply.github.com>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@entrypoint.tech>
+Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <andrew@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Andrii Iudin <andrii@ebi.ac.uk>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk>
+Carlos Neves <carlos@glencoesoftware.com>
+Carlos Neves <carlos@glencoesoftware.com> <cneves-x@05709c45-44f0-0310-885b-81a1db45b4a6>
+Carlos Neves <carlos@glencoesoftware.com> <carlos@05709c45-44f0-0310-885b-81a1db45b4a6>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-81a1db45b4a6>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
+Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
+Chris Allan <callan@glencoesoftware.com> <cxallan@05709c45-44f0-0310-885b-81a1db45b4a6>
+David Stirling <dstirling@glencoesoftware.com> <daves1990@hotmail.co.uk>
+Dominik Lindner <d.lindner@dundee.ac.uk>
+Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@05709c45-44f0-0310-885b-81a1db45b4a6>
+Douglas Russell <douglas.russell@bioch.ox.ac.uk>
+Douglas Russell <douglas.russell@bioch.ox.ac.uk> <douglas_russell@hms.harvard.edu>
+Harald Waxenegger <h.waxenegger@dundee.ac.uk> <harald.waxenegger@gmail.com>
+Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
+Jean-Marie Burel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
+Josh Moore <josh@openmicroscopy.org> <josh@05709c45-44f0-0310-885b-81a1db45b4a6>
+Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
+Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
+Josh Moore <josh@openmicroscopy.org> <jmoore@05709c45-44f0-0310-885b-81a1db45b4a6>
+Joshua Ballanco <jballanc@glencoesoftware.com>
+Kenneth Gillen <k.h.gillen@dundee.ac.uk>
+Kyle Balis-West <kyle@glencoesoftware.com>
+Liza Unson <lunson@glencoesoftware.com>
+Luca Lianas <luca.lianas@crs4.it> <lianas@crs4.it>
+Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
+Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
+Muhanad Zahra <muhanad@glencoesoftware.com> <Muhanad.Zahra@outlook.com>
+Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
+Michael Barrett <mtbarrett@mcw.edu> <103449618+barrettMCW@users.noreply.github.com>
+Paul van Schayck <polleke@gmail.com>
+Petr Walczysko <p.walczysko@dundee.ac.uk>
+Riad Gozim <r.gozim@dundee.ac.uk> <rgozim@users.noreply.github.com>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@dundee.ac.uk>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@codelibre.net>
+Scott Littlewood <sylittlewood@dundee.ac.uk> <scottlittlewood@gmail.com>
+Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
+Sébastien Simard <ssimard@pasteur.fr>
+Simon Li <spli@dundee.ac.uk> <orpheus+devel@gmail.com>
+Simone Leo <s.z.leo@dundee.ac.uk> <simleo@crs4.it>
+Will Moore <w.moore@dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> <wmoore@05709c45-44f0-0310-885b-81a1db45b4a6>

--- a/.mailmap
+++ b/.mailmap
@@ -14,11 +14,11 @@ Brian Loranger <bwzloranger@lifesci.dundee.ac.uk>
 Carlos Neves <carlos@glencoesoftware.com>
 Carlos Neves <carlos@glencoesoftware.com> <cneves-x@05709c45-44f0-0310-885b-81a1db45b4a6>
 Carlos Neves <carlos@glencoesoftware.com> <carlos@05709c45-44f0-0310-885b-81a1db45b4a6>
+Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
+Chris Allan <callan@glencoesoftware.com> <cxallan@05709c45-44f0-0310-885b-81a1db45b4a6>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-81a1db45b4a6>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
-Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
-Chris Allan <callan@glencoesoftware.com> <cxallan@05709c45-44f0-0310-885b-81a1db45b4a6>
 David Stirling <dstirling@glencoesoftware.com> <daves1990@hotmail.co.uk>
 Dominik Lindner <d.lindner@dundee.ac.uk>
 Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>


### PR DESCRIPTION
These updates reviews all commits and associates a canonical real name and email address to each individual contributor.  The following rules are used for the construction of the `.mailmap` file:

- for all contributors who were also employees of the University of Dundee of Glencoe Software, the `@dundee.ac.uk` or `@glencoesoftware.com` email address is used as the canonical email address
- for all contributors with an executed CLA, the email address sent via the CLA is used as the canonical address
- for all contributors, the name used in https://www.openmicroscopy.org/teams/ or https://www.openmicroscopy.org/contributors/ is used as the canonical real name.

The `.mailmap` is constructed according to the official [documentation](https://git-scm.com/docs/gitmailmap) using one of the two forms:

```
Proper Name <proper@email.xx> <commit@email.xx>
```
for mapping different email addresses  and
```
Proper Name <proper@email.xx> Commit Name <commit@email.xx>
```
for mapping different real names.

The unique list of commit authors can be generated and reviewing using `git shortlog -se` 

See also https://github.com/ome/openmicroscopy/pull/6349 and https://github.com/ome/bioformats/pull/4026 