### PR TITLE
Add 'django.template.context_processors.request' to TEMPLATES

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -1551,6 +1551,7 @@ TEMPLATES = [
                 "django.template.context_processors.i18n",
                 "django.template.context_processors.media",
                 "django.template.context_processors.static",
+                "django.template.context_processors.request",
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
                 "omeroweb.custom_context_processor.url_suffix",


### PR DESCRIPTION
See discussion from https://forum.image.sc/t/microscope-metrics-under-development/91624/8 onwards.

It seems that some Django apps expect this context processor to be in settings, and indeed it is present in the default django settings - see:
https://docs.djangoproject.com/en/4.2/ref/templates/api/#using-requestcontext

Without this, the app discussed above needs to hard-code this setting by writing to the `settings.py` before deployment in Docker - see https://github.com/Wapaa/OMERO-metrics/blob/5f4bc180431703973558d8176614f4c605b5e2b0/test/omero-web/Dockerfile#L13
