### PR TITLE
imgData JSON with no stateful services

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -44,6 +44,7 @@ from time import time
 
 from omeroweb.version import omeroweb_buildyear as build_year
 from omeroweb.version import omeroweb_version as omero_version
+from omeroweb.webgateway.util import get_rendering_def
 
 import omero
 import omero.scripts
@@ -1773,7 +1774,8 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None, **kwa
 
     allRdefs = manager.image.getAllRenderingDefs()
     rdefs = {}
-    rdefId = manager.image.getRenderingDefId()
+    rdef = get_rendering_def(manager.image)
+    rdefId = rdef["id"] if rdef is not None else None
     # remove duplicates per user
     for r in allRdefs:
         ownerId = r["owner"]["id"]

--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -25,8 +25,16 @@ import logging
 import traceback
 from future.utils import isbytes, bytes_to_native_str
 
+from omero.model.enums import PixelsTypeint8, PixelsTypeuint8, PixelsTypeint16
+from omero.model.enums import PixelsTypeuint16, PixelsTypeint32
+from omero.model.enums import PixelsTypeuint32, PixelsTypefloat
+from omero.model.enums import PixelsTypedouble
+
+from omero.gateway import ChannelWrapper
 from omero.rtypes import unwrap
 from omero_marshal import get_encoder
+
+from .util import get_rendering_def
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +43,32 @@ INSIGHT_POINT_LIST_RE = re.compile(r"points\[([^\]]+)\]")
 
 # OME model point list regular expression
 OME_MODEL_POINT_LIST_RE = re.compile(r"([\d.]+),([\d.]+)")
+
+
+def getChannelsNoRe(image):
+    """
+    Returns a list of Channels.
+
+    This differs from image.getChannels(noRE=True) in that we load statsInfo
+    here which is used by channel.getWindowMin() and channel.getWindowMax()
+
+    :return:    Channels
+    :rtype:     List of :class:`ChannelWrapper`
+    """
+
+    conn = image._conn
+    pid = image.getPixelsId()
+    params = omero.sys.ParametersI()
+    params.addId(pid)
+    query = """select p from Pixels p join fetch p.channels as c
+                join fetch c.logicalChannel as lc
+                left outer join fetch c.statsInfo
+                where p.id=:id"""
+    pixels = conn.getQueryService().findByQuery(query, params, conn.SERVICE_OPTS)
+    return [
+        ChannelWrapper(conn, c, idx=n, img=image)
+        for n, c in enumerate(pixels.iterateChannels())
+    ]
 
 
 def eventContextMarshal(event_context):
@@ -71,6 +105,77 @@ def eventContextMarshal(event_context):
     ctx["groupPermissions"] = encoder.encode(perms)
 
     return ctx
+
+
+def getPixelRange(image):
+    minVals = {
+        PixelsTypeint8: -128,
+        PixelsTypeuint8: 0,
+        PixelsTypeint16: -32768,
+        PixelsTypeuint16: 0,
+        PixelsTypeint32: -2147483648,
+        PixelsTypeuint32: 0,
+        PixelsTypefloat: -2147483648,
+        PixelsTypedouble: -2147483648,
+    }
+    maxVals = {
+        PixelsTypeint8: 127,
+        PixelsTypeuint8: 255,
+        PixelsTypeint16: 32767,
+        PixelsTypeuint16: 65535,
+        PixelsTypeint32: 2147483647,
+        PixelsTypeuint32: 4294967295,
+        PixelsTypefloat: 2147483647,
+        PixelsTypedouble: 2147483647,
+    }
+    pixtype = image.getPrimaryPixels().getPixelsType().getValue()
+    return [minVals[pixtype], maxVals[pixtype]]
+
+
+def getWindowMin(channel):
+    si = channel._obj.getStatsInfo()
+    if si is None:
+        return None
+    return si.getGlobalMin().val
+
+
+def getWindowMax(channel):
+    si = channel._obj.getStatsInfo()
+    if si is None:
+        return None
+    return si.getGlobalMax().val
+
+
+def rdefMarshal(rdef, image, pixel_range):
+
+    channels = []
+
+    for rdef_ch, channel in zip(rdef["c"], getChannelsNoRe(image)):
+
+        chan = {
+            "emissionWave": channel.getEmissionWave(),
+            "label": channel.getLabel(),
+            "color": rdef_ch["color"],
+            # 'reverseIntensity' is deprecated. Use 'inverted'
+            "inverted": rdef_ch["inverted"],
+            "reverseIntensity": rdef_ch["inverted"],
+            "family": rdef_ch["family"],
+            "coefficient": rdef_ch["coefficient"],
+            "active": rdef_ch["active"],
+        }
+
+        chan["window"] = {
+            "min": getWindowMin(channel) or pixel_range[0],
+            "max": getWindowMax(channel) or pixel_range[1],
+            "start": rdef_ch["start"],
+            "end": rdef_ch["end"],
+        }
+
+        lut = channel.getLut()
+        if lut and len(lut) > 0:
+            chan["lut"] = lut
+        channels.append(chan)
+    return channels
 
 
 def channelMarshal(channel):
@@ -114,6 +219,7 @@ def imageMarshal(image, key=None, request=None):
     @return:        Dict
     """
 
+    # projection / invertAxis etc from annotation
     image.loadRenderOptions()
     pr = image.getProject()
     ds = None
@@ -165,11 +271,9 @@ def imageMarshal(image, key=None, request=None):
             "canLink": image.canLink(),
         },
     }
+    reOK = False
     try:
         reOK = image._prepareRenderingEngine()
-        if not reOK:
-            logger.debug("Failed to prepare Rendering Engine for imageMarshal")
-            return rv
     except omero.ConcurrencyException as ce:
         backOff = ce.backOff
         rv = {"ConcurrencyException": {"backOff": backOff}}
@@ -180,8 +284,10 @@ def imageMarshal(image, key=None, request=None):
         return rv  # Return what we have already, in case it's useful
 
     # big images
-    levels = image._re.getResolutionLevels()
-    tiles = levels > 1
+    tiles = False
+    if reOK:
+        levels = image._re.getResolutionLevels()
+        tiles = levels > 1
     rv["tiles"] = tiles
     if tiles:
         width, height = image._re.getTileSize()
@@ -240,15 +346,20 @@ def imageMarshal(image, key=None, request=None):
             rv["init_zoom"] = init_zoom
         if nominalMagnification is not None:
             rv.update({"nominalMagnification": nominalMagnification})
+
+        rdef = get_rendering_def(image, rv)
+        if not rdef:
+            return rv
+
         try:
-            rv["pixel_range"] = image.getPixelRange()
-            rv["channels"] = [channelMarshal(x) for x in image.getChannels()]
+            rv["pixel_range"] = getPixelRange(image)
+            rv["channels"] = rdefMarshal(rdef, image, rv["pixel_range"])
             rv["split_channel"] = image.splitChannelDims()
             rv["rdefs"] = {
-                "model": (image.isGreyscaleRenderingModel() and "greyscale" or "color"),
+                "model": (rdef["model"] == "greyscale" and "greyscale" or "color"),
                 "projection": image.getProjection(),
-                "defaultZ": image._re.getDefaultZ(),
-                "defaultT": image._re.getDefaultT(),
+                "defaultZ": rdef["z"],
+                "defaultT": rdef["t"],
                 "invertAxis": image.isInvertedAxis(),
             }
         except TypeError:
@@ -265,6 +376,7 @@ def imageMarshal(image, key=None, request=None):
                 "invertAxis": image.isInvertedAxis(),
             }
     except AttributeError:
+        # Why do we do raise just for this exception?!
         rv = None
         raise
     if key is not None and rv is not None:

--- a/omeroweb/webgateway/util.py
+++ b/omeroweb/webgateway/util.py
@@ -23,10 +23,8 @@ import zipfile
 import shutil
 import logging
 
-try:
-    import long
-except ImportError:
-    long = int
+import omero
+import traceback
 
 logger = logging.getLogger(__name__)
 
@@ -238,3 +236,38 @@ def points_string_to_XY_list(string):
         x, y = xy.split(",")
         xyList.append((float(x.strip()), float(y.strip())))
     return xyList
+
+
+def load_re(image, rsp_dict=None):
+    rsp_dict = {} if rsp_dict is None else rsp_dict
+    reOK = False
+    try:
+        reOK = image._prepareRenderingEngine()
+        if not reOK:
+            rsp_dict["Error"] = "Failed to prepare Rendering Engine for imageMarshal"
+            logger.debug("Failed to prepare Rendering Engine for imageMarshal")
+    except omero.ConcurrencyException as ce:
+        backOff = ce.backOff
+        rsp_dict["ConcurrencyException"] = {"backOff": backOff}
+    except Exception as ex:  # Handle everything else.
+        rsp_dict["Exception"] = ex.message
+        logger.error(traceback.format_exc())
+    return reOK
+
+
+def get_rendering_def(image, rsp_dict=None):
+    # rsp_dict allows errors to be added
+    # Try to get user's rendering def
+    exp_id = image._conn.getUserId()
+    rdefs = image.getAllRenderingDefs(exp_id)
+    if len(rdefs) == 0:
+        # try to create our own rendering settings
+        if load_re(image, rsp_dict):
+            rdefs = image.getAllRenderingDefs(exp_id)
+    # otherwise use owners
+    if len(rdefs) == 0:
+        owner_id = image.getDetails().getOwner().id
+        if owner_id != exp_id:
+            rdefs = image.getAllRenderingDefs(owner_id)
+
+    return rdefs[0] if len(rdefs) > 0 else None

--- a/omeroweb/webgateway/util.py
+++ b/omeroweb/webgateway/util.py
@@ -93,7 +93,7 @@ def get_longs(request, name):
     vals = []
     vals_raw = request.GET.getlist(name)
     for val_raw in vals_raw:
-        vals.append(long(val_raw))
+        vals.append(int(val_raw))
     return vals
 
 


### PR DESCRIPTION
This PR is purely to allow deployment of the #536 on idr-testing by rebasing those changes onto an older version of omero-web that supports django-32. To make this easier I have now consolidated those changes into a single commit.

See #537 which shows the history of code changes (based on django-32 omero-web), including various commits used for A/B/C performance testing, which was performed with that branch deployed on idr-testing.


Deployed on idr-testing...

```
for server in omeroreadwrite omeroreadonly-1 omeroreadonly-2 omeroreadonly-3 omeroreadonly-4; do ssh $server "sudo /opt/omero/web/venv3/bin/pip uninstall -y omero-web && sudo /opt/omero/web/venv3/bin/pip install git+https://github.com/ome/omero-web.git@refs/pull/548/head && sudo service omero-web restart"; done
```