### PR TITLE
Right panel perf

### DIFF
--- a/omeroweb/webclient/controller/container.py
+++ b/omeroweb/webclient/controller/container.py
@@ -132,8 +132,9 @@ class BaseContainer(BaseController):
         rsp_obj = None
         try:
             if self.conn.SERVICE_OPTS.getOmeroGroup() == -1:
-                obj = self.conn.getQueryService().get(obj_type, int(obj_id),
-                    {'group': '-1'})
+                obj = self.conn.getQueryService().get(
+                    obj_type, int(obj_id), {"group": "-1"}
+                )
                 group_id = obj.getDetails().group.id.val
                 self.conn.SERVICE_OPTS.setOmeroGroup(group_id)
             rsp_obj = self.conn.getObject(obj_type, obj_id)

--- a/omeroweb/webclient/templates/webclient/annotations/annotations_share.html
+++ b/omeroweb/webclient/templates/webclient/annotations/annotations_share.html
@@ -242,17 +242,7 @@
                         {% if manager.share.isExpired %}
                             This {{ manager.share.getShareType|lower }} has expired and you no longer can make any comments.
                         {% else %}
-                        <form id="add_share_comment_form" action="{% url 'annotate_comment' %}" method="post">{% csrf_token %}
-                        <table>
-                            <tr class="hiddenField"><td>{{ form_comment.share }}</td></tr>
-                            <tr>
-                                <td>{{ form_comment.comment }}</td>
-                            </tr>
-                            <tr>
-                                <td><input type="submit" value="{% trans 'Add Comment' %}" /></td>
-                            </tr>
-                        </table>
-                        </form>
+                            Commenting is no-longer supported.
                         {% endif %}
                     </th>
                 </tr>

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1743,8 +1743,6 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None, **kwa
         context["insight_ns"] = omero.rtypes.rstring(
             omero.constants.metadata.NSINSIGHTTAGSET
         ).val
-    if form_comment is not None:
-        context["form_comment"] = form_comment
 
     context["figScripts"] = figScripts
     context["template"] = template

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -1717,61 +1717,12 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None, **kwa
 
     context = dict()
 
-    # we only expect a single object, but forms can take multiple objects
-    images = c_type == "image" and list(conn.getObjects("Image", [c_id])) or list()
-    datasets = (
-        c_type == "dataset" and list(conn.getObjects("Dataset", [c_id])) or list()
-    )
-    projects = (
-        c_type == "project" and list(conn.getObjects("Project", [c_id])) or list()
-    )
-    screens = c_type == "screen" and list(conn.getObjects("Screen", [c_id])) or list()
-    plates = c_type == "plate" and list(conn.getObjects("Plate", [c_id])) or list()
-    acquisitions = (
-        c_type == "acquisition"
-        and list(conn.getObjects("PlateAcquisition", [c_id]))
-        or list()
-    )
-    shares = (
-        (c_type == "share" or c_type == "discussion")
-        and [conn.getShare(c_id)]
-        or list()
-    )
-    wells = c_type == "well" and list(conn.getObjects("Well", [c_id])) or list()
-
-    # we simply set up the annotation form, passing the objects to be
-    # annotated.
-    selected = {
-        "images": c_type == "image" and [c_id] or [],
-        "datasets": c_type == "dataset" and [c_id] or [],
-        "projects": c_type == "project" and [c_id] or [],
-        "screens": c_type == "screen" and [c_id] or [],
-        "plates": c_type == "plate" and [c_id] or [],
-        "acquisitions": c_type == "acquisition" and [c_id] or [],
-        "wells": c_type == "well" and [c_id] or [],
-        "shares": ((c_type == "share" or c_type == "discussion") and [c_id] or []),
-    }
-
-    initial = {
-        "selected": selected,
-        "images": images,
-        "datasets": datasets,
-        "projects": projects,
-        "screens": screens,
-        "plates": plates,
-        "acquisitions": acquisitions,
-        "wells": wells,
-        "shares": shares,
-    }
-
-    form_comment = None
     figScripts = None
     if c_type in ("share", "discussion"):
         template = "webclient/annotations/annotations_share.html"
         manager = BaseShare(conn, c_id)
         manager.getAllUsers(c_id)
         manager.getComments(c_id)
-        form_comment = CommentAnnotationForm(initial=initial)
     else:
         try:
             manager = BaseContainer(conn, **{str(c_type): int(c_id), "index": index})


### PR DESCRIPTION
Improves performance of loading right panel for single Objects (Project, Dataset, Image, Screen, Plate, Well, PlateAcquisition)

I looked into the timing for `getObject()` with `group: -1` and found that is slower when the user is logged-in to a large group (even if that group is private).

E.g. about `1 second` in the code below.

It's actually faster to:
 - perform a preliminary `queryService.get()` to get the object, get it's group ID...
 - and then use that group ID for `getObject()`
 - These 2 queries take about `0.02 seconds` in the code below.

```
import argparse
import sys
from datetime import datetime

from omero.cli import cli_login
from omero.gateway import BlitzGateway

def main(argv):
    parser = argparse.ArgumentParser()
    parser.add_argument('dataset', type=int, help='Dataset ID')
    args = parser.parse_args(argv)

    with cli_login() as cli:
        conn = BlitzGateway(client_obj=cli._client)
        dataset_id = args.dataset
        for test in range(10):
            start = datetime.now()
            if test % 2 == 0:
                # Use group: -1 via get(), then set group for conn.getObject()
                group_id = conn.getQueryService().get("Dataset", dataset_id, {'group': '-1'}).details.group.id.val
            else:
                group_id = -1
            conn.SERVICE_OPTS.setOmeroGroup(group_id,)
            dataset = conn.getObject("Dataset", dataset_id)
            print(datetime.now() - start, "group_id", group_id)

if __name__ == '__main__':
    main(sys.argv[1:])
```
prints:
```
0:00:00.031096 group_id 2
0:00:01.097150 group_id -1
0:00:00.028419 group_id 2
0:00:00.999497 group_id -1
0:00:00.019667 group_id 2
0:00:01.045434 group_id -1
0:00:00.021599 group_id 2
0:00:01.070055 group_id -1
0:00:00.023816 group_id 2
0:00:00.942411 group_id -1
```