### PR TITLE
Remove left-over is_ajax property

### DIFF
--- a/omeroweb/feedback/views.py
+++ b/omeroweb/feedback/views.py
@@ -99,7 +99,7 @@ def send_feedback(request):
             finally:
                 fileObj.close()
         else:
-            if is_ajax(request.is_ajax):
+            if is_ajax(request):
                 return HttpResponse(
                     "<h1>Thanks for your feedback</h1><p>You may need to"
                     " refresh your browser to recover from the error</p>"


### PR DESCRIPTION
Fixes #494 

`is_ajax` property was accidentally left in https://github.com/ome/omero-web/commit/dfb1462cf30c2ea3f214c55ac55144035255d58f#diff-4858101b4bfcfaf6c55b0a41d15a313d5f9e5422aaa152a57acbe99450194b62L101

