### PR TITLE
Fix image path resolution in ome.chgrp.js

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.chgrp.js
@@ -89,10 +89,10 @@ $(function() {
     };
 
     var permsIcon = function(perms) {
-        if (perms.write) return static_url + "/image/group_green16.png";
-        if (perms.annotate) return static_url + "/image/group_orange16.png";
-        if (perms.read) return static_url + "/image/group_red16.png";
-        return static_url + "/image/personal16.png";
+        if (perms.write) return static_url + "image/group_green16.png";
+        if (perms.annotate) return static_url + "image/group_orange16.png";
+        if (perms.read) return static_url + "image/group_red16.png";
+        return static_url + "image/personal16.png";
     };
 
     var checkFilesetSplit = function checkFilesetSplit () {


### PR DESCRIPTION
As currently implemented, the logic creates a double `//` (e.g. `/static/webclient//image/group_orange16.png`) which is rendering as a broken image. 