### PR TITLE
/webgateway/original_file_paths: handle images without Fileset

### DIFF
--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2822,6 +2822,8 @@ def original_file_paths(request, iid, conn=None, **kwargs):
     image = conn.getObject("Image", iid)
     if image is None:
         raise Http404
+    if image.fileset is None:
+        return {}
     paths = image.getImportedImageFilePaths()
     fileset_id = image.fileset.id.val
     return {


### PR DESCRIPTION
Fixes #420  

For images created via the API (or OMERO 4), this should skip the call to getImportedImageFilePaths() and return an empty dictionary

To test this change, create an image via the API e.g. using of the OMERO scripts, note its ID and make a request to  `/webgateway/original_file_paths/<id>` from your browser (the `../...` button should be hidden from the right hand panel).
The request should error without this PR and return an empty body with this PR included.