### PR TITLE
Fix breaking change: _marshal_images() handles missing archived flag

### DIFF
--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -531,7 +531,7 @@ def _marshal_image(
     """Given an Image row (list) marshals it into a dictionary.  Order
     and type of columns in row is:
       * id (rlong)
-      * archived (boolean)
+      * archived (boolean) - optional. Defaults to False if only 5 in row
       * name (rstring)
       * details.owner.id (rlong)
       * details.permissions (dict)
@@ -550,7 +550,11 @@ def _marshal_image(
     @param row_pixels The Image row pixels data to marshal
     @type row_pixels L{list}
     """
-    image_id, archived, name, owner_id, permissions, fileset_id = row
+    if len(row) == 6:
+        image_id, archived, name, owner_id, permissions, fileset_id = row
+    else:
+        image_id, name, owner_id, permissions, fileset_id = row
+        archived = False
     image = dict()
     image["id"] = unwrap(image_id)
     image["archived"] = unwrap(archived) is True


### PR DESCRIPTION
The change at https://github.com/ome/omero-web/pull/555/files#diff-dfcabd11e666e142b223e6aee67714ee9badf6ecdcaa5ceec24b7805e3d49520R553
has caused apps that use this to break:
 - mapr https://github.com/ome/omero-mapr/issues/84
 - auto-tag https://www.openmicroscopy.org/qa2/qa/feedback/41954/

This fix handles the missing `archived` flag (where row has 5 items) and defaults it to false.

To test:
 - Test with auto-tag (load central panel) or with mapr (search/browse by KVP in left panel > Project > Dataset > Images to load images in tree and centre pane)
 
Propose to release this fix ASAP (as 5.27.1)?