### PR TITLE
Include reason in JSON response on CSRF failure

### DIFF
--- a/omeroweb/feedback/views.py
+++ b/omeroweb/feedback/views.py
@@ -177,13 +177,7 @@ def csrf_failure(request, reason=""):
     Always return Json response
     since this is accepted by browser and API users
     """
-    error = (
-        f"CSRF Error. {reason} You need to include valid CSRF tokens for any"
-        " POST, PUT, PATCH or DELETE operations."
-        " You have to include CSRF token in the POST data or"
-        " add the token to the HTTP header."
-    )
-    return JsonResponse({"message": error}, status=403)
+    return JsonResponse({"message": f"CSRF Failed: {reason}"}, status=403)
 
 
 def handler500(request):

--- a/omeroweb/feedback/views.py
+++ b/omeroweb/feedback/views.py
@@ -178,7 +178,7 @@ def csrf_failure(request, reason=""):
     since this is accepted by browser and API users
     """
     error = (
-        "CSRF Error. You need to include valid CSRF tokens for any"
+        f"CSRF Error. {reason} You need to include valid CSRF tokens for any"
         " POST, PUT, PATCH or DELETE operations."
         " You have to include CSRF token in the POST data or"
         " add the token to the HTTP header."


### PR DESCRIPTION
If a POST/PUT/DELETE request is rejected by `CsrfViewMiddleware`, the current body of the HTTP response unconditionally suggests the rejection is due to an invalid CSRF token.  However there are other reasons that might cause the rejection of the request such as a missing or malformed Referer header when connecting to HTTPS - see https://docs.djangoproject.com/en/4.2/ref/csrf/ for more details.

One way to test these condition is to do a simple connection test using the JSON API e.g. in Python using https://github.com/ome/openmicroscopy/blob/develop/examples/Training/python/Json_Api/Login.py and test various failures conditions including

- missing `X-CSRFToken` in the header
- invalid value for the `X-CSRFToken` in the header
- missing `Referer` in the header (note OMERO.web must be deployed on HTTPS)
- malformed `Referer` value in the header (note OMERO.web must be deployed on HTTPS)

Without this change the error should be identical in all situation  making it quite hard to troubleshoot the issue without having access to the OMERO.web logs where the underlying caused is logged at WARN level.

```
{'message': "CSRF Error. You need to include valid CSRF tokens for any POST, PUT, PATCH or DELETE operations. You have to include CSRF token in the POST data or add the token to the HTTP header. "}
```

With this change, the response message should include the failure reason:

```
{'message': 'CSRF Failed: Referer checking failed - no Referer. '}