### PR TITLE
Add support for ?show=fileset-123

### DIFF
--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -276,7 +276,7 @@ class Show(object):
             params = omero.sys.ParametersI()
             params.addId(attributes["id"])
             params.page(0, 1)
-            query = "select img from Image img where img.fileset.id=:id"
+            query = "select img from Image img where img.fileset.id=:id order by img.id"
             first_image = self.conn.getQueryService().findAllByQuery(
                 query, params, self.conn.SERVICE_OPTS
             )[0]

--- a/omeroweb/webclient/show.py
+++ b/omeroweb/webclient/show.py
@@ -278,7 +278,8 @@ class Show(object):
             params.page(0, 1)
             query = "select img from Image img where img.fileset.id=:id"
             first_image = self.conn.getQueryService().findAllByQuery(
-                query, params, self.conn.SERVICE_OPTS)[0]
+                query, params, self.conn.SERVICE_OPTS
+            )[0]
             first_selected = self.conn.getObject("Image", first_image.id.val)
         else:
             # All other objects can be loaded by type and attributes.


### PR DESCRIPTION
Often it's useful to find Images etc by Fileset, e.g. when an import completes with...

```
...
Other imported objects:
Fileset:6314846

==> Summary
444 files uploaded, 1 fileset created, 1 image imported, 0 errors in 0:13:35.110
```

This PR adds support for `webclient/?show=fileset-6314846`. Since we can't select a Fileset in the webclient, we simply pick a Image from that Fileset, similar to support for `?show=roi-123`.