### PR TITLE
Batch by MAX_TABLE_DOWNLOAD_ROWS

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3008,7 +3008,7 @@ def perform_table_query(
         def row_generator(table, h):
             # hits are all consecutive rows - can load them in batches
             idx = 0
-            batch = 1000
+            batch = settings.MAX_TABLE_DOWNLOAD_ROWS
             while idx < len(h):
                 batch = min(batch, len(h) - idx)
                 res = table.slice(col_indices, h[idx : idx + batch])


### PR DESCRIPTION
We will be loading `MAX_TABLE_DOWNLOAD_ROWS` into memory and presenting it for download, it makes sense that batching happens at the same scale. With ome/omero-web#554 this is less of a concern but it makes sense to unify.  In the near future it may be pertinent to remove the client side batching and "lazy" semantics entirely as they no longer really make sense or are completely unused.

/cc @erindiel, @sbesson