### PR TITLE
cap numpy to less than 2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ requires = pip >= 19.0.0
 deps =
     setuptools
     pre-commit
-    numpy>=1.9
+    numpy>=1.9,<2
     pytest
     PyYAML
     tables


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/414