### PR TITLE
Update imgData endpoint to return more metadata about the resolutions

### DIFF
--- a/omeroweb/webgateway/marshal.py
+++ b/omeroweb/webgateway/marshal.py
@@ -185,11 +185,17 @@ def imageMarshal(image, key=None, request=None):
     rv["tiles"] = tiles
     if tiles:
         width, height = image._re.getTileSize()
-        zoomLevelScaling = image.getZoomLevelScaling()
-
         rv.update({"tile_size": {"width": width, "height": height}, "levels": levels})
-        if zoomLevelScaling is not None:
-            rv["zoomLevelScaling"] = zoomLevelScaling
+
+        resolution_descriptions = image._re.getResolutionDescriptions()
+        rv["resolutions"] = {
+            index: {"sizeX": r.sizeX, "sizeY": r.sizeY}
+            for index, r in enumerate(resolution_descriptions)
+        }
+        rv["zoomLevelScaling"] = {
+            index: r.sizeX / resolution_descriptions[0].sizeX
+            for index, r in enumerate(resolution_descriptions)
+        }
 
     nominalMagnification = (
         image.getObjectiveSettings() is not None


### PR DESCRIPTION
Fixes #584 

The response to the `webgateway/imgData` endpoint uses `ImageWrapper.getZoomLevelScaling` which reduces the resolution description as a one dimensional array of scalar zoom levels.
This reduction suffers from limitations both due to rounding errors as well as resolution levels where sizeX and sizeY might have different zoom level scaling.
This commit marshals the sizeX/sizeY pair returned from PixelBuffer.getResolutionDescriptions into a new dictionary for all resolutions and returns it as an additional `resolutions` field in the JSON response for multi-resolution images.

The proposed value of the `resolutions` attribute mirrors `zoomLevelScaling` by using a dictionary where each key is the resolution index and only being populated for images with more than one resolution. As a possible discussion point, `resolutions` could be populated for all images independently of the number of resolution level.

/cc @melissalinkert @kkoz 