### PR TITLE
Inherit annotation support

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -104,7 +104,7 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
             }
 
             // convert objects to json data
-            ajaxdata = {"type": "map"};
+            ajaxdata = {"type": "map", "parents": true};
             for (var i=0; i < objects.length; i++) {
                 var o = objects[i].split(/-(.+)/);
                 if (typeof ajaxdata[o[0]] !== 'undefined') {

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -104,7 +104,7 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
             }
 
             // convert objects to json data
-            ajaxdata = {"type": "map", "parents": "yes"};
+            ajaxdata = {"type": "map", "parents": "true"};
             for (var i=0; i < objects.length; i++) {
                 var o = objects[i].split(/-(.+)/);
                 if (typeof ajaxdata[o[0]] !== 'undefined') {
@@ -148,12 +148,12 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     var anns = data.annotations.map(populate_experimenter);
 
                     var inh_map_annotations = [];
-                    if (data.hasOwnProperty("inherited")){
-                        data.inherited.annotations.forEach(function(ann) {
+                    if (data.hasOwnProperty("parents")){
+                        data.parents.annotations.forEach(function(ann) {
                             ann = populate_experimenter(ann);
                             let class_ = ann.link.parent.class;
                             let id_ = '' + ann.link.parent.id;
-                            children = data.inherited.inheritors[class_][id_];
+                            children = data.parents.lineage[class_][id_];
                             class_ = children[0].class;
                             ann.childClass = class_.substring(0, class_.length - 1);
                             ann.childNames = [];

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -104,7 +104,7 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
             }
 
             // convert objects to json data
-            ajaxdata = {"type": "map", "parents": true};
+            ajaxdata = {"type": "map", "parents": "yes"};
             for (var i=0; i < objects.length; i++) {
                 var o = objects[i].split(/-(.+)/);
                 if (typeof ajaxdata[o[0]] !== 'undefined') {
@@ -151,7 +151,10 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     var inh_anns = [];
                     data.inherited.annotations.forEach(function(ann) {
                         ann = populate_experimenter(ann);
-                        for(j = 0; j < data.inherited.inheritors[ann["id"]].length; j++){
+                        let class_ = ann.link.parent.class;
+                        let id_ = '' + ann.link.parent.id;
+                        children = data.inherited.inheritors[class_][id_];
+                        for(j = 0; j < children.length; j++){
                             // Unpacking the parent annoations for each image
                             let clone_ann = { ...ann };
                             //clone_ann.link.parent.class = clone_ann.link.parent.class.substring(0, class_.length - 1);

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -147,20 +147,24 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     // Populate experimenters within anns
                     var anns = data.annotations.map(populate_experimenter);
 
-
-                    var inh_anns = [];
-                    data.inherited.annotations.forEach(function(ann) {
-                        ann = populate_experimenter(ann);
-                        let class_ = ann.link.parent.class;
-                        let id_ = '' + ann.link.parent.id;
-                        children = data.inherited.inheritors[class_][id_];
-                        for(j = 0; j < children.length; j++){
-                            // Unpacking the parent annoations for each image
-                            let clone_ann = { ...ann };
-                            //clone_ann.link.parent.class = clone_ann.link.parent.class.substring(0, class_.length - 1);
-                            inh_anns.push(clone_ann);
-                        }
-                    });
+                    var inh_map_annotations = [];
+                    if (data.hasOwnProperty("inherited")){
+                        data.inherited.annotations.forEach(function(ann) {
+                            ann = populate_experimenter(ann);
+                            let class_ = ann.link.parent.class;
+                            let id_ = '' + ann.link.parent.id;
+                            children = data.inherited.inheritors[class_][id_];
+                            class_ = children[0].class;
+                            ann.childClass = class_.substring(0, class_.length - 1);
+                            ann.childNames = [];
+                            if (children[0].hasOwnProperty("name")){
+                                for(j = 0; j < children.length; j++){
+                                    ann.childNames.push(children[j].name);
+                                }
+                            }
+                            inh_map_annotations.push(ann);
+                        });
+                    }
 
                     // Sort map anns into 3 lists...
                     var client_map_annotations = [];
@@ -177,22 +181,10 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                         }
                     });
 
-                    var inh_client_map_annotations = [];
-                    var inh_map_annotations = [];
-                    inh_anns.forEach(function(ann){
-                        if (isClientMapAnn(ann)) {
-                            inh_client_map_annotations.push(ann);
-                        } else {
-                            inh_map_annotations.push(ann);
-                        }
-                    });
-
                     if (batchAnn) {
                         my_client_map_annotations = groupDuplicateAnns(my_client_map_annotations);
                         client_map_annotations = groupDuplicateAnns(client_map_annotations);
                         map_annotations = groupDuplicateAnns(map_annotations);
-                        inh_client_map_annotations = groupDuplicateAnns(inh_client_map_annotations);
-                        inh_map_annotations = groupDuplicateAnns(inh_map_annotations);
                     }
 
                     // Update html...
@@ -207,16 +199,14 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     }
                     // In batch_annotate view, we show which object each map is linked to
                     var showParent = batchAnn;
-                    html = html + mapAnnsTempl({'anns': inh_client_map_annotations, 'isInherited': true,
-                        'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
-                    html = html + mapAnnsTempl({'anns': inh_map_annotations, 'isInherited': true,
-                        'showTableHead': false, 'showNs': true, 'clientMapAnn': false, 'showParent': showParent});
                     html = html + mapAnnsTempl({'anns': my_client_map_annotations, 'objCount': objects.length,
                         'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent,
                         'isInherited': false});
                     html = html + mapAnnsTempl({'anns': client_map_annotations, 'isInherited': false,
                         'showTableHead': false, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
                     html = html + mapAnnsTempl({'anns': map_annotations, 'isInherited': false,
+                        'showTableHead': false, 'showNs': true, 'clientMapAnn': false, 'showParent': showParent});
+                    html = html + mapAnnsTempl({'anns': inh_map_annotations, 'isInherited': true,
                         'showTableHead': false, 'showNs': true, 'clientMapAnn': false, 'showParent': showParent});
                     $mapAnnContainer.html(html);
 

--- a/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -36,13 +36,6 @@
               <% } %>
 
                 <span class="tooltip_html" style='display:none'>
-                    <% if (isInherited) { %>
-                      <% if (ann.childNames.length > 1) { %>
-                        You are viewing an annotation inherited by <b><%- ann.childNames.length %></b> <%- ann.childClass %>s<br />
-                      <% } else { %>
-                        You are viewing an inherited annotation<br />
-                      <% } %>
-                    <% } %>
                     <!-- ann.parentNames is a property of grouped annotations -->
                     <% if (ann.parentNames) { %>
                       You are
@@ -70,10 +63,12 @@
                         <% } %>
                     <% } %>
                     <% if (isInherited) { %>
-                        <b>Inherited by:</b><br />
-                        <% _.each(ann.childNames, function(cname) { %>
-                          &nbsp <%- cname %><br />
-                        <% }) %>
+                        <% if (showParent) { %>
+                          <b>Inherited by:</b><br />
+                          <% _.each(ann.childNames, function(cname) { %>
+                            &nbsp <%- cname %><br />
+                          <% }) %>
+                        <% } %>
                       <b>Namespace:</b> <%- ann.ns.slice(0, 50) %><br />
                     <% } %>
                 </span>

--- a/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -10,14 +10,7 @@
             <% if (!ann.id || (ann.permissions.canEdit && clientMapAnn && !isInherited)){ %> editableKeyValueTable <% } %>
             ">
     <thead>
-      <% if (isInherited) { %>
-        <tr">
-          <th colspan="2">
-              <%- (ann.link.parent.class.substring(0, ann.link.parent.class.length - 1) + ":" + ann.link.parent.id  + ":" + ann.link.parent.name).slice(0, 50) %>
-          </th>
-        </tr>
-      <% } %>
-      <% if (showNs && ann.ns) { %>
+      <% if (showNs && ann.ns && !isInherited) { %>
       <tr title="<%- ann.ns %>">
           <th colspan="2">
               <%- ann.ns.slice(0, 50) %>
@@ -27,6 +20,9 @@
       <tr class="tooltip">
           <th colspan="2">
             <% if (ann.id) { %>
+              <% if (isInherited) { %>
+                Added on <%- ann.link.parent.class.substring(0, ann.link.parent.class.length - 1) %> <%- ann.link.parent.name.slice(0, 30) %>
+              <% } else { %>
                 Added by: <%- ann.owner.firstName %> <%- ann.owner.lastName %>
                 <% if (showParent && ann.link.parent.name){ %>
                   <br>
@@ -37,8 +33,14 @@
                   <% } %>
                   <%- ann.parentNames ? (ann.parentNames.length + " objects") : ann.link.parent.name %>
                 <% } %>
+              <% } %>
 
                 <span class="tooltip_html" style='display:none'>
+                    <% if (isInherited) { %>
+                      <% if (ann.childNames.length > 1){ %>
+                        You are viewing annotations inherited by <b><%- ann.childNames.length %></b> <%- ann.childClass %>s
+                      <% } %>
+                    <% } %>
                     <% if (ann.parentNames) { %>
                       You are
                       <% print (ann.permissions.canEdit && clientMapAnn ? 'editing' : 'viewing') %>
@@ -64,6 +66,15 @@
                         <% if (ann.link.date) { %>
                             <br /><b>On:</b> <% print(OME.formatDate(ann.link.date)) %>
                         <% } %>
+                    <% } %>
+                    <% if (isInherited) { %>
+                      <% if (ann.childNames.length > 1) { %>
+                        <br /><b>Inherited by:</b>
+                        <% _.each(ann.childNames, function(cname) { %>
+                          <br />&nbsp <%- cname %>
+                        <% }) %>
+                      <% } %>
+                      <br /><b>Namespace:</b> <%- ann.ns.slice(0, 50) %><br />
                     <% } %>
                 </span>
             <% } else if (objCount && objCount > 1) { %>

--- a/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -7,9 +7,16 @@
             data-added-by="<%= WEBCLIENT.USER.id %>"
         <% } %>
         class="keyValueTable
-            <% if (!ann.id || (ann.permissions.canEdit && clientMapAnn)){ %> editableKeyValueTable <% } %>
+            <% if (!ann.id || (ann.permissions.canEdit && clientMapAnn && !isInherited)){ %> editableKeyValueTable <% } %>
             ">
     <thead>
+      <% if (isInherited) { %>
+        <tr">
+          <th colspan="2">
+              <%- (ann.link.parent.class.substring(0, ann.link.parent.class.length - 1) + ":" + ann.link.parent.id  + ":" + ann.link.parent.name).slice(0, 50) %>
+          </th>
+        </tr>
+      <% } %>
       <% if (showNs && ann.ns) { %>
       <tr title="<%- ann.ns %>">
           <th colspan="2">

--- a/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -37,16 +37,18 @@
 
                 <span class="tooltip_html" style='display:none'>
                     <% if (isInherited) { %>
-                      <% if (ann.childNames.length > 1){ %>
-                        You are viewing annotations inherited by <b><%- ann.childNames.length %></b> <%- ann.childClass %>s
+                      <% if (ann.childNames.length > 1) { %>
+                        You are viewing an annotation inherited by <b><%- ann.childNames.length %></b> <%- ann.childClass %>s<br />
+                      <% } else { %>
+                        You are viewing an inherited annotation<br />
                       <% } %>
                     <% } %>
+                    <!-- ann.parentNames is a property of grouped annotations -->
                     <% if (ann.parentNames) { %>
                       You are
                       <% print (ann.permissions.canEdit && clientMapAnn ? 'editing' : 'viewing') %>
-                      <b><%- ann.parentNames.length %></b> identical Key-Value annotations:
-                    <% } %>
-                    <% if (!ann.parentNames && ann.link) { %>
+                      <b><%- ann.parentNames.length %></b> identical Key-Value annotations:<br />
+                    <% } else if (ann.link) { %>
                         <!-- If single object show e.g. Image ID: (slice ImageI -> Image) -->
                         <b><%- ann.link.parent.class.slice(0, ann.link.parent.class.length-1) %>
                             ID:</b> <%- ann.link.parent.id %><br />
@@ -59,22 +61,20 @@
                         <% }) %>
                     <% } %>
                     <% if (ann.owner) { %>
-                        <b>Owner:</b> <%- ann.owner.firstName %> <%- ann.owner.lastName %>
+                        <b>Owner:</b> <%- ann.owner.firstName %> <%- ann.owner.lastName %><br />
                     <% } %>
                     <% if (ann.link) { %>
-                        <br /><b>Linked by:</b> <%- ann.link.owner.firstName %> <%- ann.link.owner.lastName %>
+                        <b>Linked by:</b> <%- ann.link.owner.firstName %> <%- ann.link.owner.lastName %><br />
                         <% if (ann.link.date) { %>
-                            <br /><b>On:</b> <% print(OME.formatDate(ann.link.date)) %>
+                            <b>On:</b> <% print(OME.formatDate(ann.link.date)) %><br />
                         <% } %>
                     <% } %>
                     <% if (isInherited) { %>
-                      <% if (ann.childNames.length > 1) { %>
-                        <br /><b>Inherited by:</b>
+                        <b>Inherited by:</b><br />
                         <% _.each(ann.childNames, function(cname) { %>
-                          <br />&nbsp <%- cname %>
+                          &nbsp <%- cname %><br />
                         <% }) %>
-                      <% } %>
-                      <br /><b>Namespace:</b> <%- ann.ns.slice(0, 50) %><br />
+                      <b>Namespace:</b> <%- ann.ns.slice(0, 50) %><br />
                     <% } %>
                 </span>
             <% } else if (objCount && objCount > 1) { %>

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -24,6 +24,7 @@ import time
 import pytz
 import omero
 from builtins import bytes
+from collections import defaultdict
 
 from omero.rtypes import rlong, unwrap, wrap
 from django.conf import settings
@@ -2074,3 +2075,113 @@ def marshal_annotations(
     experimenters.sort(key=lambda x: x["id"])
 
     return annotations, experimenters
+
+
+def marshal_lineage(conn,
+                    project_ids=None,
+                    dataset_ids=None,
+                    image_ids=None,
+                    screen_ids=None,
+                    plate_ids=None,
+                    run_ids=None,
+                    well_ids=None):
+
+    def add_refs(ref_, dataset=None, project=None, well=None,
+                 run=None, plate=None, screen=None):
+        def _add_refs(obj_type, obj_id):
+            if obj_id:
+                all_obj_ids[obj_type].add(obj_id)
+                lineage_d[obj_type][obj_id].append(ref_)
+        _add_refs("DatasetI", dataset)
+        _add_refs("ProjectI", project)
+        _add_refs("PlateAcquisitionI", run)
+        _add_refs("WellI", well)
+        _add_refs("PlateI", plate)
+        _add_refs("ScreenI", screen)
+
+    def parse_hql_id(hql_ids):
+        return ("" if x is None else x.getValue() for x in hql_ids)
+
+    requested = {
+        "ImageI": image_ids,
+        "DatasetI": dataset_ids,
+        "ProjectI": project_ids,
+        "PlateAcquisitionI": run_ids,
+        "WellI": well_ids,
+        "PlateI": plate_ids,
+        "ScreenI": screen_ids,
+    }
+
+    child_ref_d = defaultdict(dict)  # Children references dict
+    lineage_d, all_obj_ids = {}, {}  # Result dictionnaries
+    for obj_type in ["ImageI", "DatasetI", "ProjectI", "PlateI",
+                     "PlateAcquisitionI", "WellI", "ScreenI"]:
+        lineage_d[obj_type] = defaultdict(list)
+        all_obj_ids[obj_type] = set(requested[obj_type])
+
+        if len(requested[obj_type]) > 0:
+            for o in conn.getObjects(obj_type[:-1], requested[obj_type]):
+                details = {"id": o.getId(),
+                           "class": obj_type}
+                if obj_type not in ["PlateAcquisitionI", "WellI"]:
+                    details["name"] = o.getName()
+                child_ref_d[obj_type][details["id"]] = details
+
+    service_opts = conn.SERVICE_OPTS.copy()
+    qs = conn.getQueryService()
+    hql_image = ("select img.id, dset.id, pdl.parent.id, smp.well.id,"
+                 " smp.plateAcquisition.id, plt.id, spl.parent.id"
+                 " from Image img"
+                 " left outer join img.datasetLinks dil"
+                 " left outer join dil.parent dset"
+                 " left outer join img.wellSamples smp"
+                 " left outer join dset.projectLinks pdl"
+                 " left outer join smp.well.plate plt"
+                 " left outer join plt.screenLinks spl"
+                 " where img.id in (:ids)")
+
+    hql_wellrun = ("select child_o.id, plt.id, pdl.parent.id"
+                   " from {} child_o"
+                   " join child_o.plate plt"
+                   " left outer join plt.screenLinks pdl"
+                   " where child_o.id in (:ids)")
+
+    hql_dsetplate = ("select child_o.id, opl.parent.id FROM {} child_o"
+                     " left outer join child_o.{}Links opl "
+                     " where child_o.id in (:ids)")
+
+    if len(requested["ImageI"]) > 0:
+        params = omero.sys.ParametersI()
+        params.addIds(requested["ImageI"])
+        for (im, ds, pr,
+             wl, rn, pl, sc) in map(parse_hql_id,
+                                    qs.projection(hql_image,
+                                                  params, service_opts)):
+            ref_ = child_ref_d["ImageI"][im]
+            add_refs(ref_, ds, pr, wl, rn, pl, sc)
+
+    for _type in ["WellI", "PlateAcquisitionI"]:
+        if len(requested[_type]) > 0:
+            params = omero.sys.ParametersI()
+            params.addIds(requested[_type])
+            for ob, pl, sc in map(parse_hql_id,
+                                  qs.projection(hql_wellrun.format(_type[:-1]),
+                                                params, service_opts)):
+                ref_ = child_ref_d[_type][ob]
+                add_refs(ref_, plate=pl, screen=sc)
+
+    for _type, parent_type in zip(["PlateI", "DatasetI"],
+                                  ["screen", "project"]):
+        if len(requested[_type]) > 0:
+            params = omero.sys.ParametersI()
+            params.addIds(requested[_type])
+            for ob, p in map(parse_hql_id,
+                             qs.projection(hql_dsetplate.format(_type[:-1],
+                                                                parent_type),
+                                           params, service_opts)):
+                ref_ = child_ref_d[_type][ob]
+                if _type == "PlateI":
+                    add_refs(ref_, screen=p)
+                else:
+                    add_refs(ref_, project=p)
+    return lineage_d, all_obj_ids

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -2145,7 +2145,7 @@ def marshal_lineage(
                     name = o.getWellPos()
                 else:
                     name = o.getName()
-                    if (obj_type == "PlateAcquisitionI" and name is None):
+                    if obj_type == "PlateAcquisitionI" and name is None:
                         name = f"Run {o.getId()}"
                 details["name"] = name
                 child_ref_d[obj_type][details["id"]] = details

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -2141,8 +2141,13 @@ def marshal_lineage(
         if len(requested[obj_type]) > 0:
             for o in conn.getObjects(obj_type[:-1], requested[obj_type]):
                 details = {"id": o.getId(), "class": obj_type}
-                if obj_type not in ["PlateAcquisitionI", "WellI"]:
-                    details["name"] = o.getName()
+                if obj_type == "WellI":
+                    name = o.getWellPos()
+                else:
+                    name = o.getName()
+                    if (obj_type == "PlateAcquisitionI" and name is None):
+                        name = f"Run {o.getId()}"
+                details["name"] = name
                 child_ref_d[obj_type][details["id"]] = details
 
     service_opts = conn.SERVICE_OPTS.copy()

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1393,7 +1393,9 @@ def api_annotations(request, conn=None, **kwargs):
                 to_query[type_].add(id_)
                 continue
 
-            details = {"id": id_, "class": type_ + "I"}
+            details = {"id": id_, "class": type_ + "I", "name": obj.getName()}
+            if type_ in ["Well", "PlateAcquisition"]:
+                del details["name"]
 
             for p_type, p_ids in get_parentIds_recursive(obj).items():
                 to_query[p_type].update(p_ids)

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1418,9 +1418,7 @@ def api_annotations(request, conn=None, **kwargs):
         limit=limit,
     )
     if not with_parents:
-        return JsonResponse(
-            {"annotations": all_anns, "experimenters": exps}
-        )
+        return JsonResponse({"annotations": all_anns, "experimenters": exps})
 
     anns = []
     inh_anns = {"annotations": [], "inheritors": defaultdict(dict)}

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1368,8 +1368,15 @@ def api_annotations(request, conn=None, **kwargs):
     to_query = defaultdict(set)
     inheritors = defaultdict(lambda: defaultdict(list))
     requested = defaultdict(list)
-    for type_ in ("Image", "Dataset", "Project",
-                  "Well", "Acquisition", "Plate", "Screen"):
+    for type_ in (
+        "Image",
+        "Dataset",
+        "Project",
+        "Well",
+        "Acquisition",
+        "Plate",
+        "Screen",
+    ):
         if type_ == "Acquisition":
             type_ = "PlateAcquisition"
 
@@ -1378,9 +1385,7 @@ def api_annotations(request, conn=None, **kwargs):
             requested[type_].append(id_)
 
             obj = conn.getObject(type_, id_)
-            obj_descr = {"id": id_,
-                         "class": type_+"I",
-                         "name": obj.getName()}
+            obj_descr = {"id": id_, "class": type_ + "I", "name": obj.getName()}
             if type_ == "Well":
                 del obj_descr["name"]
 
@@ -1417,9 +1422,9 @@ def api_annotations(request, conn=None, **kwargs):
             inherited_anns["annotations"].append(ann)
             inherited_anns["inheritors"][int(ann["id"])] = inheritor_l
 
-    return JsonResponse({"annotations": anns,
-                         "inherited": inherited_anns,
-                         "experimenters": exps})
+    return JsonResponse(
+        {"annotations": anns, "inherited": inherited_anns, "experimenters": exps}
+    )
 
 
 @login_required()

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -194,26 +194,6 @@ def validate_redirect_url(url):
     return url
 
 
-def get_parentIds_recursive(obj):
-    """
-    Goes recursively through the object parents list.
-    Returns a dictionary containing a list of parents Id
-    per type.
-    params:
-        - obj: if not in exisiting_d, add and iterate on parents
-    """
-    d = defaultdict(set)
-    if obj.OMERO_CLASS == "WellSample":
-        d["PlateAcquisition"].add(int(obj.getPlateAcquisition().getId()))
-        obj = obj.getParent()  # Jump right away to the Well
-    d[obj.OMERO_CLASS].add(int(obj.getId()))
-
-    for parent in obj.listParents():
-        for k, v in get_parentIds_recursive(parent).items():
-            d[k].update(v)
-    return d
-
-
 ##############################################################################
 # custom index page
 


### PR DESCRIPTION
This PR is to discuss the implementation of support for inherited annotations.

On the webclient api front, this PR include changes to `api_annotations`, which now also includes a field on inherited annotations in the returned JSON:
``` json
{
  "annotations": [],    // list of annotations (no change)
  "experimenters": [],  // list of experimenters (no change)
  "inherited": { // new
      "annotations": [], // list of inherited annotations (no duplicates)
      "inheritors": {}   // annID dictionnary of inheritors. Same style as annotations.link.parent
}
```

To use it, you would have to "unpack" the inherited annotations to populate a list of annotation, one for each matching inheritor. The annotations are then processed normally.

For example, I used this changes to add the results in the main UI of the Key-Value pairs, and look like that (from a dataset object):
![image](https://github.com/ome/omero-web/assets/10853316/2995733f-d464-4693-8383-37545f30957e)

See other example with [parallel PR](https://github.com/ome/omero-figure/pull/525) on support with OMERO.figure

I had to implement a recursive function to list parents of objects, because `obj.getAncestry()` does not go through all links if an image is inside multiple datasets. Was there a better way to do that ?

I hope that it's not too hacky in the way it's implemented. Looking forward from comment / feedback