### PR TITLE
Use Image.LANCZOS alias rather than Image.ANTIALIAS

### DIFF
--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -89,7 +89,7 @@ def defaultThumbnail(size=(120, 120)):
     if len(size) == 1:
         size = (size[0], size[0])
     img = Image.open(settings.DEFAULT_IMG)
-    img.thumbnail(size, Image.ANTIALIAS)
+    img.thumbnail(size, Image.LANCZOS)
     f = BytesIO()
     img.save(f, "PNG")
     f.seek(0)
@@ -903,7 +903,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         """
 
         img = Image.open(settings.DEFAULT_USER)
-        img.thumbnail((150, 150), Image.ANTIALIAS)
+        img.thumbnail((150, 150), Image.LANCZOS)
         f = BytesIO()
         img.save(f, "PNG")
         f.seek(0)


### PR DESCRIPTION
These aliases are strictly equivalent but the latter has been deprecated in Pillow 9.1 and dropped in Pillow 10 - see https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html

See also https://github.com/ome/omero-py/pull/376