### PR TITLE
Do not strip leading or trailing whitespaces in password fields

### DIFF
--- a/omeroweb/webadmin/forms.py
+++ b/omeroweb/webadmin/forms.py
@@ -52,6 +52,7 @@ class LoginForm(forms.Form):
         widget=forms.TextInput(attrs={"size": 22, "autofocus": "autofocus"}),
     )
     password = forms.CharField(
+        strip=False,
         widget=forms.PasswordInput(attrs={"size": 22, "autocomplete": "off"}),
     )
 
@@ -544,14 +545,17 @@ class UploadPhotoForm(forms.Form):
 
 class ChangePassword(forms.Form):
     old_password = forms.CharField(
+        strip=False,
         widget=forms.PasswordInput(attrs={"size": 30, "autocomplete": "off"}),
         label="Current password",
     )
     password = forms.CharField(
+        strip=False,
         widget=forms.PasswordInput(attrs={"size": 30, "autocomplete": "off"}),
         label="New password",
     )
     confirmation = forms.CharField(
+        strip=False,
         widget=forms.PasswordInput(attrs={"size": 30, "autocomplete": "off"}),
         label="Confirm password",
     )


### PR DESCRIPTION
The default behavior of the CharField class in Django forms is to strip leading and trailing whitespaces from the input text - see https://docs.djangoproject.com/en/4.2/ref/forms/fields/#django.forms.CharField.strip.

For authentication, this means that a user with a password containing leading or trailing whitespace is currently unable to log in via OMERO.web.

This commit fixes the login form as well as the change password form to preserve leading/trailing whitespace in all passwords fields.

Two workflows should be tested for this change

1. authentication workflow

   a. create a new user
   b. change its password using the OMERO CLI (`omero user password`) and set a value including a leading or trailing password
   c. log in via OMERO CLI using the new password should work and confirm  the password has been set in the DB
   d. log in via OMERO.web using the new password should fail without this PR but succeed with this PR

2. password change workflow

   a. create a new user
   b. change its password using the OMERO Web (my account or as an admin) and set a value including a leading or trailing password
   c. log in via OMERO CLI using the new password should fail without this PR  and succeed with this PR
   d. log in via OMERO.web using the new password should succeed without this PR (as the whitespaces will be stripped from both forms) as well as with this PR

/cc @stick