### PR TITLE
Don't disable the histogram for big images

### DIFF
--- a/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -473,14 +473,14 @@
             <input id="showactive" type="checkbox" />
             Active
           </label>
-          <div style="float:right {% if tiledImage %}; color:#bbb{%endif%}"
-            {% if tiledImage or share %}
+          <div style="float:right {% if share %}; color:#bbb{%endif%}"
+            {% if share %}
               title="Histogram not supported for tiled images or in share"
             {%else%}
               title="Show histogram of pixel intensities for selected channel"
             {% endif %} >
             <!-- histogram (not supported for Big images) -->
-            <input id="showhistogram" type="checkbox" {% if tiledImage or share %}disabled{% endif %}/>
+            <input id="showhistogram" type="checkbox" {% if share %}disabled{% endif %}/>
             <label for="showhistogram">Show Histogram</label>
           </div>
           <div id="histogram" style="display:none; width: 100%; height: 125px; background:white; border: solid #ccc 1px; margin-bottom: 6px"></div>

--- a/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -475,7 +475,7 @@
           </label>
           <div style="float:right {% if share %}; color:#bbb{%endif%}"
             {% if share %}
-              title="Histogram not supported for tiled images or in share"
+              title="Histogram not supported in a share"
             {%else%}
               title="Show histogram of pixel intensities for selected channel"
             {% endif %} >

--- a/omeroweb/webgateway/static/webgateway/js/ome.histogram.js
+++ b/omeroweb/webgateway/static/webgateway/js/ome.histogram.js
@@ -108,6 +108,10 @@ window.OME.Histogram = function(element, webgatewayUrl, graphWidth, graphHeight)
             url += "&p=" + proj;
         }
         $.getJSON(url, function(data){
+            if (data.error) {
+                alert("Error loading histogram: " + data.error);
+                return;
+            }
             plotJson(data.data, color);
             this.plotStartEnd(window, color);
         }.bind(this));

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -2908,9 +2908,7 @@ def histogram_json(request, iid, theC, conn=None, **kwargs):
     except omero.ApiUsageException as ex:
         logger.warn(ex)
         resObj = {"error": ex.message}
-        return HttpResponseBadRequest(
-            json.dumps(resObj), content_type="application/json"
-        )
+        return JsonResponse(resObj, content_type="application/json")
     return JsonResponse({"data": histogram})
 
 


### PR DESCRIPTION
See #641 and request at https://forum.image.sc/t/olympus-whole-slide-scanner-histogram-feature-not-available-in-omero-iviewer/56308/7

# TODO: do the same for iviewer!

As @sbesson mentioned on that issue, the server does indeed support histograms on Big images!

To test:

 - Show histogram on a big image
 
<img width="390" height="827" alt="Screenshot 2025-11-28 at 17 37 00" src="https://github.com/user-attachments/assets/ec9ad6fc-a344-4936-b46a-37326d874d2e" />
