### PR TITLE
Don't overwrite kwargs in activities json

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3851,16 +3851,16 @@ def activities(request, conn=None, **kwargs):
                     try:
                         # we can only retrieve this ONCE - must save results
                         results = proc.getResults(0, conn.SERVICE_OPTS)
-                        kwargs = {
+                        update_kwargs = {
                             "status": "finished",
                             "returncode": cb.returncode,
                         }
                         if cb.returncode != 0:
-                            kwargs["Message"] = (
+                            update_kwargs["Message"] = (
                                 f"Script exited with failure."
                                 f" (returncode={cb.returncode})"
                             )
-                        update_callback(request, cbString, **kwargs)
+                        update_callback(request, cbString, **update_kwargs)
                         new_results.append(cbString)
                     except Exception:
                         update_callback(


### PR DESCRIPTION
Reported at https://github.com/ome/omero-figure/issues/545

This fixes a bug introduced in #474, the `kwargs` parameter overwrites the `kwargs` from the function `def activities(request, conn=None, **kwargs):` causing various issues.

E.g. the detection of `json` template fails at https://github.com/ome/omero-web/blob/4d8d25ef7528e49cadfb5b777a47f6953c198fba/omeroweb/webclient/views.py#L3930 so the format of the JSON returned to OMERO.figure is broken, as reported above.

To test:
 - Open the developer Console in your browser
 - Export a figure from OMERO.figure
 - Check that the export completes and the Download button is shown with no errors in the Console