### PR TITLE
Add some initial CSP settings to test

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1171,8 +1171,8 @@ CUSTOM_SETTINGS_MAPPINGS = {
             "Remember to terminate lines with; when necessary."
         ),
     ],
-    # Content-Security-Protocol settings: https://django-csp.readthedocs.io/en/latest/configuration.html
-    # default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self';base-uri 'self';form-action 'self'
+    # Content-Security-Protocol settings:
+    # see https://django-csp.readthedocs.io/en/latest/configuration.html
     "omero.web.csp_default_src": [
         "CSP_DEFAULT_SRC",
         "[\"'self'\"]",

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -372,7 +372,9 @@ CUSTOM_SETTINGS_MAPPINGS = {
             '{"index": 5, '
             '"class": "django.contrib.messages.middleware.MessageMiddleware"},'
             '{"index": 6, '
-            '"class": "django.middleware.clickjacking.XFrameOptionsMiddleware"}'
+            '"class": "django.middleware.clickjacking.XFrameOptionsMiddleware"},'
+            '{"index": 7, '
+            '"class": "csp.middleware.CSPMiddleware"}'
             "]"
         ),
         json.loads,
@@ -1168,6 +1170,24 @@ CUSTOM_SETTINGS_MAPPINGS = {
             "Lines will be joined with \\n. "
             "Remember to terminate lines with; when necessary."
         ),
+    ],
+
+    # Content-Security-Protocol settings: https://django-csp.readthedocs.io/en/latest/configuration.html
+    # default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self';base-uri 'self';form-action 'self'
+    "omero.web.csp_default_src": [
+        "CSP_DEFAULT_SRC", '["\'self\'"]', json.loads, "Set the CSP default-src directive",
+    ],
+    "omero.web.csp_script_src": [
+        "CSP_SCRIPT_SRC", '["\'self\'"]', json.loads, "Set the CSP script-src directive",
+    ],
+    "omero.web.csp_img_src": [
+        "CSP_IMG_SRC", '["\'self\'"]', json.loads, "Set the CSP img-src directive",
+    ],
+    "omero.web.csp_style_src": [
+        "CSP_STYLE_SRC", '["\'self\'"]', json.loads, "Set the CSP style-src directive",
+    ],
+    "omero.web.csp_base_uri": [
+        "CSP_BASE_URI", '["\'self\'"]', json.loads, "Set the CSP base-uri directive",
     ],
 }
 

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1171,23 +1171,37 @@ CUSTOM_SETTINGS_MAPPINGS = {
             "Remember to terminate lines with; when necessary."
         ),
     ],
-
     # Content-Security-Protocol settings: https://django-csp.readthedocs.io/en/latest/configuration.html
     # default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self';base-uri 'self';form-action 'self'
     "omero.web.csp_default_src": [
-        "CSP_DEFAULT_SRC", '["\'self\'"]', json.loads, "Set the CSP default-src directive",
+        "CSP_DEFAULT_SRC",
+        "[\"'self'\"]",
+        json.loads,
+        "Set the CSP default-src directive",
     ],
     "omero.web.csp_script_src": [
-        "CSP_SCRIPT_SRC", '["\'self\'"]', json.loads, "Set the CSP script-src directive",
+        "CSP_SCRIPT_SRC",
+        "[\"'self'\"]",
+        json.loads,
+        "Set the CSP script-src directive",
     ],
     "omero.web.csp_img_src": [
-        "CSP_IMG_SRC", '["\'self\'"]', json.loads, "Set the CSP img-src directive",
+        "CSP_IMG_SRC",
+        "[\"'self'\"]",
+        json.loads,
+        "Set the CSP img-src directive",
     ],
     "omero.web.csp_style_src": [
-        "CSP_STYLE_SRC", '["\'self\'"]', json.loads, "Set the CSP style-src directive",
+        "CSP_STYLE_SRC",
+        "[\"'self'\"]",
+        json.loads,
+        "Set the CSP style-src directive",
     ],
     "omero.web.csp_base_uri": [
-        "CSP_BASE_URI", '["\'self\'"]', json.loads, "Set the CSP base-uri directive",
+        "CSP_BASE_URI",
+        "[\"'self'\"]",
+        json.loads,
+        "Set the CSP base-uri directive",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "Django>=4.2.3,<4.3",
         "django-pipeline==2.1.0",
         "django-cors-headers==3.7.0",
+        "django-csp",
         "whitenoise>=5.3.0",
         "gunicorn>=19.3",
         "omero-marshal>=0.7.0",


### PR DESCRIPTION
Fixes #21. 

Based initially on reading docs at https://django-csp.readthedocs.io/en/latest/configuration.html and reading
https://blog.sucuri.net/2023/04/how-to-set-up-a-content-security-policy-csp-in-3-steps.html

This picks a handful of the most common settings and adds them to `omeroweb.settings` allowing them to be configured, and using `"'self'"` as the default value.

To test - page shouldn't be able to load images, scripts etc from other domains.