### PR TITLE
linkify supports urls that include $ character

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -61,7 +61,7 @@ OME.getURLParameter = function(key) {
 };
 
 var linkify = function(input) {
-    var regex = /(https?|ftp|file):\/\/[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]/g;
+    var regex = /(https?|ftp|file):\/\/[-a-zA-Z0-9+&@#/%?=~_|!:,.;$]*[-a-zA-Z0-9+&@#/%=~_|$]/g;
     input = input.replace(regex, "<a href='$&' target='_blank'>$&</a>");
     return linkObjects(input);
 };


### PR DESCRIPTION
See https://forum.image.sc/t/omero-add-link-as-comment/89134/4

Test by adding the URL from that issue within a Description and/or Comment on an object in webclient.

Should see that the whole URL is included in the link:

![Screenshot 2024-06-10 at 14 01 17](https://github.com/ome/omero-web/assets/900055/ee73ea6f-93b4-41c3-8db9-6c51270d3aa9)
