### PR TITLE
Inherit all ann

### DIFF
--- a/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/omeroweb/webclient/static/webclient/css/dusty.css
@@ -478,7 +478,6 @@ button::-moz-focus-inner {
     
 .tag_annotation_wrapper .tag, .imagefilter .tag {
 	 display:inline-block;
-	 float:left;
 	 margin:1px 3px;
 	 position:relative;
 	 

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -206,8 +206,10 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                         'showTableHead': false, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
                     html = html + mapAnnsTempl({'anns': map_annotations, 'isInherited': false,
                         'showTableHead': false, 'showNs': true, 'clientMapAnn': false, 'showParent': showParent});
-                    html = html + mapAnnsTempl({'anns': inh_map_annotations, 'isInherited': true,
-                        'showTableHead': false, 'showNs': true, 'clientMapAnn': false, 'showParent': showParent});
+                    if (inh_map_annotations.length > 0) {
+                        html = html + mapAnnsTempl({'anns': inh_map_annotations, 'isInherited': true,
+                            'showTableHead': false, 'showNs': true, 'clientMapAnn': false, 'showParent': showParent});
+                    }
                     $mapAnnContainer.html(html);
 
                     // re-use the ajaxdata to set Object IDS data on the parent container

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_ratings_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_ratings_pane.js
@@ -96,9 +96,37 @@ var RatingsPane = function RatingsPane($element, opts) {
 
             $("#ratings_spinner").show();
 
-            $.getJSON(WEBCLIENT.URLS.webindex + "api/annotations/?type=rating&" + request, function(data){
+            $.getJSON(WEBCLIENT.URLS.webindex + "api/annotations/?parents=true&type=rating&" + request, function(data){
+
+                var experimenters = data.experimenters.reduce(function(prev, exp){
+                    prev[exp.id + ""] = exp;
+                    return prev;
+                }, {});
 
                 var anns = data.annotations;
+                var inh_anns = [];
+                if (data.hasOwnProperty("parents")){
+                    inh_anns = data.parents.annotations.map(function(ann) {
+                        ann.owner = experimenters[ann.owner.id];
+                        if (ann.link && ann.link.owner) {
+                            ann.link.owner = experimenters[ann.link.owner.id];
+                        }
+                        ann.addedBy = [ann.link.owner.id];
+                        let class_ = ann.link.parent.class;
+                        let id_ = '' + ann.link.parent.id;
+                        children = data.parents.lineage[class_][id_];
+                        class_ = children[0].class;
+                        ann.childClass = class_.substring(0, class_.length - 1);
+                        ann.childNames = [];
+                        if (children[0].hasOwnProperty("name")){
+                            for(j = 0; j < children.length; j++){
+                                ann.childNames.push(children[j].name);
+                            }
+                        }
+                        return ann;
+                    });
+                }
+
                 var sum = anns.reduce(function(prev, ann){
                     return prev + ann.longValue;
                 }, 0);
@@ -107,12 +135,29 @@ var RatingsPane = function RatingsPane($element, opts) {
                 });
                 var average = Math.round(sum/anns.length);
 
+                var sum_inh = inh_anns.reduce(function(prev, ann){
+                    return prev + ann.longValue;
+                }, 0);
+                var myRatings_inh = inh_anns.filter(function(ann){
+                    return ann.owner.id == WEBCLIENT.USER.id;
+                });
+                var average_inh = Math.round(sum_inh/inh_anns.length);
+
                 // Update html...
                 var html = ratingsTempl({'anns': anns,
                                          'canAnnotate': canAnnotate,
                                          'average': average,
                                          'count': anns.length,
-                                         'static': WEBCLIENT.URLS.static_webclient});
+                                         'static': WEBCLIENT.URLS.static_webclient,
+                                         'isInherited': false});
+                if (inh_anns.length > 0) {
+                    html = html + ratingsTempl({'anns': inh_anns,
+                                                'canAnnotate': false,
+                                                'average': average_inh,
+                                                'count': inh_anns.length,
+                                                'static': WEBCLIENT.URLS.static_webclient,
+                                                'isInherited': true});
+                }
                 $("#ratings_spinner").hide();
                 $rating_annotations.html(html);
 

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_ratings_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_ratings_pane.js
@@ -135,14 +135,6 @@ var RatingsPane = function RatingsPane($element, opts) {
                 });
                 var average = Math.round(sum/anns.length);
 
-                var sum_inh = inh_anns.reduce(function(prev, ann){
-                    return prev + ann.longValue;
-                }, 0);
-                var myRatings_inh = inh_anns.filter(function(ann){
-                    return ann.owner.id == WEBCLIENT.USER.id;
-                });
-                var average_inh = Math.round(sum_inh/inh_anns.length);
-
                 // Update html...
                 var html = ratingsTempl({'anns': anns,
                                          'canAnnotate': canAnnotate,
@@ -150,14 +142,6 @@ var RatingsPane = function RatingsPane($element, opts) {
                                          'count': anns.length,
                                          'static': WEBCLIENT.URLS.static_webclient,
                                          'isInherited': false});
-                if (inh_anns.length > 0) {
-                    html = html + ratingsTempl({'anns': inh_anns,
-                                                'canAnnotate': false,
-                                                'average': average_inh,
-                                                'count': inh_anns.length,
-                                                'static': WEBCLIENT.URLS.static_webclient,
-                                                'isInherited': true});
-                }
                 $("#ratings_spinner").hide();
                 $rating_annotations.html(html);
 

--- a/omeroweb/webclient/static/webclient/javascript/ome.right_panel_tags_pane.js
+++ b/omeroweb/webclient/static/webclient/javascript/ome.right_panel_tags_pane.js
@@ -143,8 +143,8 @@ var TagPane = function TagPane($element, opts) {
                     }
                     // AddedBy IDs for filtering
                     tag.addedBy = [tag.link.owner.id];
-                    tag.textValue = tag.textValue;
-                    tag.description = tag.description;
+                    tag.textValue = _.escape(tag.textValue);
+                    tag.description = _.escape(tag.description);
                     tag.canRemove = tag.link.permissions.canDelete;
                     return tag;
                 });
@@ -158,8 +158,8 @@ var TagPane = function TagPane($element, opts) {
                         }
                         // AddedBy IDs for filtering
                         tag.addedBy = [tag.link.owner.id];
-                        tag.textValue = tag.textValue;
-                        tag.description = tag.description;
+                        tag.textValue = _.escape(tag.textValue);
+                        tag.description = _.escape(tag.description);
                         tag.canRemove = false;
                         let class_ = tag.link.parent.class;
                         let id_ = '' + tag.link.parent.id;
@@ -185,12 +185,14 @@ var TagPane = function TagPane($element, opts) {
                         var tagId = tag.id,
                             linkOwner = tag.link.owner.id;
                         if (summary[tagId] === undefined) {
-                            summary[tagId] = {'textValue': _.escape(tag.textValue),
+                            summary[tagId] = {'textValue': tag.textValue,
+                                              'description': tag.description,
                                               'id': tag.id,
                                               'canRemove': false,
                                               'canRemoveCount': 0,
                                               'links': [],
-                                              'addedBy': []
+                                              'addedBy': [],
+                                              'owner': experimenters[linkOwner]
                                              };
                         }
                         // Add link to list...
@@ -225,13 +227,15 @@ var TagPane = function TagPane($element, opts) {
                             linkOwner = tag.link.owner.id;
                         if (summary[tagId] === undefined) {
                             summary[tagId] = {'textValue': _.escape(tag.textValue),
+                                              'description': _.escape(tag.description),
                                               'id': tag.id,
                                               'canRemove': false,
                                               'canRemoveCount': 0,
                                               'links': [],
                                               'addedBy': [],
                                               'childClass': tag.childClass,
-                                              'childNames': tag.childNames
+                                              'childNames': tag.childNames,
+                                              'owner': experimenters[linkOwner]
                                             };
                         }
                         // Add link to list...
@@ -265,9 +269,6 @@ var TagPane = function TagPane($element, opts) {
                                     'userId': WEBCLIENT.USER.id,
                                     'isInherited': false});
                 if (inh_tags.length > 0) {
-                    if (tags.length > 0) {
-                        html = html + "<br/><br/>"
-                    }
                     html = html + tagTmpl({'tags': inh_tags,
                                         'webindex': WEBCLIENT.URLS.webindex,
                                         'userId': WEBCLIENT.USER.id,

--- a/omeroweb/webclient/templates/webclient/annotations/comments_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/comments_underscore.html
@@ -48,7 +48,7 @@
                 <div>
                     &nbsp
                     <% if (idx < 20) { %>
-                        - <b><%- link.parent.class %> <%- link.parent.id %>:</b> <% print(_.escape(link.parent.name).slice(0, 28)) %>
+                         <b><%- link.parent.class %> <%- link.parent.id %>:</b> <% print(_.escape(link.parent.name).slice(0, 28)) %>
                         <% if (link.owner.id !== userId){
                             print("(" + link.owner.firstName.slice(0, 1) + " " + _.escape(link.owner.lastName) + ")")
                         } %>
@@ -71,7 +71,7 @@
         <% if (isInherited && ann.links) { %>
             <b>Inherited by:</b><br />
             <% _.each(ann.childNames, function(cname) { %>
-                &nbsp- <%- cname.slice(0, 28) %><br />
+                &nbsp <%- cname.slice(0, 28) %><br />
             <% }) %>
         <% } %>
     </span>

--- a/omeroweb/webclient/templates/webclient/annotations/comments_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/comments_underscore.html
@@ -1,3 +1,7 @@
+<% if (isInherited) { %>
+    <hr /><h2>Inherited comments</h2><br /><br />
+  <% } %>
+
 <% _.each(anns, function(ann) { %>
 <div class="ann_comment_wrapper" data-added-by="<% print(_.escape(ann.addedBy.join(','))) %>">
 
@@ -12,11 +16,16 @@
             <strong>
                 <%- ann.owner.firstName %> <%- ann.owner.lastName %>
             </strong>
-            at
-            <% print(OME.formatDate(ann.link.date)) %>
+            <% if (isInherited) { %>
+                on
+                <%- ann.link.parent.class.substring(0, ann.link.parent.class.length - 1) %> <%- ann.link.parent.name.slice(0, 30) %>
+            <% } else { %>
+                at
+                <% print(OME.formatDate(ann.link.date)) %>
+            <% } %>
         </div>
 
-        <% if (ann.permissions.canDelete) { %>
+        <% if (ann.permissions.canDelete && !isInherited) { %>
             <img class='removeComment' id="<%- ann.id %>-comment"
                 src="<%= static %>image/icon_basic_delete.png"
                 url='<%= webindex %>action/remove/comment/<%- ann.id %>/'
@@ -26,13 +35,17 @@
         <div class='commentText'><%- ann.textValue %></div>
     </div>
 
-    <% if (ann.ns || ann.description) { %>
     <span class="tooltip_html" style='display:none'>
         <b>ID:</b> <%- ann.id %><br />
         <% if (ann.ns) { %><b>Namespace:</b> <%- ann.ns %><br /><% } %>
         <% if (ann.description) { %><b>Description:</b> <%- ann.description %><br /><% } %>
+        <% if (isInherited) { %>
+            <b>Inherited by:</b><br />
+            <% _.each(ann.childNames, function(cname) { %>
+                &nbsp <%- cname %><br />
+            <% }) %>
+        <% } %>
     </span>
-    <% } %>
 
 </div>
 <% }) %>

--- a/omeroweb/webclient/templates/webclient/annotations/comments_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/comments_underscore.html
@@ -18,7 +18,7 @@
             </strong>
             <% if (isInherited) { %>
                 on
-                <%- ann.link.parent.class.substring(0, ann.link.parent.class.length - 1) %> <%- ann.link.parent.name.slice(0, 30) %>
+                <%- ann.link.parent.class %> <%- ann.link.parent.name.slice(0, 30) %>
             <% } else { %>
                 at
                 <% print(OME.formatDate(ann.link.date)) %>
@@ -36,13 +36,42 @@
     </div>
 
     <span class="tooltip_html" style='display:none'>
-        <b>ID:</b> <%- ann.id %><br />
-        <% if (ann.ns) { %><b>Namespace:</b> <%- ann.ns %><br /><% } %>
-        <% if (ann.description) { %><b>Description:</b> <%- ann.description %><br /><% } %>
-        <% if (isInherited) { %>
+        <!-- show different tooltip for batch_annotate panel -->
+        <% if (ann.links && !isInherited) { %>
+            Can remove File from <b><%- ann.canRemoveCount %> object<% if(ann.canRemoveCount !== 1) {print('s')} %></b>:<br/>
+        <% } %>
+        <b>Annotation ID:</b> <%- ann.id %><br />
+        <b>Owner:</b> <%- ann.owner.firstName %> <%- ann.owner.lastName %><br />
+        <% if (ann.links) { %>
+            <b>Linked to:</b><br />
+            <% _.each(ann.links, function(link, idx) { %>
+                <div>
+                    &nbsp
+                    <% if (idx < 20) { %>
+                        - <b><%- link.parent.class %> <%- link.parent.id %>:</b> <% print(_.escape(link.parent.name).slice(0, 28)) %>
+                        <% if (link.owner.id !== userId){
+                            print("(" + link.owner.firstName.slice(0, 1) + " " + _.escape(link.owner.lastName) + ")")
+                        } %>
+                    <% } else if (idx === 20) { %>
+                        and <b><% print(ann.links.length - 20) %></b> other objects...
+                    <% } %>
+                </div>
+            <% }) %>
+        <% } else if (isInherited) { %>
+            <b>Linked to:</b> <% print(_.escape(ann.link.parent.name).slice(0, 28)) %><br />
+        <% } else { %>
+            <b>Linked by:</b> <%- ann.link.owner.firstName %> <%- ann.link.owner.lastName %><br />
+            <b>On:</b> <% print(OME.formatDate(ann.link.date)) %><br />
+        <% } %>
+        <% if (ann.description){ %>
+            <b>Description:</b> <%- ann.description %><br/>
+        <% } %><% if (ann.ns){ %>
+            <b>Namespace:</b> <%- ann.ns %><br/>
+        <% } %>
+        <% if (isInherited && ann.links) { %>
             <b>Inherited by:</b><br />
             <% _.each(ann.childNames, function(cname) { %>
-                &nbsp <%- cname %><br />
+                &nbsp- <%- cname.slice(0, 28) %><br />
             <% }) %>
         <% } %>
     </span>

--- a/omeroweb/webclient/templates/webclient/annotations/fileanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/fileanns_underscore.html
@@ -1,3 +1,6 @@
+<% if (isInherited) { %>
+    <hr /><h2>Inherited attachements</h2><br /><br />
+<% } %>
 
 <% _.each(anns, function(ann) { %>
 <li class="file_ann_wrapper"
@@ -30,6 +33,12 @@
                     <% } %>
                 </div>
             <% }) %>
+            <% if (isInherited) { %>
+                <b>Inherited by:</b><br />
+                <% _.each(ann.childNames, function(cname) { %>
+                    &nbsp <%- cname %><br />
+                <% }) %>
+            <% } %>
         <% } else { %>
             <b>Annotation ID:</b> <%- ann.id %><br />
             <b>Owner:</b> <%- ann.owner.firstName %> <%- ann.owner.lastName %><br />
@@ -43,26 +52,34 @@
                 <br/><b>Mimetype:</b> <%- ann.file.mimetype %>
             <% } %>
             <br/><b>File ID:</b> <%- ann.file.id %>
+            <% if (isInherited) { %>
+                <br /><b>Inherited by:</b><br />
+                <% _.each(ann.childNames, function(cname) { %>
+                    &nbsp <%- cname %><br />
+                <% }) %>
+            <% } %>
         <% } %>
     </span>
 
-    <div class="attachment_actions">
-        <input type="checkbox" style="display:none;"/>
-        <% if ((ann.ns && ann.ns === 'openmicroscopy.org/omero/bulk_annotations') || ann.file.mimetype == 'OMERO.tables' ){ %>
-            <a class='action btn_view' title="View OMERO.table" target="_blank"
-            href='<%= webindex %>omero_table/<%- ann.file.id %>/'>&nbsp;</a>
-        <% } %>
-        <% if (ann.link.permissions.canDelete) { %> <!-- and not ann.isOriginalMetadata -->
-            <a class='removeFile action' id="<%- ann.id %>-file" title="Remove File"
-            href='<%= webindex %>action/remove/file/<%- ann.id %>/'>&#8211</a>
-        <% } %>
+    <% if (!isInherited) { %>
+        <div class="attachment_actions">
+            <input type="checkbox" style="display:none;"/>
+            <% if ((ann.ns && ann.ns === 'openmicroscopy.org/omero/bulk_annotations') || ann.file.mimetype == 'OMERO.tables' ){ %>
+                <a class='action btn_view' title="View OMERO.table" target="_blank"
+                href='<%= webindex %>omero_table/<%- ann.file.id %>/'>&nbsp;</a>
+            <% } %>
+            <% if (ann.link.permissions.canDelete) { %> <!-- and not ann.isOriginalMetadata -->
+                <a class='removeFile action' id="<%- ann.id %>-file" title="Remove File"
+                href='<%= webindex %>action/remove/file/<%- ann.id %>/'>&#8211</a>
+            <% } %>
 
-        <% if (ann.permissions.canDelete) { %> <!-- and not ann.isOriginalMetadata -->
-            <a id="<%- ann.id %>-file" type="image" class="deleteFile action" title="Delete File"
-                href="<%= webindex %>action/delete/file/<%- ann.id %>/"> &#215 </a>
-        <% } %>
+            <% if (ann.permissions.canDelete) { %> <!-- and not ann.isOriginalMetadata -->
+                <a id="<%- ann.id %>-file" type="image" class="deleteFile action" title="Delete File"
+                    href="<%= webindex %>action/delete/file/<%- ann.id %>/"> &#215 </a>
+            <% } %>
 
-    </div>
+        </div>
+    <% } %>
 </li>
 
 <% }) %>

--- a/omeroweb/webclient/templates/webclient/annotations/fileanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/fileanns_underscore.html
@@ -28,7 +28,7 @@
                 <div>
                     &nbsp
                     <% if (idx < 20) { %>
-                        - <b><%- link.parent.class %> <%- link.parent.id %>:</b> <% print(_.escape(link.parent.name).slice(0, 28)) %>
+                         <b><%- link.parent.class %> <%- link.parent.id %>:</b> <% print(_.escape(link.parent.name).slice(0, 28)) %>
                         <% if (link.owner.id !== userId){
                             print("(" + link.owner.firstName.slice(0, 1) + " " + _.escape(link.owner.lastName) + ")")
                         } %>
@@ -54,7 +54,7 @@
         <% if (isInherited && ann.links) { %>
             <b>Inherited by:</b><br />
             <% _.each(ann.childNames, function(cname) { %>
-                &nbsp- <%- cname.slice(0, 28) %><br />
+                &nbsp <%- cname.slice(0, 28) %><br />
             <% }) %>
         <% } %>
     </span>

--- a/omeroweb/webclient/templates/webclient/annotations/fileanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/fileanns_underscore.html
@@ -3,9 +3,9 @@
 <% } %>
 
 <% _.each(anns, function(ann) { %>
-<li class="file_ann_wrapper"
-    id="file_ann-<%- ann.id %>"
-    data-added-by="<% print(_.escape(ann.addedBy.join(','))) %>">
+    <li class="file_ann_wrapper"
+        id="file_ann-<%- ann.id %>"
+        data-added-by="<% print(_.escape(ann.addedBy.join(','))) %>">
 
     <a class='tooltip'
         href="<% if (ann.permissions.canDownload) { print(webindex + 'annotation/' + ann.id)} else {print('#') } %>">
@@ -17,14 +17,18 @@
 
     <span class="tooltip_html" style='display:none'>
         <!-- show different tooltip for batch_annotate panel -->
+        <% if (ann.links && !isInherited) { %>
+            Can remove File from <b><%- ann.canRemoveCount %> object<% if(ann.canRemoveCount !== 1) {print('s')} %></b>:<br/>
+        <% } %>
+        <b>Annotation ID:</b> <%- ann.id %><br />
+        <b>Owner:</b> <%- ann.owner.firstName %> <%- ann.owner.lastName %><br />
         <% if (ann.links) { %>
-            Can remove File from <b><%- ann.canRemoveCount %>
-            object<% if(ann.canRemoveCount !== 1) {print('s')} %></b>:<br/>
+            <b>Linked to:</b><br />
             <% _.each(ann.links, function(link, idx) { %>
                 <div>
+                    &nbsp
                     <% if (idx < 20) { %>
-                        <b><%- link.parent.class %> <%- link.parent.id %></b>
-                        <% print(_.escape(link.parent.name).slice(0, 28)) %>
+                        - <b><%- link.parent.class %> <%- link.parent.id %>:</b> <% print(_.escape(link.parent.name).slice(0, 28)) %>
                         <% if (link.owner.id !== userId){
                             print("(" + link.owner.firstName.slice(0, 1) + " " + _.escape(link.owner.lastName) + ")")
                         } %>
@@ -33,31 +37,25 @@
                     <% } %>
                 </div>
             <% }) %>
-            <% if (isInherited) { %>
-                <b>Inherited by:</b><br />
-                <% _.each(ann.childNames, function(cname) { %>
-                    &nbsp <%- cname %><br />
-                <% }) %>
-            <% } %>
+        <% } else if (isInherited) { %>
+            <b>Linked to:</b> <% print(_.escape(ann.link.parent.name).slice(0, 28)) %><br />
         <% } else { %>
-            <b>Annotation ID:</b> <%- ann.id %><br />
-            <b>Owner:</b> <%- ann.owner.firstName %> <%- ann.owner.lastName %><br />
             <b>Linked by:</b> <%- ann.link.owner.firstName %> <%- ann.link.owner.lastName %><br />
-            <b>On:</b> <% print(OME.formatDate(ann.link.date)) %> <br />
-            <b>Description:</b> <%- ann.description %>
-            <% if (ann.ns){ %>
-                <br/><b>Namespace:</b> <%- ann.ns %>
-            <% } %>
-            <% if (ann.file.mimetype){ %>
-                <br/><b>Mimetype:</b> <%- ann.file.mimetype %>
-            <% } %>
-            <br/><b>File ID:</b> <%- ann.file.id %>
-            <% if (isInherited) { %>
-                <br /><b>Inherited by:</b><br />
-                <% _.each(ann.childNames, function(cname) { %>
-                    &nbsp <%- cname %><br />
-                <% }) %>
-            <% } %>
+            <b>On:</b> <% print(OME.formatDate(ann.link.date)) %><br />
+        <% } %>
+        <b>Description:</b> <%- ann.description %><br/>
+        <% if (ann.ns){ %>
+            <b>Namespace:</b> <%- ann.ns %><br/>
+        <% } %>
+        <% if (ann.file.mimetype){ %>
+            <b>Mimetype:</b> <%- ann.file.mimetype %><br/>
+        <% } %>
+        <b>File ID:</b> <%- ann.file.id %><br/>
+        <% if (isInherited && ann.links) { %>
+            <b>Inherited by:</b><br />
+            <% _.each(ann.childNames, function(cname) { %>
+                &nbsp- <%- cname.slice(0, 28) %><br />
+            <% }) %>
         <% } %>
     </span>
 

--- a/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -1,3 +1,7 @@
+<% if (isInherited) { %>
+  <hr /><h2>Inherited key-value pairs</h2><br /><br />
+<% } %>
+
 <% _.each(anns, function(ann) { %>
 
 <table <% if (ann.id && ann.addedBy) { %>

--- a/omeroweb/webclient/templates/webclient/annotations/ratings_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/ratings_underscore.html
@@ -1,3 +1,7 @@
+<% if (isInherited) { %>
+    <hr /><h2>Inherited ratings</h2><br /><br />
+<% } %>
+
 <ul class="lnfiles">
 
     <li class="rating myRating" style="position: relative">

--- a/omeroweb/webclient/templates/webclient/annotations/ratings_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/ratings_underscore.html
@@ -1,7 +1,3 @@
-<% if (isInherited) { %>
-    <hr /><h2>Inherited ratings</h2><br /><br />
-<% } %>
-
 <ul class="lnfiles">
 
     <li class="rating myRating" style="position: relative">
@@ -19,7 +15,7 @@
         />
         </a>
         <% if (canAnnotate) { %>
-        <a href="#" class="removeRating removeTag" title="Delete rating">X</a>
+            <a href="#" class="removeRating removeTag" title="Delete rating">X</a>
         <% } %>
     </li>
 </ul>

--- a/omeroweb/webclient/templates/webclient/annotations/tags_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/tags_underscore.html
@@ -24,18 +24,15 @@
         <% if (tag.links && !isInherited) { %>
             Can remove Tag from <b><%- tag.canRemoveCount %> object<% if(tag.canRemoveCount !== 1) {print('s')} %></b><br/>
         <% } %>
-        <b>ID:</b> <%- tag.id %><br />
+        <b>Annotation ID:</b> <%- tag.id %><br />
         <b>Owner:</b> <%- tag.owner.firstName %> <%- tag.owner.lastName %><br />
-        <b>Description:</b> <%- tag.description %><br />
-        <b>Tagset:</b> PLACEHOLDER_TAGSET<br />
         <% if (tag.links) { %>
-            <b>Attached to:</b><br />
+            <b>Linked to:</b><br />
             <% _.each(tag.links, function(link, idx) { %>
                 <div>
                     &nbsp
                     <% if (idx < 20) { %>
-                        - <%- link.parent.class %> <%- link.parent.id %>:
-                        <%- link.parent.name.slice(0, 28) %>
+                        - <b><%- link.parent.class %> <%- link.parent.id %>:</b> <%- link.parent.name.slice(0, 28) %>
                         <% if (link.owner.id !== userId) {
                             print("(" + link.owner.firstName.slice(0, 1) + " " + _.escape(link.owner.lastName) + ")")
                         } %>
@@ -44,11 +41,15 @@
                     <% } %>
                 </div>
             <% }) %>
+        <% } else if (isInherited) { %>
+            <b>Linked to:</b> <% print(_.escape(tag.link.parent.name).slice(0, 28)) %><br />
         <% } else { %>
             <b>Linked by:</b> <%- tag.link.owner.firstName %> <%- tag.link.owner.lastName %><br />
             <b>On:</b> <% print(OME.formatDate(tag.link.date)) %><br />
         <% } %>
-        <% if (isInherited) { %>
+        <b>Tagset:</b> PLACEHOLDER_TAGSET<br />
+        <b>Description:</b> <%- tag.description %><br />
+        <% if (isInherited && tag.links) { %>
             <b>Inherited by:</b><br />
             <% _.each(tag.childNames, function(cname) { %>
                 &nbsp- <%- cname.slice(0, 28) %><br />

--- a/omeroweb/webclient/templates/webclient/annotations/tags_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/tags_underscore.html
@@ -3,7 +3,7 @@
   <% } %>
 
 <% _.each(tags, function(tag) { %>
-<span class="tag_annotation_wrapper"
+    <span class="tag_annotation_wrapper"
     data-tag-id="<%- tag.id %>"
     data-added-by="<% print(_.escape(tag.addedBy.join(','))) %>">
 
@@ -21,14 +21,20 @@
 
         <span class="tooltip_html" style='display:none'>
         <!-- show different tooltip for batch_annotate panel -->
+        <% if (tag.links && !isInherited) { %>
+            Can remove Tag from <b><%- tag.canRemoveCount %> object<% if(tag.canRemoveCount !== 1) {print('s')} %></b><br/>
+        <% } %>
+        <b>ID:</b> <%- tag.id %><br />
+        <b>Owner:</b> <%- tag.owner.firstName %> <%- tag.owner.lastName %><br />
+        <b>Description:</b> <%- tag.description %><br />
+        <b>Tagset:</b> PLACEHOLDER_TAGSET<br />
         <% if (tag.links) { %>
-            <% if (!isInherited) { %>
-                Can remove Tag from <b><%- tag.canRemoveCount %> object<% if(tag.canRemoveCount !== 1) {print('s')} %></b>:<br/>
-            <% } %>
+            <b>Attached to:</b><br />
             <% _.each(tag.links, function(link, idx) { %>
                 <div>
+                    &nbsp
                     <% if (idx < 20) { %>
-                        <b><%- link.parent.class %> <%- link.parent.id %></b>
+                        - <%- link.parent.class %> <%- link.parent.id %>:
                         <%- link.parent.name.slice(0, 28) %>
                         <% if (link.owner.id !== userId) {
                             print("(" + link.owner.firstName.slice(0, 1) + " " + _.escape(link.owner.lastName) + ")")
@@ -38,31 +44,18 @@
                     <% } %>
                 </div>
             <% }) %>
-            <% if (isInherited) { %>
-                <br /><b>Inherited by:</b><br />
-                <% _.each(tag.childNames, function(cname) { %>
-                    &nbsp <%- cname %><br />
-                <% }) %>
-            <% } %>
         <% } else { %>
-            <% if (isInherited) { %>
-                Added on <%- tag.link.parent.class.substring(0, tag.link.parent.class.length - 1) %> <%- tag.link.parent.name.slice(0, 30) %><br />
-            <% } %>
-            <b>ID:</b> <%- tag.id %><br />
-            <b>Owner:</b> <%- tag.owner.firstName %> <%- tag.owner.lastName %><br />
             <b>Linked by:</b> <%- tag.link.owner.firstName %> <%- tag.link.owner.lastName %><br />
             <b>On:</b> <% print(OME.formatDate(tag.link.date)) %><br />
-            <b>Description:</b> <%- tag.description %><br />
-            <% if (isInherited) { %>
-                <b>Inherited by:</b><br />
-                <% _.each(tag.childNames, function(cname) { %>
-                    &nbsp <%- cname %><br />
-                <% }) %>
-            <% } %>
+        <% } %>
+        <% if (isInherited) { %>
+            <b>Inherited by:</b><br />
+            <% _.each(tag.childNames, function(cname) { %>
+                &nbsp- <%- cname.slice(0, 28) %><br />
+            <% }) %>
         <% } %>
         </span>
     </div>
-
 </span>
 
 <% }) %>

--- a/omeroweb/webclient/templates/webclient/annotations/tags_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/tags_underscore.html
@@ -1,3 +1,6 @@
+<% if (isInherited) { %>
+    <hr /><h2>Inherited tags</h2><br /><br />
+  <% } %>
 
 <% _.each(tags, function(tag) { %>
 <span class="tag_annotation_wrapper"
@@ -19,7 +22,9 @@
         <span class="tooltip_html" style='display:none'>
         <!-- show different tooltip for batch_annotate panel -->
         <% if (tag.links) { %>
-            Can remove Tag from <b><%- tag.canRemoveCount %> object<% if(tag.canRemoveCount !== 1) {print('s')} %></b>:<br/>
+            <% if (!isInherited) { %>
+                Can remove Tag from <b><%- tag.canRemoveCount %> object<% if(tag.canRemoveCount !== 1) {print('s')} %></b>:<br/>
+            <% } %>
             <% _.each(tag.links, function(link, idx) { %>
                 <div>
                     <% if (idx < 20) { %>
@@ -33,12 +38,27 @@
                     <% } %>
                 </div>
             <% }) %>
+            <% if (isInherited) { %>
+                <br /><b>Inherited by:</b><br />
+                <% _.each(tag.childNames, function(cname) { %>
+                    &nbsp <%- cname %><br />
+                <% }) %>
+            <% } %>
         <% } else { %>
+            <% if (isInherited) { %>
+                Added on <%- tag.link.parent.class.substring(0, tag.link.parent.class.length - 1) %> <%- tag.link.parent.name.slice(0, 30) %><br />
+            <% } %>
             <b>ID:</b> <%- tag.id %><br />
             <b>Owner:</b> <%- tag.owner.firstName %> <%- tag.owner.lastName %><br />
             <b>Linked by:</b> <%- tag.link.owner.firstName %> <%- tag.link.owner.lastName %><br />
             <b>On:</b> <% print(OME.formatDate(tag.link.date)) %><br />
-            <b>Description:</b> <%- tag.description %>
+            <b>Description:</b> <%- tag.description %><br />
+            <% if (isInherited) { %>
+                <b>Inherited by:</b><br />
+                <% _.each(tag.childNames, function(cname) { %>
+                    &nbsp <%- cname %><br />
+                <% }) %>
+            <% } %>
         <% } %>
         </span>
     </div>

--- a/omeroweb/webclient/templates/webclient/annotations/tags_underscore.html
+++ b/omeroweb/webclient/templates/webclient/annotations/tags_underscore.html
@@ -32,7 +32,7 @@
                 <div>
                     &nbsp
                     <% if (idx < 20) { %>
-                        - <b><%- link.parent.class %> <%- link.parent.id %>:</b> <%- link.parent.name.slice(0, 28) %>
+                         <b><%- link.parent.class %> <%- link.parent.id %>:</b> <%- link.parent.name.slice(0, 28) %>
                         <% if (link.owner.id !== userId) {
                             print("(" + link.owner.firstName.slice(0, 1) + " " + _.escape(link.owner.lastName) + ")")
                         } %>
@@ -52,7 +52,7 @@
         <% if (isInherited && tag.links) { %>
             <b>Inherited by:</b><br />
             <% _.each(tag.childNames, function(cname) { %>
-                &nbsp- <%- cname.slice(0, 28) %><br />
+                &nbsp <%- cname.slice(0, 28) %><br />
             <% }) %>
         <% } %>
         </span>


### PR DESCRIPTION
Hello,
this includes the display of inherited annotations of other types than mapAnnotations.

This PR also harmonizes the annotation tooltips across possible cases:
* single object selected, annotation inherited or from the current object
* multiple objects selected, annotation inherited or from the current objects

Some annotations should have extras in their tooltip:
* tag annotations show tagsets
* file annotations show FileID

- [ ] Retrieve tagset of tags to display in the tooltip
- [ ] Improve display with inherited file annotation
- [ ] Handle ratings

Fixes https://github.com/ome/omero-web/issues/556

https://forum.image.sc/t/simultaneous-display-of-tags-for-the-image-dataset-and-project-levels/96503