### PR TITLE
Permit subpackages as app plugins

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -25,8 +25,7 @@
 #
 # Version: 1.0
 #
-
-
+import importlib
 import os.path
 import sys
 import logging
@@ -1596,9 +1595,9 @@ for app in ADDITIONAL_APPS:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
         INSTALLED_APPS += (app,)
     try:
         logger.debug("Attempting to import additional app settings for app: %s" % app)
-        module = __import__("%s.settings" % app)
-        process_custom_settings(module.settings)
-        report_settings(module.settings)
+        module = importlib.import_module("%s.settings" % app)
+        process_custom_settings(module)
+        report_settings(module)
     except ImportError:
         logger.debug("Couldn't import settings from app: %s" % app)
 


### PR DESCRIPTION
Currently plugin apps are added to the `omero.web.apps` config setting, but when processing them the settings loader fails if the added app is a subpackage (e.g. `my_package.frontend_plugin` rather than just `frontend_plugin`).

This happens because calling `__import__` on a name always returns the root package even if you call a subpackage. As a result the code expecting to find the settings script fails as it's given the wrong starting point. I think this can be fixed by using the more modern `importutil` importer, which returns the actual subpackage that was passed in. At least in my hands this seems to allow subpackages to be loaded as omero-web apps without breaking more conventional package-level apps. It looks like it was just the settings loader that was struggling with this scenario.

There are some [special conditions](https://docs.djangoproject.com/en/5.2/ref/applications/#namespace-packages-as-apps) to follow when using namespaces for a Django app, but doing so avoids needing a dedicated package for the django portion of a complex project.

