### PR TITLE
Allow top_links to wrap if too many for space

### DIFF
--- a/omeroweb/webgateway/static/webgateway/css/ome.body.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.body.css
@@ -38,6 +38,8 @@ body {
     position: relative;
 	background:hsl(215,9%,88%);
 	-webkit-transition: color .2s linear;
+    display: flex;
+    flex-direction: column;
 }
 
 a:hover, a, a:visited {

--- a/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -64,8 +64,7 @@
 	 filter:progid:DXImageTransform.Microsoft.gradient( startColorstr='#73787d', endColorstr='#505357',GradientType=0 ); /* IE6-9 */
 	 background:linear-gradient(top, hsl(212,8%,49%) 0%,hsl(212,8%,34%) 100%); /* W3C */
 	 font-family: Helvetica,Arial,sans-serif;
-
-	 height: 35px;
+	 flex: 0 1 auto;
  }
 	
 	
@@ -100,12 +99,16 @@
 		 top:0;
 	 }
 	 
-	 #middle_header_left {
-		 
+	 #middle_header_left ul {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		width: calc(100% - 550px);
 	 }
 	 
 		#middle_header_left li{
-			float:left;
+			flex: 0 0 auto;
 			list-style-type: none;
 		} 
 
@@ -982,11 +985,9 @@ li.menu_back a {
 /* Content */
 
 #content {
-    position:absolute;
-    top:35px;
-    right:0px;
-    left:0px;
-    bottom:0px; /* Changed to eliminate footer */
+	overflow: auto;
+    flex: 1 1 auto;
+    position: relative;
     overflow:auto;
 }
 


### PR DESCRIPTION
Fixes #611.

If we have too many top-links, the header wraps to another line.

NB: the width of the top-links list is slightly hard-coded to be `550px` less than the width of the page.
Probably best to use flex layout for the header row to be more flexible (e.g. size of logo and login etc).

![Screenshot 2025-02-28 at 17 03 42](https://github.com/user-attachments/assets/8ed5ffbe-f2a8-44fd-9c24-b274526a0a7e)
