### PR TITLE
Cache script names

### DIFF
--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -320,7 +320,7 @@ class BaseContainer(BaseController):
         Get the file names of all scripts
         """
         now = time.time()
-        if now - BaseContainer._list_scripts_cache_timestamp < 60:
+        if now - BaseContainer._list_scripts_cache_timestamp < 600:
             # cache 10 minutes
             return BaseContainer._list_scripts_cache
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1738,7 +1738,7 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None, **kwa
             context["canExportAsJpg"] = manager.canExportAsJpg(request)
             context["annotationCounts"] = manager.getAnnotationCounts()
             context["tableCountsOnParents"] = manager.countTablesOnParents()
-            figScripts = manager.listFigureScripts()
+            figScripts = manager.listFigureScripts(request=request)
     context["manager"] = manager
 
     if c_type in ("tag", "tagset"):
@@ -2280,7 +2280,7 @@ def batch_annotate(request, conn=None, **kwargs):
     conn.SERVICE_OPTS.setOmeroGroup(groupId)
 
     manager = BaseContainer(conn)
-    figScripts = manager.listFigureScripts(objs)
+    figScripts = manager.listFigureScripts(objs, request=request)
     canExportAsJpg = manager.canExportAsJpg(request, objs)
     filesetInfo = None
     iids = []


### PR DESCRIPTION
The right panel re-fetches all available scripts on every render, which can take a significant amount of time.

This PR adds a very simplistic cache to fetching the script names, still with the following shortcomings:

- still fetching script names at least every 60 seconds.  Since only three script names are checked, and their existence likely never changes over the lifetime of the OMERO installation, a single check on startup with indefinite caching might be possible.
- caching happens in class variables and is specific to this function, so is not reusable. A generic memoizer or cache decorator would be preferable.

@mabruce 