### PR TITLE
Fix word wrap for names

### DIFF
--- a/omeroweb/webclient/static/webclient/css/layout.css
+++ b/omeroweb/webclient/static/webclient/css/layout.css
@@ -672,6 +672,7 @@
 			width:85%;
 			display:inline-block;
 			padding:5px 0;
+            word-wrap: break-word;
 	    }
     
 	        .data_heading span {
@@ -679,6 +680,7 @@
 	            line-height:1.2em;
 	            float:left;
 	            overflow:hidden;
+                width: 100%;
 	        }
             
 	            .data_heading img {

--- a/omeroweb/webclient/templates/webclient/annotations/includes/name.html
+++ b/omeroweb/webclient/templates/webclient/annotations/includes/name.html
@@ -26,7 +26,7 @@
     <div class="data_heading" id="{{ manager.obj_type }}name-{{ manager.obj_id }}">
         <div>
             <h1>
-                <span id="{{ manager.obj_type }}name-{{ manager.obj_id }}-name" style="word-wrap: break-word;">
+                <span id="{{ manager.obj_type }}name-{{ manager.obj_id }}-name">
                     {{ nameText|escape }}
                 </span>
             </h1>
@@ -37,7 +37,7 @@
     </div>
 {% else %}
     <div class="data_heading">
-      <h1 style="word-wrap: break-word;">{{ nameText|escape }}</h1>
+      <h1>{{ nameText|escape }}</h1>
     </div>
 {% endif %}
 


### PR DESCRIPTION
Fixes #572 
See report at https://forum.image.sc/t/image-names-not-wrapping/100493

To test, set various long names without spaces.
These should now wrap correctly instead of disappearing off the screen.