### PR TITLE
Fix tree child counts for Tags view to enable paging in center panel

### DIFF
--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -1238,8 +1238,16 @@ def _marshal_tag(conn, row):
     @type row L{list}
 
     """
-    tag_id, text_value, description, owner_id, permissions, \
-        namespace, tag_child_count, image_child_count = row
+    (
+        tag_id,
+        text_value,
+        description,
+        owner_id,
+        permissions,
+        namespace,
+        tag_child_count,
+        image_child_count,
+    ) = row
 
     tag = dict()
     tag["id"] = unwrap(tag_id)

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -1229,6 +1229,8 @@ def _marshal_tag(conn, row):
       * details.owner.id (rlong)
       * details.permissions (dict)
       * namespace (rstring)
+      * tag child count (rint)
+      * image child count (rint)
 
     @param conn OMERO gateway.
     @type conn L{omero.gateway.BlitzGateway}
@@ -1236,7 +1238,8 @@ def _marshal_tag(conn, row):
     @type row L{list}
 
     """
-    tag_id, text_value, description, owner_id, permissions, namespace, child_count = row
+    tag_id, text_value, description, owner_id, permissions, \
+        namespace, tag_child_count, image_child_count = row
 
     tag = dict()
     tag["id"] = unwrap(tag_id)
@@ -1252,10 +1255,10 @@ def _marshal_tag(conn, row):
         and unwrap_to_str(namespace) == omero.constants.metadata.NSINSIGHTTAGSET
     ):
         tag["set"] = True
+        tag["childCount"] = unwrap(tag_child_count)
     else:
         tag["set"] = False
-
-    tag["childCount"] = unwrap(child_count)
+        tag["childCount"] = unwrap(image_child_count)
 
     return tag
 
@@ -1318,7 +1321,10 @@ def marshal_tags(
                    (select count(aalink2)
                     from AnnotationAnnotationLink aalink2
                     where aalink2.child.class=TagAnnotation
-                    and aalink2.parent.id=aalink.child.id) as childCount)
+                    and aalink2.parent.id=aalink.child.id) as tagChildCount,
+                   (select count(aalink3)
+                    from ImageAnnotationLink aalink3
+                    where aalink3.child.id=aalink.child.id) as imageChildCount)
             from AnnotationAnnotationLink aalink
             where aalink.parent.class=TagAnnotation
             and aalink.child.class=TagAnnotation
@@ -1348,7 +1354,10 @@ def marshal_tags(
                    (select count(aalink2)
                     from AnnotationAnnotationLink aalink2
                     where aalink2.child.class=TagAnnotation
-                    and aalink2.parent.id=tag.id) as childCount)
+                    and aalink2.parent.id=tag.id) as tagChildCount,
+                   (select count(aalink3)
+                    from ImageAnnotationLink aalink3
+                    where aalink3.child.id=tag.id) as imageChildCount)
             from TagAnnotation tag
             """
 
@@ -1381,9 +1390,10 @@ def marshal_tags(
             e[0]["ownerId"],
             e[0]["tag_details_permissions"],
             e[0]["ns"],
-            e[0]["childCount"],
+            e[0]["tagChildCount"],
+            e[0]["imageChildCount"],
         ]
-        tags.append(_marshal_tag(conn, e[0:7]))
+        tags.append(_marshal_tag(conn, e[0:8]))
 
     return tags
 


### PR DESCRIPTION
Large datasets only load a limited number (by default 200) images into the left-hand tree view and center panel. Under the "Explore" tag, if a dataset has more than 200 images, paging links are added to the bottom of the center panel. Paging updates both the tree and center panel.

For the "Tags" tab, if a tag has more than 200 matching images, the same limitation of loading only the first 200 existed, but the paging links at the bottom of the center panel were not added.

The apparent cause for this was that the "child count" property for the items in the tree (tag sets and tags) was not in fact the number of images, but rather tags.  This worked well for showing how many tags a tag set has, but failed to indicate the number of images and subsequently enable the paging if there are more than 200.

This PR changes the behavior of the tag tree API call, which now returns as the "child count" the number of tags for tag sets, and the number of images for tags.  This enables paging for large numbers of images, but retains the count shown in the tree for tag sets.

Other tagged items (datasets, projects, etc.) are still not considered in the indicated count.

cc: @muhanadz 