### PR TITLE
Fix display of ContrastMethod

### DIFF
--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -693,7 +693,7 @@ class MetadataChannelForm(forms.Form):
                             )
                         }
                     ),
-                    initial=logicalCh.getContrastMethod(),
+                    initial=logicalCh.getContrastMethod().value,
                     label="Contrast method",
                     required=False,
                 )


### PR DESCRIPTION
As reported (with fix) at https://forum.image.sc/t/what-is-the-best-strategy-for-adding-instrument-and-aquisition-data-to-ome-tiff-files/104308/13 the ContrastMethod is not getting displayed in webclient.

This simple fix addresses that issue.

To test:
 - Check image at https://merge-ci.openmicroscopy.org/web/webclient/?show=image-12018  (Contrast Method has been set with the script from https://github.com/will-moore/python-scripts/blob/1d35118f67d60c1d1b43618ffe84d4f0cfde0c17/add_instrument_metadata.py#L101 to set various Contrast Methods passing in the Image ID:
 ```
python add_instrument_metadata.py 3351
```
 - Check Contrast Method is shown in webclient right panel
 
![Screenshot 2024-11-20 at 13 23 36](https://github.com/user-attachments/assets/c5233f47-0c9a-447d-9e8c-dcf3da7840de)

This shows that image without this fix:

![Screenshot 2024-11-20 at 13 31 33](https://github.com/user-attachments/assets/7a156931-42b9-46ce-a828-c05462d15d9c)


cc @pwetterauer 