### PR TITLE
"Others" annotation display tweaks

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_customanns_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_customanns_pane.js
@@ -85,7 +85,7 @@ var CustomAnnsPane = function CustomAnnsPane($element, opts) {
                     ann.addedBy = [ann.link.owner.id];
                     // convert 'class' to 'type' E.g. XmlAnnotationI to Xml
                     ann.type = ann.class.replace('AnnotationI', '');
-                    var attrs = ['textValue', 'timeValue', 'termValue', 'longValue', 'doubleValue', 'boolValue'];
+                    var attrs = ['name', 'textValue', 'timeValue', 'termValue', 'longValue', 'doubleValue', 'boolValue'];
                     attrs.forEach(function(a){
                         if (ann[a] !== undefined){
                             ann.value = ann[a];

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_customanns_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_customanns_pane.js
@@ -85,7 +85,7 @@ var CustomAnnsPane = function CustomAnnsPane($element, opts) {
                     ann.addedBy = [ann.link.owner.id];
                     // convert 'class' to 'type' E.g. XmlAnnotationI to Xml
                     ann.type = ann.class.replace('AnnotationI', '');
-                    var attrs = ['name', 'textValue', 'timeValue', 'termValue', 'longValue', 'doubleValue', 'boolValue'];
+                    var attrs = ['textValue', 'timeValue', 'termValue', 'longValue', 'doubleValue', 'boolValue'];
                     attrs.forEach(function(a){
                         if (ann[a] !== undefined){
                             ann.value = ann[a];

--- a/omeroweb/webclient/templates/webclient/annotations/custom_ann_tooltip.html
+++ b/omeroweb/webclient/templates/webclient/annotations/custom_ann_tooltip.html
@@ -21,6 +21,7 @@
 
 <span class="tooltip_html" style='display:none'>
     <b>ID:</b> {{ ann.id }}<br />
+    {% if ann.name %}<b>Name:</b> {{ ann.name }}<br />{% endif %}
     {% if ann.ns %}<b>Namespace:</b> {{ ann.ns }}<br />{% endif %}
     {% if ann.description %}<b>Description:</b> {{ ann.description }}<br />{% endif %}
     <b>Owner:</b> {{ ann.getOwner.getFullName }}<br />

--- a/omeroweb/webclient/templates/webclient/annotations/customanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/customanns_underscore.html
@@ -9,8 +9,12 @@
             <div><% print(_.escape((ann.value + "").slice(0, 20))) %>...</div>
             <div class="show_xml">Open in new window</div>
             <div style="display: none"><%- ann.value %></div>
-        <% } else { %>
+        <% } else if (ann.value != null) { %>
             <div><%- ann.value %></div>
+        <% } else if (ann.type === 'List' && ann.name) { %>
+            <div><%- ann.name %></div>
+        <% } else { %>
+            <div>(No data)</div>
         <% } %>
         </div>
 

--- a/omeroweb/webclient/templates/webclient/annotations/customanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/customanns_underscore.html
@@ -17,6 +17,7 @@
         <span class="tooltip_html" style='display:none'>
             <b>ID:</b> <%- ann.id %><br />
             <% if (ann.ns) { %><b>Namespace:</b> <%- ann.ns %><br /><% } %>
+            <% if (ann.name) { %><b>Name:</b> <%- ann.name %><br /><% } %>
             <% if (ann.description) { %><b>Description:</b> <%- ann.description %><br /><% } %>
             <b>Owner:</b> <%- ann.owner.firstName %> <%- ann.owner.lastName %><br />
             <b>Date:</b> <% print(OME.formatDate(ann.date)) %>

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -1885,6 +1885,7 @@ def _marshal_annotation(conn, annotation, link=None):
     ownerId = annotation.details.owner.id.val
     ann["id"] = annotation.id.val
     ann["ns"] = unwrap(annotation.ns)
+    ann["name"] = unwrap(annotation.name)
     ann["description"] = unwrap(annotation.description)
     ann["owner"] = {"id": ownerId}
     creation = annotation.details.creationEvent._time


### PR DESCRIPTION
Lately we've been experimenting with [ListAnnotation](https://omero.readthedocs.io/en/stable/developers/Model/EveryObject.html#omero-model-class-listannotation) objects as a means to group other annotations together. Within OMERO.web's right panel these are apparently displayed under the "Others" section when populating the annotation list.

My understanding is that this section is intended to provide a basic display of miscellaneous or custom annotation types. The display attempts to show an entry for each with the format "Type: Value".

However, for ListAnnotations specifically there is no actual value field associated with them. The end result is this:

<img width="349" alt="Screenshot 2024-02-06 at 09 35 33" src="https://github.com/ome/omero-web/assets/26802537/5cd62a96-3d74-4fa7-b98f-451e53a7cbcb">


To further complicate things, the tooltips providing more details are bound to the value field, meaning that the user cannot see any further details about these annotations. Attach 10 ListAnnotation objects and you'll just see the word "List" 10 times.

To attempt to improve this I've modified the code that handles this to fall back to using the 'name' field if no other value fields are present. This field is common to all annotation types (though optional) and might be a sensible thing to display in the absence of anything else. The result would be:

<img width="349" alt="Screenshot 2024-02-06 at 09 35 15" src="https://github.com/ome/omero-web/assets/26802537/76616be4-67c5-4e2a-93dd-b3349a622b5c">

Having some data in the name field also then restores the ability to view tooltips.

Unfortunately the **webclient json API** for annotations currently seems to return everything except for the name field, I'm not sure why. For the sake of this PR I've added that field to the returned results. Hope that doesn't break anything.

**Testing:** Create ListAnnotations with name/description/namespace info and attach them to an object. Without PR: OMERO.web right panel only shows "List" for each. With PR: Right panel shows "List: [name]". Other BasicAnnotation subtypes should still display their respective values, though their tooltips will now include the "name" field.

