### PR TITLE
Use z-index to ensure centre panel stays behind #trayhandle_left

### DIFF
--- a/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -1024,6 +1024,7 @@ li.menu_back a {
 
 #center_panel {
     left:0px; right:0px; top:0px; bottom:0px;
+	z-index: 0;
 	background:hsl(210,1%,98%);
 	position:absolute;
 	/* I wish that background: hsl(220,8%,16%);*/


### PR DESCRIPTION
Tiny fix for an issue that has been really annoying recently - The drag handle to resize the left panel of webclient is hidden behind the centre panel contents (if the contents takes up more than half the height of the panel).

Before:

![Screenshot 2023-10-23 at 14 12 07](https://github.com/ome/omero-web/assets/900055/9467fb36-730f-403b-a407-aa1c78b78e9a)

After:

![Screenshot 2023-10-23 at 14 12 20](https://github.com/ome/omero-web/assets/900055/f8a805ff-30d9-46c7-bc78-9c52763f7aec)
