### PR TITLE
Remove Python 3.8 from the testing matrix

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Default tox environment when run without `-e`
-envlist = py38, py39, py310, py311, py312
+envlist = py39, py310, py311, py312
 
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel
@@ -18,7 +18,6 @@ deps =
     # https://github.com/pytest-dev/pytest-xdist/issues/585
     pytest-xdist < 2
     restructuredtext-lint
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
     https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.11"


### PR DESCRIPTION
See also https://github.com/ome/omero-py/pull/434

Python 3.8 support officially ended on October 7th, 2024. Recommendation is that consumers of the library should upgrade their environment to Python 3.9+.
Initially this commit removes Python 3.8 from the CI testing matrix. In a future change, we might want to bump python_requires to require Python 3.9 as the minimal version