### PR TITLE
Limit number of FileAnnotations retrieved for OMERO.web UI

### DIFF
--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -609,7 +609,7 @@ class BaseContainer(BaseController):
 
         # Perform the full query and limit the results so that we don't get
         # overwhelmed
-        params.page(0, 100)  # offset, limit
+        params.page(0, 500)  # offset, limit
         columns = "fa.id, ofile.name"
         order_by = "ORDER BY ofile.name, fa.id DESC"
         query = self.FILES_BY_OBJECT_QUERY.format(

--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -611,7 +611,7 @@ class BaseContainer(BaseController):
         # overwhelmed
         params.page(0, 100)  # offset, limit
         columns = "fa.id, ofile.name"
-        order_by = "ORDER BY fa.details.updateEvent.time DESC"
+        order_by = "ORDER BY ofile.name, fa.id DESC"
         query = self.FILES_BY_OBJECT_QUERY.format(
             columns=columns,
             parent_type=parent_type,

--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -547,7 +547,7 @@ class BaseContainer(BaseController):
         "    {order_by}"
     )
 
-    def getFilesByObject(self, parent_type=None, parent_ids=None):
+    def getFilesByObject(self, parent_type=None, parent_ids=None, offset=0, limit=100):
         me = (
             (not self.canUseOthersAnns()) and self.conn.getEventContext().userId or None
         )
@@ -609,7 +609,7 @@ class BaseContainer(BaseController):
 
         # Perform the full query and limit the results so that we don't get
         # overwhelmed
-        params.page(0, 500)  # offset, limit
+        params.page(offset, limit)
         columns = "fa.id, ofile.name"
         order_by = "ORDER BY ofile.name, fa.id DESC"
         query = self.FILES_BY_OBJECT_QUERY.format(

--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -539,7 +539,7 @@ class BaseContainer(BaseController):
         "        SELECT 1 FROM {parent_type}AnnotationLink sa_link "
         "            WHERE sa_link.parent.id in (:ids) "
         "                AND fa.id = sa_link.child.id "
-        "                AND fa.ns not in (:ns_to_exclude) "
+        "                AND (fa.ns not in (:ns_to_exclude) OR fa.ns IS NULL)"
         "                {owned_by_me} "
         "            GROUP BY sa_link.child.id "
         "            HAVING count(sa_link.id) >= :count "

--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -620,7 +620,7 @@ class BaseContainer(BaseController):
         )
         rows = q.projection(query, params, self.conn.SERVICE_OPTS)
 
-        logger.warn(f"TOTAL FILES: {total_files}")
+        logger.warning(f"TOTAL FILES: {total_files}")
         return (
             total_files,
             [self.FileAnnotationShim(_id, name) for (_id, name) in rows],

--- a/omeroweb/webclient/templates/webclient/annotations/files_form.html
+++ b/omeroweb/webclient/templates/webclient/annotations/files_form.html
@@ -60,7 +60,10 @@
 
 <p>
     <h1>And/or attach an existing File:</h1>
-    <span>Select the attachments to add (total: {{ total_files }})</span>
+    <span>
+      Select the attachments to add
+      (total: {{ total_files }}{% if total_files > 500 %}, showing 500{% endif %})
+    </span>
     
     <div>{{ form_file.files }}</div>
     <!-- hidden fields used to specify the objects we're tagging -->

--- a/omeroweb/webclient/templates/webclient/annotations/files_form.html
+++ b/omeroweb/webclient/templates/webclient/annotations/files_form.html
@@ -60,7 +60,7 @@
 
 <p>
     <h1>And/or attach an existing File:</h1>
-    <span>Select the attachments to add</span>
+    <span>Select the attachments to add (total: {{ total_files }})</span>
     
     <div>{{ form_file.files }}</div>
     <!-- hidden fields used to specify the objects we're tagging -->

--- a/omeroweb/webclient/templates/webclient/annotations/files_form.html
+++ b/omeroweb/webclient/templates/webclient/annotations/files_form.html
@@ -62,7 +62,7 @@
     <h1>And/or attach an existing File:</h1>
     <span>
       Select the attachments to add
-      (total: {{ total_files }}{% if total_files > 500 %}, showing 500{% endif %})
+      (total: {{ total_files }}{% if total_files > max_files %}, showing {{ max_files }}{% endif %})
     </span>
     
     <div>{{ form_file.files }}</div>

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2385,14 +2385,14 @@ def annotate_file(request, conn=None, **kwargs):
                 return handlerInternalError(request, x)
 
     if manager is not None:
-        files = manager.getFilesByObject()
+        total_files, files = manager.getFilesByObject()
     else:
         manager = BaseContainer(conn)
         for dtype, objs in oids.items():
             if len(objs) > 0:
                 # NB: we only support a single data-type now. E.g. 'image' OR
                 # 'dataset' etc.
-                files = manager.getFilesByObject(
+                total_files, files = manager.getFilesByObject(
                     parent_type=dtype, parent_ids=[o.getId() for o in objs]
                 )
                 break
@@ -2421,7 +2421,7 @@ def annotate_file(request, conn=None, **kwargs):
 
     else:
         form_file = FilesAnnotationForm(initial=initial)
-        context = {"form_file": form_file}
+        context = {"form_file": form_file, "total_files": total_files}
         template = "webclient/annotations/files_form.html"
     context["template"] = template
     return context

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2318,6 +2318,8 @@ def batch_annotate(request, conn=None, **kwargs):
     return context
 
 
+MAX_FILES_IN_FILE_ANNOTATION_DIALOG = 500
+
 @login_required()
 @render_response()
 def annotate_file(request, conn=None, **kwargs):
@@ -2385,7 +2387,10 @@ def annotate_file(request, conn=None, **kwargs):
                 return handlerInternalError(request, x)
 
     if manager is not None:
-        total_files, files = manager.getFilesByObject()
+        total_files, files = manager.getFilesByObject(
+            offset=0,
+            limit=MAX_FILES_IN_FILE_ANNOTATION_DIALOG,
+        )
     else:
         manager = BaseContainer(conn)
         for dtype, objs in oids.items():
@@ -2393,7 +2398,10 @@ def annotate_file(request, conn=None, **kwargs):
                 # NB: we only support a single data-type now. E.g. 'image' OR
                 # 'dataset' etc.
                 total_files, files = manager.getFilesByObject(
-                    parent_type=dtype, parent_ids=[o.getId() for o in objs]
+                    parent_type=dtype,
+                    parent_ids=[o.getId() for o in objs],
+                    offset=0,
+                    limit=MAX_FILES_IN_FILE_ANNOTATION_DIALOG,
                 )
                 break
 
@@ -2421,7 +2429,11 @@ def annotate_file(request, conn=None, **kwargs):
 
     else:
         form_file = FilesAnnotationForm(initial=initial)
-        context = {"form_file": form_file, "total_files": total_files}
+        context = {
+            "form_file": form_file,
+            "total_files": total_files,
+            "max_files": MAX_FILES_IN_FILE_ANNOTATION_DIALOG,
+        }
         template = "webclient/annotations/files_form.html"
     context["template"] = template
     return context

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -2320,6 +2320,7 @@ def batch_annotate(request, conn=None, **kwargs):
 
 MAX_FILES_IN_FILE_ANNOTATION_DIALOG = 500
 
+
 @login_required()
 @render_response()
 def annotate_file(request, conn=None, **kwargs):


### PR DESCRIPTION
Addresses issue #517

The current "Choose attachment" dialog retrieves a list of every `FileAnnotation` not currently linked to the selected object(s) for linking, causing poor performance or failures on systems with a large number of `FileAnnotation`s.

The goal of this PR is to address the potential performance impact only; any other improvements e.g. to the UI should be addressed in separate PRs.

Main discussion points:

### API changes

1. `getFilesByObject` now returns a tuple of the number of total files and a list of `FileAnnotationShim`s; previously the method returned a single list of `FileAnnotation`s. 
2. In case of no objects passed to the controller, `getFilesByObject` previously returned all `FileAnnotation`s, and will now raise a `ValueError`.  This also means `listFileAnnotations` is no longer used and could be deprecated.

### Testing

There are currently no stated expectations to the exact behavior of the "Choose attachment" dialog or the `getFilesByObject` method.  The UI also does not expose all of the available options of the method.  With the large number of permutations of options and object types (and multiple object types, which are not handled), exhaustive testing will be difficult.  Current testing is likely minimal.

- We should document the expected behavior of the "Choose attachment" dialog in the possible situations.
- A testing plan is needed.

Potential pitfalls:
- It is currently possible for multiple users to link the same annotation to the same parent object in a read-annotate group

### Discussion

- What should be the limit on number of `FileAnnotation`s returned?  Currently set to `100`, but suggested to increase to several hundred.
- How should `FileAnnotation`s be sorted? Currently by descending `updateEvent.time`, but suggested to use `name` as previously.
- Indication in the dialog that the results are truncated; space is currently limited, but some indication that not all available annotations are shown is likely needed.
