### PR TITLE
webclient page scaleable, login page device-width

### DIFF
--- a/omeroweb/webclient/templates/webclient/login.html
+++ b/omeroweb/webclient/templates/webclient/login.html
@@ -68,7 +68,8 @@
 
 {% block head %}
     {{ block.super }}
-	
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+
 	<script type="text/javascript" charset="utf-8">
 			$(function(){ $("label").inFieldLabels(); });
 		</script>

--- a/omeroweb/webgateway/templates/webgateway/base/base_main.html
+++ b/omeroweb/webgateway/templates/webgateway/base/base_main.html
@@ -34,8 +34,6 @@
     <!-- Turn touch events into drag events for jquery-ui -->
     <script type="text/javascript" src="{% static "3rdparty/jquery.ui.touch-punch-0.2.3.min.js" %}"></script>
 
-    <!-- Make the width fit the mobile viewport -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <!-- Allow webclient to be 'added to home-screen' as a full-screen app on iOS -->
     <meta name="apple-mobile-web-app-capable" content="yes">
 {% endblock %}


### PR DESCRIPTION
I noticed that the webclient login page is really not very mobile-phone friendly as the whole page shrinks to be quite small.

At the same time, the main webclient page is completely unusable on a phone as it is NOT scaleable and you can't access the centre & right areas of the page.
This is because it has the `user-scalable=no` flag on the `<viewport>`
which is "against Web Content Accessibility Guidelines" see https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag

Using Chrome dev tools to emulate a phone E.g. a `Google Pixel 4`.

Before this PR: login page is tiny and webclient page is unusable:

<img width="354" alt="Screenshot 2024-08-27 at 20 42 12" src="https://github.com/user-attachments/assets/eef7cfd1-6c0b-45bc-9107-bb6100f1dcee">

<img width="360" alt="Screenshot 2024-08-27 at 20 42 46" src="https://github.com/user-attachments/assets/8efe919d-7d2a-4149-bbf8-6d39a9aed708">

After these changes, the login page is a useful size (but still scalable) and the webclient page is usable as you can zoom (rescale) and pan around the page to access all functionality:

<img width="356" alt="Screenshot 2024-08-27 at 20 45 30" src="https://github.com/user-attachments/assets/e129c731-6507-493b-b8be-9479e7dd21f3">

<img width="358" alt="Screenshot 2024-08-27 at 20 44 24" src="https://github.com/user-attachments/assets/0fbb57ea-d6f0-4c2c-b6d3-d687371d4db1">

<img width="357" alt="Screenshot 2024-08-27 at 20 44 55" src="https://github.com/user-attachments/assets/a4a7d7e0-3514-4f39-b67d-6b492fd740c6">
