### PR TITLE
Bump minimal omero-marshal version to 0.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "django-cors-headers==3.7.0",
         "whitenoise>=5.3.0",
         "gunicorn>=19.3",
-        "omero-marshal>=0.7.0",
+        "omero-marshal>=0.9.1",
         "Pillow",
         "pytz",
         "portalocker",


### PR DESCRIPTION
See

- https://github.com/ome/omero-marshal/releases/tag/v0.9.1
- https://github.com/ome/omero-marshal/releases/tag/v0.9.0
- https://github.com/ome/omero-marshal/releases/tag/v0.8.0