### PR TITLE
Strip line endings from LUTs in text format

### DIFF
--- a/omeroweb/webgateway/util.py
+++ b/omeroweb/webgateway/util.py
@@ -256,12 +256,11 @@ def load_lut_to_rgb(conn, orig_file_id):
         lut_data = lut_data.decode()
         r, g, b = [], [], []
 
-        lines = lut_data.split("\n")
+        lines = lut_data.splitlines()
         sep = None
         if "\t" in lines[0]:
             sep = "\t"
         for line in lines:
-            line = line.rstrip()
             val = line.split(sep)
             if len(val) < 3 or not val[-1].isnumeric():
                 continue


### PR DESCRIPTION
If a LUT is uploaded to a server in Windows CRLF style, the `load_lut_to_rgb` fails to read the LUT value (so the luts.json or luts.png can't be generated on the fly).

The line endings can be changed in the LUT file directly https://askubuntu.com/a/803166
But this would prevent the issue in the first place.