### PR TITLE
Fix issues related to images with very high channel count

### DIFF
--- a/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -1064,7 +1064,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
   /**
    * @return {String} The current query with state information.
    */
-  this.getQuery = function (include_slider_pos, include_xy_pos, include_zoom) {
+  this.getQuery = function (include_slider_pos, include_xy_pos, include_zoom, remove_inactive_channels) {
       
     var query = [];
     /* Channels (verbose as IE7 does not support Array.filter */
@@ -1079,6 +1079,19 @@ jQuery._WeblitzViewport = function (container, server, options) {
       chs.push(ch);
       maps_json.push({'inverted': {'enabled': channels[i].inverted}});
     }
+
+    if (remove_inactive_channels) {
+      // remove inactive channels from chs and maps_json to avoid URL lengths exceeding the
+      // maximum for images with many channels. Always keep the first channel to avoid errors
+      // when all channels are disabled
+      for (var j=chs.length - 1; j > 0; j--) {
+        if (chs[j][0] === '-') {
+          chs.splice(j, 1);
+          maps_json.splice(j, 1);
+        }
+      }
+    }
+
     query.push('c=' + chs.join(','));
     /* Rendering Model */
     query.push('m=' + this.loadedImg.rdefs.model.toLowerCase().substring(0,1));
@@ -1200,7 +1213,7 @@ jQuery._WeblitzViewport = function (container, server, options) {
 
   this.getRelUrl = function (append) {
     append = append !== undefined ? '/'+append : '';
-    return this.loadedImg.id + '/' + this.loadedImg.current.z + '/' + this.loadedImg.current.t + append + '/?' + this.getQuery();
+    return this.loadedImg.id + '/' + this.loadedImg.current.z + '/' + this.loadedImg.current.t + append + '/?' + this.getQuery(undefined, undefined, undefined, true);
   };
 
   this.getUrl = function (base) {

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2392,25 +2392,27 @@ def copy_image_rdef_json(request, conn=None, **kwargs):
             del request.session["rdef"]
         return True
 
+    def req(field: str):
+        return request.GET.get(field, request.POST.get(field))
+
     # If we've got an rdef encoded in request instead of ImageId...
-    r = request.GET or request.POST
-    if r.get("c") is not None:
+    if req("c") is not None:
         # make a map of settings we need
-        rdef = {"c": str(r.get("c"))}  # channels
-        if r.get("maps"):
+        rdef = {"c": str(req("c"))}  # channels
+        if req("maps"):
             try:
-                rdef["maps"] = json.loads(r.get("maps"))
+                rdef["maps"] = json.loads(req("maps"))
             except Exception:
                 pass
-        if r.get("pixel_range"):
-            rdef["pixel_range"] = str(r.get("pixel_range"))
-        if r.get("m"):
-            rdef["m"] = str(r.get("m"))  # model (grey)
-        if r.get("z"):
-            rdef["z"] = str(r.get("z"))  # z & t pos
-        if r.get("t"):
-            rdef["t"] = str(r.get("t"))
-        imageId = request.GET.get("imageId", request.POST.get("imageId", None))
+        if req("pixel_range"):
+            rdef["pixel_range"] = str(req("pixel_range"))
+        if req("m"):
+            rdef["m"] = str(req("m"))  # model (grey)
+        if req("z"):
+            rdef["z"] = str(req("z"))  # z & t pos
+        if req("t"):
+            rdef["t"] = str(req("t"))
+        imageId = req("imageId")
         if imageId:
             rdef["imageId"] = int(imageId)
 

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2416,7 +2416,7 @@ def copy_image_rdef_json(request, conn=None, **kwargs):
         if imageId:
             rdef["imageId"] = int(imageId)
 
-        if request.method == "GET":
+        if request.method == "GET" or req("store"):
             request.session.modified = True
             request.session["rdef"] = rdef
             # remove any previous rdef we may have via 'fromId'


### PR DESCRIPTION
This PR will address a number of issues with images that have a very high channel count and therefore produce URLs that exceed the length limitations.

Currently addressed:
- Right-hand preview panel `render_image` URLs (inactive channels are removed from URL). Note that this does not address requests with more than the allowed number of active channels.
- Fix `copy_image_rdef_json` in `webgateway/views.py` to fetch arguments from both `GET` and `POST` as given. Also allow just storing rendering defs via `POST`, which was only possible via `GET` previously.  Allowing `POST` for all calls allows passing in settings for very large numbers of channels.