### PR TITLE
JSON API: add support for login using JSON data

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3480,7 +3480,7 @@ class LoginView(View):
                 form = self.form_class(dict(payload))
             except Exception:
                 logger.debug(f"Invalid JSON data: {request.body}")
-                form = self.form_class(dict(payload))
+                form = self.form_class()
         else:
             form = self.form_class(request.POST.copy())
 


### PR DESCRIPTION
Discovered while using the JSON API and failing to authenticate using `curl --json`. It took me a while to figure out this undocumented limitation especially since other JSON API POST endpoints expect the data to be sent as JSON.

The JSON API login endpoint delegates to the WebGateway LoginView logic which only support form data defined in the login form. This commit proposes to extend the LoginView.post() logic to also support authentication sent at JSON data.

There are a few ways to test this change:
- using `curl --json` with the appropriate headers
- using `requests.post(login_url, json=payload)` e.g. by modifying https://github.com/ome/openmicroscopy/blob/1ae1bfa5b831dc0225df48dbef7871cc6ab044f6/examples/Training/python/Json_Api/Login.py#L70 to use `json` rather than `data`

This change should not affect the ability to log in using the login page or the JSON API with form data.