### PR TITLE
linkify supports urls that include {}[] characters

### DIFF
--- a/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -61,7 +61,7 @@ OME.getURLParameter = function(key) {
 };
 
 var linkify = function(input) {
-    var regex = /(https?|ftp|file):\/\/[-a-zA-Z0-9+&@#/%?=~_|!:,.;$]*[-a-zA-Z0-9+&@#/%=~_|$]/g;
+    var regex = /(https?|ftp|file):\/\/[-a-zA-Z0-9+&@#/%?=~_{}[\]|!:,.;$]*[-a-zA-Z0-9+&@#/%=~_{}[\]|$]/g;
     input = input.replace(regex, "<a href='$&' target='_blank'>$&</a>");
     return linkObjects(input);
 };


### PR DESCRIPTION
Test by adding URL:
https://openbis-eln-lims.ethz.ch/openbis/webapp/eln-lims/?menuUniqueId={%22type%22:%22SAMPLE%22,%22id%22:%2220150127162826183-170%22}&viewName=showViewSamplePageFromPermId&viewData=%2220150127162826183-170%22

![grafik](https://github.com/user-attachments/assets/ccc60543-41e0-42a7-951f-35cb4f2af294)
