### PR TITLE
New table API endpoints for lower level table access

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -723,7 +723,6 @@ CUSTOM_SETTINGS_MAPPINGS = {
         "Prevent download of OMERO.tables exceeding this number of cells "
         "in a single request.",
     ],
-
     # VIEWER
     "omero.web.viewer.view": [
         "VIEWER_VIEW",

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -720,8 +720,8 @@ CUSTOM_SETTINGS_MAPPINGS = {
         "MAX_TABLE_SLICE_SIZE",
         1_000_000,
         int,
-        "Prevent download of OMERO.tables exceeding this number of cells "
-        "in a single request.",
+        "Maximum number of cells that can be retrieved in a single call "
+        "to the table slicing endpoint.",
     ],
     # VIEWER
     "omero.web.viewer.view": [

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -716,6 +716,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
         "Prevent download of OMERO.tables exceeding this number of rows "
         "in a single request.",
     ],
+    "omero.web.max_table_slice_size": [
+        "MAX_TABLE_SLICE_SIZE",
+        1_000_000,
+        int,
+        "Prevent download of OMERO.tables exceeding this number of cells "
+        "in a single request.",
+    ],
+
     # VIEWER
     "omero.web.viewer.view": [
         "VIEWER_VIEW",

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -16,6 +16,10 @@
 from django.urls import re_path
 from omeroweb.webgateway import views
 
+
+COMPACT_JSON = {'_json_dumps_params': {'separators': (',', ':')}}
+
+
 webgateway = re_path(r"^$", views.index, name="webgateway")
 """
 Returns a main prefix
@@ -601,7 +605,10 @@ This url will retrieve all rendering definitions for a given image (id)
 
 
 perform_get_where_list = re_path(
-    r"^table/(?P<fileid>\d+)/rows/$", views.perform_get_where_list, name="webgateway_perform_get_where_list"
+    r"^table/(?P<fileid>\d+)/rows/$",
+    views.perform_get_where_list,
+    name="webgateway_perform_get_where_list",
+    kwargs=COMPACT_JSON,
 )
 """
 Query a table specified by fileid and return the matching rows
@@ -609,7 +616,10 @@ Query a table specified by fileid and return the matching rows
 
 
 perform_slice = re_path(
-    r"^table/(?P<fileid>\d+)/slice/$", views.perform_slice, name="webgateway_perform_slice"
+    r"^table/(?P<fileid>\d+)/slice/$",
+    views.perform_slice,
+    name="webgateway_perform_slice",
+    kwargs=COMPACT_JSON,
 )
 """
 Fetch a table slice specified by rows and columns

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -604,10 +604,10 @@ This url will retrieve all rendering definitions for a given image (id)
 """
 
 
-perform_get_where_list = re_path(
+table_get_where_list = re_path(
     r"^table/(?P<fileid>\d+)/rows/$",
-    views.perform_get_where_list,
-    name="webgateway_perform_get_where_list",
+    views.table_get_where_list,
+    name="webgateway_table_get_where_list",
     kwargs=COMPACT_JSON,
 )
 """
@@ -615,10 +615,10 @@ Query a table specified by fileid and return the matching rows
 """
 
 
-perform_slice = re_path(
+table_slice = re_path(
     r"^table/(?P<fileid>\d+)/slice/$",
-    views.perform_slice,
-    name="webgateway_perform_slice",
+    views.table_slice,
+    name="webgateway_table_slice",
     kwargs=COMPACT_JSON,
 )
 """
@@ -684,6 +684,6 @@ urlpatterns = [
     object_table_query,
     open_with_options,
     # low-level table API
-    perform_get_where_list,
-    perform_slice,
+    table_get_where_list,
+    table_slice,
 ]

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -17,7 +17,7 @@ from django.urls import re_path
 from omeroweb.webgateway import views
 
 
-COMPACT_JSON = {'_json_dumps_params': {'separators': (',', ':')}}
+COMPACT_JSON = {"_json_dumps_params": {"separators": (",", ":")}}
 
 
 webgateway = re_path(r"^$", views.index, name="webgateway")

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -673,7 +673,7 @@ urlpatterns = [
     table_obj_id_bitmask,
     object_table_query,
     open_with_options,
-
+    # low-level table API
     perform_get_where_list,
     perform_slice,
 ]

--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -600,6 +600,22 @@ This url will retrieve all rendering definitions for a given image (id)
 """
 
 
+perform_get_where_list = re_path(
+    r"^table/(?P<fileid>\d+)/rows/$", views.perform_get_where_list, name="webgateway_perform_get_where_list"
+)
+"""
+Query a table specified by fileid and return the matching rows
+"""
+
+
+perform_slice = re_path(
+    r"^table/(?P<fileid>\d+)/slice/$", views.perform_slice, name="webgateway_perform_slice"
+)
+"""
+Fetch a table slice specified by rows and columns
+"""
+
+
 urlpatterns = [
     webgateway,
     render_image,
@@ -657,4 +673,7 @@ urlpatterns = [
     table_obj_id_bitmask,
     object_table_query,
     open_with_options,
+
+    perform_get_where_list,
+    perform_slice,
 ]

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3529,12 +3529,7 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
         column_count = len(table.getHeaders())
         end = min(row_count, start + settings.MAX_TABLE_SLICE_SIZE)
         logger.info(f"Query '{query}' from rows {start} to {end}")
-        if start >= end:
-            hits = []
-        else:
-            hits = table.getWhereList(query, None, start, end, 1)
-            # TODO: getWhereList may ignore start and end - remove once fixed
-            hits = [hit for hit in hits if start <= hit < end]
+        hits = table.getWhereList(query, None, start, end, 1) if start < end else []
         return {
             "rows": hits,
             "meta": {

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3589,22 +3589,22 @@ def perform_slice(request, fileid, conn=None, **kwargs):
     source = request.POST if request.method == "POST" else request.GET
     try:
         # Limit number of items to avoid problems when given massive ranges
-        rows = list(limit_generator(
-            (
-                row
-                for item in source.get("rows").split(",")
-                for row in parse(item)
-            ),
-            settings.MAX_TABLE_SLICE_SIZE
-        ))
-        columns = list(limit_generator(
-            (
-                column
-                for item in source.get("columns").split(",")
-                for column in parse(item)
-            ),
-            settings.MAX_TABLE_SLICE_SIZE / len(rows)
-        ))
+        rows = list(
+            limit_generator(
+                (row for item in source.get("rows").split(",") for row in parse(item)),
+                settings.MAX_TABLE_SLICE_SIZE,
+            )
+        )
+        columns = list(
+            limit_generator(
+                (
+                    column
+                    for item in source.get("columns").split(",")
+                    for column in parse(item)
+                ),
+                settings.MAX_TABLE_SLICE_SIZE / len(rows),
+            )
+        )
     except (ValueError, AttributeError) as error:
         return {
             "error": f"Need comma-separated list of rows and columns ({str(error)})"

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3624,15 +3624,18 @@ def perform_slice(request, fileid, conn=None, **kwargs):
     if not table:
         return {"error": "Table %s not found" % fileid}
     column_count = len(table.getHeaders())
-    if any(column >= column_count for column in columns):
+    row_count = table.getNumberOfRows()
+    if not all(0 <= column < column_count for column in columns):
         return {"error": "Columns out of range"}
+    if not all(0 <= row < row_count for row in rows):
+        return {"error": "Rows out of range"}
     try:
         columns = table.slice(columns, rows).columns
         return {
             "columns": [column.values for column in columns],
             "meta": {
                 "columns": [column.name for column in columns],
-                "rowCount": table.getNumberOfRows(),
+                "rowCount": row_count,
                 "columnCount": column_count,
                 "maxCells": settings.MAX_TABLE_SLICE_SIZE,
             },

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3588,11 +3588,7 @@ def perform_slice(request, fileid, conn=None, **kwargs):
     if not table:
         return {'error': 'Table %s not found' % fileid}
     try:
-        try:
-            columns = table.slice(columns, rows).columns
-        except:
-            logger.exception('Error slicing table %s with %d columns and %d rows' % (fileid, len(columns), len(rows)))
-            return {'error': 'Error slicing table'}
+        columns = table.slice(columns, rows).columns
         return {
             'columns': [column.values for column in columns],
             'meta': {
@@ -3600,6 +3596,9 @@ def perform_slice(request, fileid, conn=None, **kwargs):
                 'rowCount': table.getNumberOfRows(),
             },
         }
+    except:
+        logger.exception('Error slicing table %s with %d columns and %d rows' % (fileid, len(columns), len(rows)))
+        return {'error': 'Error slicing table'}
     finally:
         table.close()
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3477,6 +3477,30 @@ def get_image_rdefs_json(request, img_id=None, conn=None, **kwargs):
 @login_required()
 @jsonp
 def perform_get_where_list(request, fileid, conn=None, **kwargs):
+    """
+    Retrieves matching row numbers for a table query
+
+    Example: /webgateway/table/123/rows/?query=object<100&start=50
+
+    Query arguments:
+    query: table query in PyTables syntax
+    start: row number to start searching
+
+    Uses MAX_TABLE_SLICE_SIZE to determine how many rows will be searched.
+
+    @param request:     http request.
+    @param img_id:      the id of the image in question
+    @param conn:        L{omero.gateway.BlitzGateway}
+    @param **kwargs:    unused
+    @return:            A dictionary with keys 'rows' and 'meta' in the success case,
+                        one with key 'error' if something went wrong.
+                        'rows' is an array of matching row numbers.
+                        'meta' includes:
+                            - rowCount: total number of rows in table
+                            - start: row on which search was started
+                            - end: row on which search ended (exclusive), can be used for
+                                   follow-up query as new start value if end<rowCount
+    """
     query = request.GET.get('query')
     if not query:
         return {'error': 'Must specify query'}
@@ -3517,6 +3541,29 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
 @login_required()
 @jsonp
 def perform_slice(request, fileid, conn=None, **kwargs):
+    """
+    Performs a table slice
+
+    Example: /webgateway/table/123/slice/?rows=1,2,5-10&columns=0,3-4
+
+    Query arguments:
+    rows: row numbers to retrieve in comma-separated list, hyphen-separated ranges allowed
+    columns: column numbers to retrieve in comma-separated list, hyphen-separated ranges allowed
+
+    At most MAX_TABLE_SLICE_SIZE data points (number of rows * number of columns) can be retrieved,
+    if more are requested, an error is returned.
+
+    @param request:     http request.
+    @param img_id:      the id of the image in question
+    @param conn:        L{omero.gateway.BlitzGateway}
+    @param **kwargs:    unused
+    @return:            A dictionary with keys 'columns' and 'meta' in the success case,
+                        one with key 'error' if something went wrong.
+                        'columns' is an array of column data arrays
+                        'meta' includes:
+                            - rowCount: total number of rows in table
+                            - columns: names of columns in same order as data arrays
+    """
 
     def parse(item):
         try:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3478,7 +3478,7 @@ def get_image_rdefs_json(request, img_id=None, conn=None, **kwargs):
 
 @login_required()
 @jsonp
-def perform_get_where_list(request, fileid, conn=None, **kwargs):
+def table_get_where_list(request, fileid, conn=None, **kwargs):
     """
     Retrieves matching row numbers for a table query
 
@@ -3549,7 +3549,7 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
 
 @login_required()
 @jsonp
-def perform_slice(request, fileid, conn=None, **kwargs):
+def table_slice(request, fileid, conn=None, **kwargs):
     """
     Performs a table slice
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3529,7 +3529,7 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
                 elif range_start + 1 == range_end:  # two values
                     yield from (range_start, range_end)
                 else:  # three or more values, collapse
-                    yield f'{range_start}-{range_end}'
+                    yield f"{range_start}-{range_end}"
 
         count = 0
         for hit in generator:

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3487,6 +3487,9 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
     Query arguments:
     query: table query in PyTables syntax
     start: row number to start searching
+    collapse: optional argument, if present, collapses three or more
+        sequential row numbers in the resulting array into strings formatted as
+        "start-end". The same format can be submitted back to the slice request.
 
     Uses MAX_TABLE_SLICE_SIZE to determine how many rows will be searched.
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3491,7 +3491,7 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
     Uses MAX_TABLE_SLICE_SIZE to determine how many rows will be searched.
 
     @param request:     http request.
-    @param img_id:      the id of the image in question
+    @param fileid:      the id of the table
     @param conn:        L{omero.gateway.BlitzGateway}
     @param **kwargs:    unused
     @return:            A dictionary with keys 'rows' and 'meta' in the success case,
@@ -3509,11 +3509,11 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
 
         def dump_range():
             if range_start is not None:
-                if range_start == range_end:
+                if range_start == range_end:  # single value
                     yield range_start
-                elif range_start + 1 == range_end:
+                elif range_start + 1 == range_end:  # two values
                     yield from (range_start, range_end)
-                else:
+                else:  # three or more values, collapse
                     yield f'{range_start}-{range_end}'
 
         for hit in generator:
@@ -3542,10 +3542,10 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
         row_count = table.getNumberOfRows()
         column_count = len(table.getHeaders())
         end = min(row_count, start + settings.MAX_TABLE_SLICE_SIZE)
+        logger.info(f"Query '{query}' from rows {start} to {end}")
         if start >= end:
             hits = []
         else:
-            logger.info(query)
             hits = table.getWhereList(query, None, start, end, 1)
             # TODO: getWhereList may ignore start and end - remove once fixed
             hits = (hit for hit in hits if start <= hit < end)
@@ -3585,7 +3585,7 @@ def perform_slice(request, fileid, conn=None, **kwargs):
     be retrieved, if more are requested, an error is returned.
 
     @param request:     http request.
-    @param img_id:      the id of the image in question
+    @param fileid:      the id of the table
     @param conn:        L{omero.gateway.BlitzGateway}
     @param **kwargs:    unused
     @return:            A dictionary with keys 'columns' and 'meta' in the success

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -1463,7 +1463,9 @@ def jsonp(f):
             # NB: To support old api E.g. /get_rois_json/
             # We need to support lists
             safe = type(rv) is dict
-            return JsonResponse(rv, safe=safe)
+            # Allow optional JSON dumps parameters
+            json_params = kwargs.get("_json_dumps_params", None)
+            return JsonResponse(rv, safe=safe, json_dumps_params=json_params)
         except Exception as ex:
             # Default status is 500 'server error'
             # But we try to handle all 'expected' errors appropriately

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3499,9 +3499,16 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
                         'rows' is an array of matching row numbers.
                         'meta' includes:
                             - rowCount: total number of rows in table
+                            - columnCount: total number of columns in table
                             - start: row on which search was started
                             - end: row on which search ended (exclusive), can be used
                               for follow-up query as new start value if end<rowCount
+                            - maxCells: maximum number of cells that can be requested
+                              in one request
+                            - partialCount: number of matching rows returned in this
+                              response. Important: if start>0 and/or end<rowCount,
+                              this may not be the total number of matching rows in the
+                              table!
     """
 
     class ValueFetcher(object):
@@ -3606,6 +3613,9 @@ def perform_slice(request, fileid, conn=None, **kwargs):
                         'meta' includes:
                             - rowCount: total number of rows in table
                             - columns: names of columns in same order as data arrays
+                            - columnCount: total number of columns in table
+                            - maxCells: maximum number of cells that can be requested
+                              in one request
     """
 
     def parse(item):

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3534,6 +3534,7 @@ def perform_get_where_list(request, fileid, conn=None, **kwargs):
                 "columnCount": column_count,
                 "start": start,
                 "end": end,
+                "maxCells": settings.MAX_TABLE_SLICE_SIZE,
             },
         }
     except Exception:
@@ -3626,6 +3627,7 @@ def perform_slice(request, fileid, conn=None, **kwargs):
                 "columns": [column.name for column in columns],
                 "rowCount": table.getNumberOfRows(),
                 "columnCount": column_count,
+                "maxCells": settings.MAX_TABLE_SLICE_SIZE,
             },
         }
     except Exception as error:


### PR DESCRIPTION
This PR adds two new endpoints for lower level table access:

* For querying: `/webgateway/table/123/rows/` takes a `query` argument in the usual format and returns matching row numbers.  No actual data is returned.  Limited paging support by always returning up to `MAX_TABLE_SLICE_SIZE` rows and taking a `start` argument from where to start the search. `rowCount` and `end` are returned to easily detect the end of results or need for additional calls (with new `start` set to previous `end`).
* For data retrieval: `/webgateway/table/123/slice/` takes numeric lists of `rows` and `columns` and performs a slice.  Data is returned in columnar format (vs. rows in the current table API).  The number of requested rows times columns cannot exceed `MAX_TABLE_SLICE_SIZE`, which defaults to 1 million.  Both `GET` and `POST` are supported to allow for large numbers of rows and columns (exceeding the possible query string length). For retrieval of consecutive rows or columns, ranges can be specified as e.g. `1-5` instead of `1,2,3,4,5`.

Examples:
```
/webgateway/table/123/rows/?query=object%3E100000&start=8470
```
```json
{"rows":[8470,8471,8472,8473,8474,8475,8476],"meta":{"rowCount":8477,"start":8470,"end":8477}}
```

```
/webgateway/table/123/slice/?rows=8005-8010&columns=0-1
```
```json
{"columns":[[114391,114392,114393,114394,114395,114396],[NaN,NaN,NaN,NaN,NaN,NaN]],"meta":{"columns":["object","name"],"rowCount":8477}}
```

Notes:
* Added a way to supply additional formatting options to `json.dumps`, allowing e.g. for removing whitespace from the output
* Unrelated to this PR, since `NaN`s are allowed in the output but not supported by plain JSON, clients can use [JSON5](https://json5.org/) for parsing