### PR TITLE
omeroweb.webgateway.obj_id_bitmask: handle empty query results

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3214,6 +3214,12 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, **kwargs):
             # accordingly.
             col_name = column_names[0]
         row_numbers = table.getWhereList(query, None, 0, 0, 1)
+        # If there are no matches for the query, don't call table.slice()
+        if len(row_numbers) == 0:
+            return HttpResponse(
+                numpy.packbits(numpy.array([0], dtype="int64")).tobytes(),
+                content_type="application/octet-stream"
+            )
         (column,) = table.slice([column_names.index(col_name)], row_numbers).columns
         try:
             return HttpResponse(

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3218,7 +3218,7 @@ def obj_id_bitmask(request, fileid, conn=None, query=None, **kwargs):
         if len(row_numbers) == 0:
             return HttpResponse(
                 numpy.packbits(numpy.array([0], dtype="int64")).tobytes(),
-                content_type="application/octet-stream"
+                content_type="application/octet-stream",
             )
         (column,) = table.slice([column_names.index(col_name)], row_numbers).columns
         try:


### PR DESCRIPTION
See https://github.com/ome/openmicroscopy/pull/6411

The current implementation behaves incorrectly when `getWhereList` returns an empty list (no matches). This is due to the fact that the contract of `table.slice()` is to return all rows if `row_numbers` is empty or None.

Instead, this fix detects the scenario where `row_numbers` is empty and return the corresponding bitmask as an HTTP response