### PR TITLE
Update PyPI publish workflow to use build instead of sdist

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -13,8 +13,8 @@ jobs:
           python-version: '3.9'
       - name: Build a binary wheel and a source tarball
         run: |
-          python -mpip install wheel
-          python setup.py sdist bdist_wheel
+          python -mpip install build
+          python -m build
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@v1.8.14


### PR DESCRIPTION
`sdist` produces a package name containing `omero-web` instead of `omero_web`, triggering a deprecation warning (see [PEP 625](https://peps.python.org/pep-0625/)).

Other packages have been updated similarly: [omero-py](https://github.com/ome/omero-py/pull/406), [omero-scripts](https://github.com/ome/omero-scripts/pull/220)