### PR TITLE
Allow display of ex-members data in group

### DIFF
--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -261,17 +261,6 @@ def marshal_experimenter(conn, experimenter_id):
     params.add("id", rlong(experimenter_id))
     qs = conn.getQueryService()
 
-    join_clause = ""
-    where_clause = ""
-    print("Is Admin: %s" % str(conn.isAdmin()))
-    # if not conn.isAdmin():
-    #     group_ids = conn.getEventContext().memberOfGroups
-    #     user_gid = conn.getAdminService().getSecurityRoles().userGroupId
-    #     if user_gid in group_ids:
-    #         group_ids.remove(user_gid)
-    #     params.addIds(group_ids)
-    #     join_clause = "join experimenter.groupExperimenterMap gem"
-    #     where_clause = "and gem.parent.id in :ids"
     q = """
         select distinct experimenter.id,
                experimenter.omeName,
@@ -279,14 +268,8 @@ def marshal_experimenter(conn, experimenter_id):
                experimenter.lastName,
                experimenter.email
         from Experimenter experimenter
-        %s
         where experimenter.id = :id
-        %s
-        """ % (
-        join_clause,
-        where_clause,
-    )
-    print("Query: %s" % q)
+        """
     rows = qs.projection(q, params, service_opts)
     if len(rows) != 1:
         return None

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -263,14 +263,15 @@ def marshal_experimenter(conn, experimenter_id):
 
     join_clause = ""
     where_clause = ""
-    if not conn.isAdmin():
-        group_ids = conn.getEventContext().memberOfGroups
-        user_gid = conn.getAdminService().getSecurityRoles().userGroupId
-        if user_gid in group_ids:
-            group_ids.remove(user_gid)
-        params.addIds(group_ids)
-        join_clause = "join experimenter.groupExperimenterMap gem"
-        where_clause = "and gem.parent.id in :ids"
+    print("Is Admin: %s" % str(conn.isAdmin()))
+    # if not conn.isAdmin():
+    #     group_ids = conn.getEventContext().memberOfGroups
+    #     user_gid = conn.getAdminService().getSecurityRoles().userGroupId
+    #     if user_gid in group_ids:
+    #         group_ids.remove(user_gid)
+    #     params.addIds(group_ids)
+    #     join_clause = "join experimenter.groupExperimenterMap gem"
+    #     where_clause = "and gem.parent.id in :ids"
     q = """
         select distinct experimenter.id,
                experimenter.omeName,
@@ -285,6 +286,7 @@ def marshal_experimenter(conn, experimenter_id):
         join_clause,
         where_clause,
     )
+    print("Query: %s" % q)
     rows = qs.projection(q, params, service_opts)
     if len(rows) != 1:
         return None

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -468,11 +468,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     # need to be sure that tree will be correct omero.group
     # that we have permission to access (e.g. Admin or Group Member)
     if first_sel is not None:
-        print("First selected: %s" % str(first_sel))
         group_id = first_sel.details.group.id.val
-        print(
-            "Group id: %s" % str(group_id), "valid group:", conn.isValidGroup(group_id)
-        )
         if conn.isValidGroup(group_id):
             switch_active_group(request, group_id)
         else:
@@ -508,21 +504,11 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
         user_id = int(user_id)
     except Exception:
         user_id = None
-    # check if user_id is in a currnt group
-    print("user_id:", user_id)
-    # if user_id is not None:
-    #     if (
-    #         user_id
-    #         not in (
-    #             set(map(lambda x: x.id, leaders)) | set(map(lambda x: x.id, members))
-    #         )
-    #         and user_id != -1
-    #     ):
-    #         # All users in group is allowed
-    #         user_id = None
+
+    # If no User or 'show' object specified, use 'session' user...
     if user_id is None:
-        # ... or check that current user is valid in active group
         user_id = request.session.get("user_id", None)
+        # ... check that user is valid in active group
         if user_id is None or int(user_id) not in userIds:
             if user_id != -1:  # All users in group is allowed
                 user_id = conn.getEventContext().userId

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -520,12 +520,12 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     #     ):
     #         # All users in group is allowed
     #         user_id = None
-    # if user_id is None:
-    #     # ... or check that current user is valid in active group
-    #     user_id = request.session.get("user_id", None)
-    #     if user_id is None or int(user_id) not in userIds:
-    #         if user_id != -1:  # All users in group is allowed
-    #             user_id = conn.getEventContext().userId
+    if user_id is None:
+        # ... or check that current user is valid in active group
+        user_id = request.session.get("user_id", None)
+        if user_id is None or int(user_id) not in userIds:
+            if user_id != -1:  # All users in group is allowed
+                user_id = conn.getEventContext().userId
 
     request.session["user_id"] = user_id
 

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -470,7 +470,9 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     if first_sel is not None:
         print("First selected: %s" % str(first_sel))
         group_id = first_sel.details.group.id.val
-        print("Group id: %s" % str(group_id), "valid group:", conn.isValidGroup(group_id))
+        print(
+            "Group id: %s" % str(group_id), "valid group:", conn.isValidGroup(group_id)
+        )
         if conn.isValidGroup(group_id):
             switch_active_group(request, group_id)
         else:

--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -466,8 +466,11 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
             return HttpResponseRedirect("%s?url=%s" % (reverse("weblogin"), url))
 
     # need to be sure that tree will be correct omero.group
+    # that we have permission to access (e.g. Admin or Group Member)
     if first_sel is not None:
+        print("First selected: %s" % str(first_sel))
         group_id = first_sel.details.group.id.val
+        print("Group id: %s" % str(group_id), "valid group:", conn.isValidGroup(group_id))
         if conn.isValidGroup(group_id):
             switch_active_group(request, group_id)
         else:
@@ -504,22 +507,23 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     except Exception:
         user_id = None
     # check if user_id is in a currnt group
-    if user_id is not None:
-        if (
-            user_id
-            not in (
-                set(map(lambda x: x.id, leaders)) | set(map(lambda x: x.id, members))
-            )
-            and user_id != -1
-        ):
-            # All users in group is allowed
-            user_id = None
-    if user_id is None:
-        # ... or check that current user is valid in active group
-        user_id = request.session.get("user_id", None)
-        if user_id is None or int(user_id) not in userIds:
-            if user_id != -1:  # All users in group is allowed
-                user_id = conn.getEventContext().userId
+    print("user_id:", user_id)
+    # if user_id is not None:
+    #     if (
+    #         user_id
+    #         not in (
+    #             set(map(lambda x: x.id, leaders)) | set(map(lambda x: x.id, members))
+    #         )
+    #         and user_id != -1
+    #     ):
+    #         # All users in group is allowed
+    #         user_id = None
+    # if user_id is None:
+    #     # ... or check that current user is valid in active group
+    #     user_id = request.session.get("user_id", None)
+    #     if user_id is None or int(user_id) not in userIds:
+    #         if user_id != -1:  # All users in group is allowed
+    #             user_id = conn.getEventContext().userId
 
     request.session["user_id"] = user_id
 


### PR DESCRIPTION
Currently, if you set the user context (for filtering data in the tree) to a user who is not in the current group, the filtering will automatically switch to "All Members". However, this prevents filtering by an Experimenter who has left a Group: see https://forum.image.sc/t/visibility-of-data-from-a-user-that-left-the-group/117309

This PR removes that restriction, allowing you to filter by a user who is not a member of the current Group.

With these changes you can: use `?experimenter=123` or `?image-123` (image owned by ex-member) to switch the filtering  of a group to the Ex member (without changing the group context or switching to "All Members").

E.g. this workflow...

 - Filter a group by "All Members" to allow you to find an image owned by an Ex Member
 - Copy the Link to that image
 - Switch back to only showing your own images (to switch off "All Members")
 - Then go to the image link. This will switch to filtering to by Ex Member - (and will show the chosen image)

A follow-up PR could add options to the Group-User dropdown menu to check for the existence of any data that belongs to non-group members (see discussion on image.sc above).