### PR TITLE
get strings from omero.cmd.ERR and omero.CmdError correctly

### DIFF
--- a/omeroweb/webclient/webclient_gateway.py
+++ b/omeroweb/webclient/webclient_gateway.py
@@ -1591,7 +1591,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         try:
             cb = self.c.submit(command, loops=120)
         except omero.CmdError as ex:
-            message = ex.err.message
+            message = str(ex.err)
         finally:
             if cb:
                 cb.close(True)

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -445,7 +445,7 @@ def graphResponseMarshal(conn, rsp):
     rv = {}
     if isinstance(rsp, omero.cmd.ERR):
         rsp_params = ", ".join(["%s: %s" % (k, v) for k, v in rsp.parameters.items()])
-        rv["error"] = rsp.message
+        rv["error"] = str(rsp.category)
         rv["report"] = "%s %s" % (rsp.name, rsp_params)
     else:
         included = rsp.responses[0].includedObjects


### PR DESCRIPTION
Fixes #481 

This fixes 2 similar bugs where we're handling `omero.CmdError` or `omero.cmd.ERR` objects and converting into strings.

Both were previously failing with `AttributeError: 'ERR' object has no attribute 'message'`.

Changes based on using the appropriate attributes as tested at https://github.com/ome/omero-web/issues/481#issuecomment-1959903979

