### PR TITLE
Webclient activites: defensively cast start_time to string

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -3975,7 +3975,7 @@ def activities(request, conn=None, **kwargs):
                 new_errors = True
         jobs.append(rv[key])
 
-    jobs.sort(key=lambda x: x["start_time"], reverse=True)
+    jobs.sort(key=lambda x: str(x["start_time"]), reverse=True)
     context = {
         "sizeOfJobs": len(request.session["callback"]),
         "jobs": jobs,


### PR DESCRIPTION
Fixes #652

As part of the Django 5.2 upgrade work, start times of callbacks are serialized as strings. Various error messages suggest there are still conditions under which datetime and string objects are directly compared when sorting jobs which is illicit. This commit fixes the sorting by ensuring strings are always compared.

As we have not identified how to reproduce the original issue, functional testing should probably validate that the activities endpoint still works as expected with various jobs submitted and in-between restarts of the application