### PR TITLE
Fix getAnnotationCounts Acquisition #299

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2312,8 +2312,9 @@ def batch_annotate(request, conn=None, **kwargs):
     context["canDownload"] = manager.canDownload(objs)
     context["template"] = "webclient/annotations/batch_annotate.html"
     context["webclient_path"] = reverse("webindex")
+    objs["plateacquisition"] = objs.pop("acquisition")
     context["annotationCounts"] = manager.getBatchAnnotationCounts(
-        getObjects(request, conn)
+        objs
     )
     return context
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2313,9 +2313,7 @@ def batch_annotate(request, conn=None, **kwargs):
     context["template"] = "webclient/annotations/batch_annotate.html"
     context["webclient_path"] = reverse("webindex")
     objs["plateacquisition"] = objs.pop("acquisition")
-    context["annotationCounts"] = manager.getBatchAnnotationCounts(
-        objs
-    )
+    context["annotationCounts"] = manager.getBatchAnnotationCounts(objs)
     return context
 
 


### PR DESCRIPTION
Fix of https://github.com/ome/omero-web/issues/299

Replace acquisition by plateacquisition expected by manager.getBatchAnnotationCounts

Also reuse the existing objs loaded at the beginning of omeroweb.webclient.views.batch_annotate, as it should stay the same.
Avoid loading the objects twice.