### PR TITLE
Force Django 5.2 in next release

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,16 @@ This document highlights steps that may need to be taken by developers
 when upgrading OMERO.web to ensure plugins or other customizations
 continue to function as expected.
 
+## OMERO.web 5.31.0
+
+### Django 5.2 support
+
+OMERO.web 5.31.0 requires Django version 5.2.
+
+The sessions store must be cleared before restarting OMERO.web following this upgrade - see
+https://omero.readthedocs.io/en/stable/sysadmins/omeroweb-upgrade.html#clear-the-sessions-store-optional
+for more information.
+
 ## OMERO.web 5.30.0
 
 ### Python support

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "omero-py>=5.19.0",
         # minimum requirements for `omero web start`
         "concurrent-log-handler>=0.9.20",
-        "Django>=4.2.25,<5.3",
+        "Django>=5.2.9,<5.3",
         "django-pipeline",
         "django-cors-headers==3.7.0",
         "whitenoise>=5.3.0",


### PR DESCRIPTION
The 5.30.0 release allowed Django 5.2, but still supported 4.2 as well.

With the next release, we will only allow Django 5.2.