### PR TITLE
Preview viewer uses omero-web-zarr s3 data if available

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -118,7 +118,7 @@
             {% if share and not share.share.isOwned %}
             OME.preview_viewport = $.WeblitzViewport($("#viewport"), "{% url 'webindex' %}{{ share.share.id }}", {'mediaroot': '{{ STATIC_URL }}' } );
             {% else %}
-            OME.preview_viewport = $.WeblitzViewport($("#viewport"), "{% url 'webindex' %}", {'mediaroot': '{{ STATIC_URL }}' } );
+            OME.preview_viewport = $.WeblitzViewport($("#viewport"), '{{ base_url }}', {'mediaroot': '{{ STATIC_URL }}' } );
             {% endif %}
 
             OME.preview_viewport.bind('imageLoad', _refresh_cb);

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1808,16 +1808,17 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None, **kwa
     size_x = manager.image.getSizeX()
     size_y = manager.image.getSizeY()
 
-    base_url = reverse('webindex')
+    base_url = reverse("webindex")
     big_image = (size_x * size_y) > (max_w * max_h)
     if not big_image:
         # if we have omero_web_zarr installed and s3 data is available, we
         # use that as data source for viewer via /zarr/render_image etc.
         try:
             from omero_web_zarr.views import get_zarr_s3_path
+
             zarr_path = get_zarr_s3_path(conn, manager.image.id)
             if zarr_path is not None and zarr_path.startswith("http"):
-                base_url = reverse('omero_web_zarr_index')
+                base_url = reverse("omero_web_zarr_index")
         except ImportError:
             pass
     context["base_url"] = base_url


### PR DESCRIPTION
**Experimental!**

This corresponds to https://github.com/ome/omero-web-zarr/pull/15.
In that `omero-web-zarr` PR, we check whether OME-Zarr data is publicly accessible via s3 URL and if so then we can use that data for `/zarr/render_image/` doing the rendering in python omero-web code rather than using the server.

In this PR, we test for the availability of the `omero-web-zarr` plugin and the public s3 url, and if we have that then the Preview viewer uses `/zarr/` as the `base url`.