### PR TITLE
Img data json django32

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -44,6 +44,7 @@ from time import time
 
 from omeroweb.version import omeroweb_buildyear as build_year
 from omeroweb.version import omeroweb_version as omero_version
+from omeroweb.webgateway.util import get_rendering_def
 
 import omero
 import omero.scripts
@@ -1773,7 +1774,8 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None, **kwa
 
     allRdefs = manager.image.getAllRenderingDefs()
     rdefs = {}
-    rdefId = manager.image.getRenderingDefId()
+    rdef = get_rendering_def(manager.image)
+    rdefId = rdef["id"] if rdef is not None else None
     # remove duplicates per user
     for r in allRdefs:
         ownerId = r["owner"]["id"]

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -64,8 +64,10 @@ def getChannelsNoRe(image):
                 left outer join fetch c.statsInfo
                 where p.id=:id"""
     pixels = conn.getQueryService().findByQuery(query, params, conn.SERVICE_OPTS)
-    return [ChannelWrapper(conn, c, idx=n, img=image)
-            for n, c in enumerate(pixels.iterateChannels())]
+    return [
+        ChannelWrapper(conn, c, idx=n, img=image)
+        for n, c in enumerate(pixels.iterateChannels())
+    ]
 
 
 def eventContextMarshal(event_context):
@@ -113,7 +115,8 @@ def getPixelRange(image):
         PixelsTypeint32: -2147483648,
         PixelsTypeuint32: 0,
         PixelsTypefloat: -2147483648,
-        PixelsTypedouble: -2147483648}
+        PixelsTypedouble: -2147483648,
+    }
     maxVals = {
         PixelsTypeint8: 127,
         PixelsTypeuint8: 255,
@@ -122,7 +125,8 @@ def getPixelRange(image):
         PixelsTypeint32: 2147483647,
         PixelsTypeuint32: 4294967295,
         PixelsTypefloat: 2147483647,
-        PixelsTypedouble: 2147483647}
+        PixelsTypedouble: 2147483647,
+    }
     pixtype = image.getPrimaryPixels().getPixelsType().getValue()
     return [minVals[pixtype], maxVals[pixtype]]
 
@@ -145,7 +149,7 @@ def rdefMarshal(rdef, image, pixel_range):
 
     channels = []
 
-    for rdef_ch, channel in zip(rdef['c'], getChannelsNoRe(image)):
+    for rdef_ch, channel in zip(rdef["c"], getChannelsNoRe(image)):
 
         chan = {
             "emissionWave": channel.getEmissionWave(),
@@ -230,7 +234,7 @@ def get_rendering_def(image, rsp_dict):
         if load_re(image, rsp_dict):
             rdefs = image.getAllRenderingDefs(exp_id)
     # otherwise use owners
-    if len(rdefs) == 0:  
+    if len(rdefs) == 0:
         owner_id = image.getDetails().getOwner().id
         if owner_id != exp_id:
             rdefs = image.getAllRenderingDefs(owner_id)
@@ -389,7 +393,9 @@ def imageMarshal(image, key=None, request=None):
         if tiles:
             width, height = image._re.getTileSize()
             zoomLevelScaling = image.getZoomLevelScaling()
-            rv.update({"tile_size": {"width": width, "height": height}, "levels": levels})
+            rv.update(
+                {"tile_size": {"width": width, "height": height}, "levels": levels}
+            )
             if zoomLevelScaling is not None:
                 rv["zoomLevelScaling"] = zoomLevelScaling
 

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -355,9 +355,19 @@ def imageMarshal(image, key=None, request=None):
     # If image is big - need to load RE to get resolution levels
     # NB: some small images like OME-Zarr can have pyramids
     # but these will be ignored
-    if not image.requiresPixelsPyramid():
+
+    # TEMP - for A/B/C testing based on image ID
+    starttime = datetime.now()
+    big_image = (rv["size"]["width"] * rv["size"]["height"]) > (3000 * 3000)
+    rv["tile_ABC"] = image.id % 3
+    if image.id % 3 == 0 and not big_image:
         rv["tiles"] = False
+        rv["tiles_test"] = "No"
+    elif image.id % 3 == 1 and not image.requiresPixelsPyramid():
+        rv["tiles"] = False
+        rv["tiles_test"] = "requiresPixelsPyramid"
     else:
+        rv["tiles_test"] = "re.getResolutionLevels"
         if load_re(image, rv):
             levels = image._re.getResolutionLevels()
             tiles = levels > 1
@@ -373,6 +383,7 @@ def imageMarshal(image, key=None, request=None):
             if init_zoom < 0:
                 init_zoom = levels + init_zoom
     rv["init_zoom"] = init_zoom
+    rv["tiles_time"] = str(datetime.now() - starttime)
 
     if key is not None and rv is not None:
         for k in key.split("."):

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -355,19 +355,9 @@ def imageMarshal(image, key=None, request=None):
     # If image is big - need to load RE to get resolution levels
     # NB: some small images like OME-Zarr can have pyramids
     # but these will be ignored
-
-    # TEMP - for A/B/C testing based on image ID
-    starttime = datetime.now()
-    big_image = (rv["size"]["width"] * rv["size"]["height"]) > (3000 * 3000)
-    rv["tile_ABC"] = image.id % 3
-    if image.id % 3 == 0 and not big_image:
+    if not image.requiresPixelsPyramid():
         rv["tiles"] = False
-        rv["tiles_test"] = "No"
-    elif image.id % 3 == 1 and not image.requiresPixelsPyramid():
-        rv["tiles"] = False
-        rv["tiles_test"] = "requiresPixelsPyramid"
     else:
-        rv["tiles_test"] = "re.getResolutionLevels"
         if load_re(image, rv):
             levels = image._re.getResolutionLevels()
             tiles = levels > 1
@@ -383,7 +373,6 @@ def imageMarshal(image, key=None, request=None):
             if init_zoom < 0:
                 init_zoom = levels + init_zoom
     rv["init_zoom"] = init_zoom
-    rv["tiles_time"] = str(datetime.now() - starttime)
 
     if key is not None and rv is not None:
         for k in key.split("."):

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -173,7 +173,7 @@ def imageMarshal(image, key=None, request=None):
     """
     get_resolution_levels = True
     if request is not None:
-        get_res = request.GET.get("get_resolution_levels", "")
+        get_res = request.GET.get("resolution_levels", "")
         if get_res.lower() == "false":
             get_resolution_levels = False
 

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -30,6 +30,7 @@ from omero.model.enums import PixelsTypeuint16, PixelsTypeint32
 from omero.model.enums import PixelsTypeuint32, PixelsTypefloat
 from omero.model.enums import PixelsTypedouble
 
+from omero.gateway import ChannelWrapper
 from omero.rtypes import unwrap
 from omero_marshal import get_encoder
 
@@ -40,8 +41,6 @@ INSIGHT_POINT_LIST_RE = re.compile(r"points\[([^\]]+)\]")
 
 # OME model point list regular expression
 OME_MODEL_POINT_LIST_RE = re.compile(r"([\d.]+),([\d.]+)")
-
-from omero.gateway import ChannelWrapper
 
 
 def getChannelsNoRe(image):

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -355,7 +355,7 @@ def imageMarshal(image, key=None, request=None):
     # NB: some small images like OME-Zarr can have pyramids
     # but these will be ignored
 
-    # TEMP - for A/B testing only use size test if ID is odd number!
+    # TEMP - for A/B testing only use size test if ID is EVEN number!
     if image.id % 2 == 0 and not image.requiresPixelsPyramid():
         rv["tiles"] = False
     else:

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -229,7 +229,7 @@ def get_rendering_def(image, rsp_dict):
     # Try to get user's rendering def
     exp_id = image._conn.getUserId()
     rdefs = image.getAllRenderingDefs(exp_id)
-    if len(rdefs) == 0 and image.canAnnotate():
+    if len(rdefs) == 0:
         # try to create our own rendering settings
         if load_re(image, rsp_dict):
             rdefs = image.getAllRenderingDefs(exp_id)

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -351,22 +351,28 @@ def imageMarshal(image, key=None, request=None):
         rv = None
         raise
 
-    # big images
-    if load_re(image, rv):
-        levels = image._re.getResolutionLevels()
-        tiles = levels > 1
-        rv["tiles"] = tiles
-        if tiles:
-            width, height = image._re.getTileSize()
-            zoomLevelScaling = image.getZoomLevelScaling()
-            rv.update(
-                {"tile_size": {"width": width, "height": height}, "levels": levels}
-            )
-            if zoomLevelScaling is not None:
-                rv["zoomLevelScaling"] = zoomLevelScaling
+    # If image is big - need to load RE to get resolution levels
+    # NB: some small images like OME-Zarr can have pyramids
+    # but these will be ignored
 
-        if init_zoom < 0:
-            init_zoom = levels + init_zoom
+    # TEMP - for A/B testing only use size test if ID is odd number!
+    if image.id % 2 == 0 and not image.requiresPixelsPyramid():
+        rv["tiles"] = False
+    else:
+        if load_re(image, rv):
+            levels = image._re.getResolutionLevels()
+            tiles = levels > 1
+            rv["tiles"] = tiles
+            if tiles:
+                width, height = image._re.getTileSize()
+                zoomLevelScaling = image.getZoomLevelScaling()
+                rv.update(
+                    {"tile_size": {"width": width, "height": height}, "levels": levels}
+                )
+                if zoomLevelScaling is not None:
+                    rv["zoomLevelScaling"] = zoomLevelScaling
+            if init_zoom < 0:
+                init_zoom = levels + init_zoom
     rv["init_zoom"] = init_zoom
 
     if key is not None and rv is not None:

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -208,7 +208,6 @@ def channelMarshal(channel):
     return chan
 
 
-
 def imageMarshal(image, key=None, request=None):
     """
     return a dict with pretty much everything we know and care about an image,

--- a/omeroweb/webgateway/util.py
+++ b/omeroweb/webgateway/util.py
@@ -23,6 +23,9 @@ import zipfile
 import shutil
 import logging
 
+import omero
+import traceback
+
 try:
     import long
 except ImportError:
@@ -238,3 +241,38 @@ def points_string_to_XY_list(string):
         x, y = xy.split(",")
         xyList.append((float(x.strip()), float(y.strip())))
     return xyList
+
+
+def load_re(image, rsp_dict=None):
+    rsp_dict = {} if rsp_dict is None else rsp_dict
+    reOK = False
+    try:
+        reOK = image._prepareRenderingEngine()
+        if not reOK:
+            # rsp_dict["Error"] = "Failed to prepare Rendering Engine for imageMarshal"
+            logger.debug("Failed to prepare Rendering Engine for imageMarshal")
+    except omero.ConcurrencyException as ce:
+        backOff = ce.backOff
+        # rsp_dict["ConcurrencyException"] = {"backOff": backOff}
+    except Exception as ex:  # Handle everything else.
+        # rsp_dict["Exception"] = ex.message
+        logger.error(traceback.format_exc())
+    return reOK
+
+
+def get_rendering_def(image, rsp_dict=None):
+    # rsp_dict allows errors to be added
+    # Try to get user's rendering def
+    exp_id = image._conn.getUserId()
+    rdefs = image.getAllRenderingDefs(exp_id)
+    if len(rdefs) == 0:
+        # try to create our own rendering settings
+        if load_re(image, rsp_dict):
+            rdefs = image.getAllRenderingDefs(exp_id)
+    # otherwise use owners
+    if len(rdefs) == 0:
+        owner_id = image.getDetails().getOwner().id
+        if owner_id != exp_id:
+            rdefs = image.getAllRenderingDefs(owner_id)
+
+    return rdefs[0] if len(rdefs) > 0 else None

--- a/omeroweb/webgateway/util.py
+++ b/omeroweb/webgateway/util.py
@@ -249,13 +249,13 @@ def load_re(image, rsp_dict=None):
     try:
         reOK = image._prepareRenderingEngine()
         if not reOK:
-            # rsp_dict["Error"] = "Failed to prepare Rendering Engine for imageMarshal"
+            rsp_dict["Error"] = "Failed to prepare Rendering Engine for imageMarshal"
             logger.debug("Failed to prepare Rendering Engine for imageMarshal")
     except omero.ConcurrencyException as ce:
         backOff = ce.backOff
-        # rsp_dict["ConcurrencyException"] = {"backOff": backOff}
+        rsp_dict["ConcurrencyException"] = {"backOff": backOff}
     except Exception as ex:  # Handle everything else.
-        # rsp_dict["Exception"] = ex.message
+        rsp_dict["Exception"] = ex.message
         logger.error(traceback.format_exc())
     return reOK
 


### PR DESCRIPTION
This is identical to #536, except this is based off v5.22.1 and so is compatible with Django 3.2.

# Performance testing

NB: this PR includes TEMP A/B testing

- A) Images with EVEN numbered IDs: - we check the size of the image and only load rendering engine for resolution levels if it's BIG
- B) images with ODD numbered IDs - we ALWAYS load the rendering engine to check `re.requiresPixelsPyramid()`, if so, we also load resolution levels.

I would expect A (EVEN numbers) to be faster for small images BUT it seems that B is faster?!?! Possibly because the size threshold is using config service to get the BIG image limit.

# Memo file requirement

I had hoped that by checking image size, small images (EVEN IDs) would NOT need to read memo file in order to load `imgData` (required for iviewer right panel).

BUT, seems that the `imgData` won't load for e.g. idr0090 images where memo file is missing. e.g. https://idr-testing.openmicroscopy.org/webclient/imgData/12542998/ (504 timeout).
