### PR TITLE
Add Python 3.11 to the testing matrix

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   install:
     name: Install distribution from source
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,6 +14,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Default tox environment when run without `-e`
-envlist = py38, py39, py310
+envlist = py38, py39, py310, py311
 
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel
@@ -21,7 +21,7 @@ deps =
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
-
+    https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231024/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; platform_system=="Linux" and python_version=="3.11"
 
 setenv =
     OMERODIR = {toxinidir}


### PR DESCRIPTION
Consumes the upstream changes released in https://github.com/ome/omero-py/blob/master/CHANGELOG.md#5170-november-2023 to add Python 3.11 support, this should increase the testing coverage of OMERO.web on Python 3.11