### PR TITLE
Handle sudo connection in the account view

### DIFF
--- a/omeroweb/webadmin/templates/webadmin/myaccount.html
+++ b/omeroweb/webadmin/templates/webadmin/myaccount.html
@@ -280,9 +280,11 @@
             </div>
 
 
-        <form class="standard_form settings_form" action="{% url 'wamyaccount' "save" %}" method="POST">{% csrf_token %}
+        <form class="standard_form settings_form" action="{% url 'wamyaccount' "save" %}" method="POST"
+          {% if isSudo %} inert {% endif %}
+        >{% csrf_token %}
 
-           <div id="personal_details">
+           <div id="personal_details" {% if isSudo %} style="opacity: 50%;" {% endif %}>
 
                {% for field in form %}
                    {% if field.errors %}<div style="clear:both">{{ field.errors }}</div>{% endif %}
@@ -293,7 +295,7 @@
 
                {% if ldapAuth %}
                <div id="password"><label>LDAP: </label>{{ ldapAuth }}</div>
-               {% elif not isSudo %}
+               {% else %}
 
                <div id="password">
 
@@ -308,9 +310,7 @@
                </div>
                {% endif %}
 
-               {% if not isSudo %}
                <input type="submit" value="{% trans 'Save' %}" />
-               {% endif %}
              </div>
             <div style="clear:both"></div>
        </form>

--- a/omeroweb/webadmin/templates/webadmin/myaccount.html
+++ b/omeroweb/webadmin/templates/webadmin/myaccount.html
@@ -293,7 +293,7 @@
 
                {% if ldapAuth %}
                <div id="password"><label>LDAP: </label>{{ ldapAuth }}</div>
-               {% else %}
+               {% elif not isSudo %}
 
                <div id="password">
 
@@ -308,8 +308,9 @@
                </div>
                {% endif %}
 
-
+               {% if not isSudo %}
                <input type="submit" value="{% trans 'Save' %}" />
+               {% endif %}
              </div>
             <div style="clear:both"></div>
        </form>

--- a/omeroweb/webadmin/views.py
+++ b/omeroweb/webadmin/views.py
@@ -1037,6 +1037,7 @@ def my_account(request, action=None, conn=None, **kwargs):
         isLdapUser,
         hasAvatar,
     ) = prepare_experimenter(conn)
+    isSudo = conn.getEventContext().sudoerId is not None
     try:
         defaultGroupId = defaultGroup.id
     except Exception:
@@ -1092,6 +1093,7 @@ def my_account(request, action=None, conn=None, **kwargs):
     context = {
         "form": form,
         "ldapAuth": isLdapUser,
+        "isSudo": isSudo,
         "experimenter": experimenter,
         "ownedGroups": ownedGroups,
         "password_form": password_form,


### PR DESCRIPTION
Fixes #445

Summary of changes

- expand webadmin.views.my_account to also detect whether the current context was created via sudo
- If the current session was created with sudo, disable the ability to update experimenter properties and password in the UI

To test this PR, follow the authentication workflow described in https://github.com/ome/omero-web/issues/445#issuecomment-1525079385 i.e. 

1. create a session using `--sudo` via the CLI
2. use the session key as the username/password to authenticate using OMERO.web
3. got to the My Account view i.e. click on the user profile then `User settings`

Without this PR, the `Save` and `Change my password` button should be active. Clicking on `Save` should launch the 500 error page with a server `SecurityViolation` of type `Current user is not admin for the given user(s)`. Clicking on `Change my password` will ask for the current user password which is not known in this workflow since the session was created using the principal password.

With this PR, both buttons should be hidden.