### PR TITLE
Allow users to click a group name to quick-switch to that group

### DIFF
--- a/omeroweb/webclient/templates/webclient/base/includes/group_user_content.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/group_user_content.html
@@ -28,7 +28,11 @@
 
 {% for grp in myGroups %}
     <li {% if grp.id == eContext.context.groupId %}class="current_group"{% endif %}>
-        <a href="#" data-gid="{{ grp.id }}">
+        {% if grp.id == active_group.id %}
+            <a href="{{ current_url }}?experimenter=-1" data-gid="{{ grp.id }}">
+        {% else %}
+            <a href="{% url 'change_active_group' %}?active_group={{grp.id}}&url={{ current_url }}?experimenter=-1" data-gid="{{ grp.id }}">
+        {% endif %}
             <img
             {% if grp.getDetails.getPermissions.isGroupWrite %} src="{% static 'webclient/image/group_green16.png' %}"
             {% else %}

--- a/omeroweb/webclient/templates/webclient/base/includes/group_user_content.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/group_user_content.html
@@ -28,10 +28,10 @@
 
 {% for grp in myGroups %}
     <li {% if grp.id == eContext.context.groupId %}class="current_group"{% endif %}>
-        {% if grp.id == active_group.id %}
-            <a href="{{ current_url }}?experimenter=-1" data-gid="{{ grp.id }}">
+        {% if grp.id == ome.active_group %}
+            <a href="#" data-gid="{{ grp.id }}">
         {% else %}
-            <a href="{% url 'change_active_group' %}?active_group={{grp.id}}&url={{ current_url }}?experimenter=-1" data-gid="{{ grp.id }}">
+            <a href="{% url 'change_active_group' %}?active_group={{grp.id}}" data-gid="{{ grp.id }}">
         {% endif %}
             <img
             {% if grp.getDetails.getPermissions.isGroupWrite %} src="{% static 'webclient/image/group_green16.png' %}"
@@ -54,7 +54,7 @@
 
     {% for grp in groups %}
         <li {% if grp.id == eContext.context.groupId %}class="current_group"{% endif %}>
-            <a href="#" data-gid="{{ grp.id }}">
+            <a href="{% url 'change_active_group' %}?active_group={{grp.id}}&url={{ current_url }}?experimenter=-1" data-gid="{{ grp.id }}">
                 <img
                 {% if grp.getDetails.getPermissions.isGroupWrite %} src="{% static 'webclient/image/group_green16.png' %}"
                 {% else %}

--- a/omeroweb/webclient/templates/webclient/base/includes/group_user_dropdown2.html
+++ b/omeroweb/webclient/templates/webclient/base/includes/group_user_dropdown2.html
@@ -53,11 +53,9 @@
 
                         // When hover or click on a Group, show Users...
                         $( "#groupList" ).on( "mouseenter click", "li a", function(event) {
-                            event.preventDefault();
                             var gid = $(this).attr("data-gid");
                             $usersList.hide();
                             $("#groupMembers-" + gid).show();
-                            return false;
                         });
                     });
                 }


### PR DESCRIPTION
This PR slightly tweaks this group selection menu:

<img width="441" alt="Screenshot 2024-09-26 at 10 55 44" src="https://github.com/user-attachments/assets/9e70b74b-553e-448f-a003-415be766ad45">

The current workflow for selecting a group seems to be to open the menu, hover the group name and then navigate to the right submenu to choose which user to show data for.

In practice this seems a bit clunky, particularly when using a touchpad. It's easy to accidentally touch another group when trying to move the cursor to the right submenu.

This PR makes it so that clicking on the group name in the left menu behaves as if the user clicked "All Members" on the right submenu. I'd hope that this shortcut makes switching group a little faster and easier.

Based on the current code I wonder if at some point clicking the group name was meant to pin the right menu open and this is simply broken? I don't know the history here.

One question is how to handle private groups which don't normally display the "All Members" option. When tested in practice it seems that having `experimenter=-1` in the URL for these groups doesn't actually change what the user sees in the resulting tree, so I hope that's fine.