### PR TITLE
rf(py314): Replace deprecated pkgutil.find_loader

### DIFF
--- a/omeroweb/urls.py
+++ b/omeroweb/urls.py
@@ -24,7 +24,7 @@
 #
 
 import logging
-import pkgutil
+import importlib.util
 from django.conf import settings
 from django.apps import AppConfig
 from django.conf.urls import include
@@ -93,7 +93,7 @@ for app in settings.ADDITIONAL_APPS:
         urlmodule = "%s.urls" % app
 
     # Try to import module.urls.py if it exists (not for corsheaders etc)
-    urls_found = pkgutil.find_loader(urlmodule)
+    urls_found = importlib.util.find_spec(urlmodule)
     if urls_found is not None:
         try:
             __import__(urlmodule)


### PR DESCRIPTION
This PR removes [pkgutil.find_loader()][] and replaces it with [importlib.util.find_spec()][]. `find_loader` was deprecated in Python 3.12 and will be removed in 3.14. `find_spec` has been present since Python 3.4.

Both functions return `None` if the module loader cannot be found. For its use in this project, this is sufficient and no translation of the return value is needed.

[pkgutil.find_loader()]: https://docs.python.org/3/library/pkgutil.html#pkgutil.get_loader
[importlib.util.find_spec()]: https://docs.python.org/3/library/importlib.html#importlib.util.find_spec
