### PR TITLE
Remove pkg

### DIFF
--- a/omero/plugins/web.py
+++ b/omero/plugins/web.py
@@ -21,7 +21,7 @@ from functools import wraps
 from omero_ext.argparse import SUPPRESS
 
 from omero_ext.path import path
-from pkg_resources import resource_string
+from importlib_resources import files
 
 from omero.install.windows_warning import windows_warning, WINDOWS_WARNING
 
@@ -342,8 +342,8 @@ class WebControl(DiagnosticsControl):
         if settings.APPLICATION_SERVER not in settings.WSGI_TYPES:
             self.ctx.die(679, "Web template configuration requires" "wsgi or wsgi-tcp.")
 
-        template_file = "%s.conf.template" % server
-        c = resource_string("omeroweb", "templates/" + template_file).decode("utf-8")
+        template_file = "templates/%s.conf.template" % server
+        c = files("omeroweb").joinpath(template_file).read_text()
         self.ctx.out(c % d)
 
     def syncmedia(self, args):

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "pytz",
         "portalocker",
         "packaging",
+        "importlib-resources",
     ],
     include_package_data=True,
     tests_require=["pytest"],

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         # minimum requirements for `omero web start`
         "concurrent-log-handler>=0.9.20",
         "Django>=4.2.3,<4.3",
-        "django-pipeline==2.1.0",
+        "django-pipeline",
         "django-cors-headers==3.7.0",
         "whitenoise>=5.3.0",
         "gunicorn>=19.3",


### PR DESCRIPTION
This PRs allows to install and run OMERO.web with Python 3.12
The following errors happened when attempting to run OMERO.web on Ubuntu 24.04:
```
File "/opt/omero/web/venv3/lib/python3.12/site-packages/omero/cli.py", line 1677, in loadpath
#11 23.38     exec(f.read(), loc)
#11 23.38   File "<string>", line 24, in <module>
```

and

```
39.68   File "/opt/omero/web/venv3/lib/python3.12/site-packages/pipeline/__init__.py", line 1, in <module>
39.68     from pkg_resources import DistributionNotFound, get_distribution
39.68 ModuleNotFoundError: No module named 'pkg_resources'
```
