### PR TITLE
Add table_histogram endpoint

### DIFF
--- a/omeroweb/webgateway/urls.py
+++ b/omeroweb/webgateway/urls.py
@@ -629,6 +629,16 @@ table_slice = re_path(
 Fetch a table slice specified by rows and columns
 """
 
+table_histogram = re_path(
+    r"^table/(?P<fileid>\d+)/histogram/$",
+    views.table_histogram,
+    name="webgateway_table_histogram",
+    kwargs=COMPACT_JSON,
+)
+"""
+Fetch a table histogram specified by columns
+"""
+
 
 urlpatterns = [
     webgateway,
@@ -691,4 +701,5 @@ urlpatterns = [
     # low-level table API
     table_get_where_list,
     table_slice,
+    table_histogram,
 ]

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3690,7 +3690,7 @@ def table_slice(request, fileid, conn=None, **kwargs):
 
     Query arguments:
     rows: row numbers to retrieve in comma-separated list,
-          hyphen-separated ranges allowed
+          hyphen-separated ranges allowed, or * for all rows
     columns: column numbers to retrieve in comma-separated list,
              hyphen-separated ranges allowed
 
@@ -3711,6 +3711,15 @@ def table_slice(request, fileid, conn=None, **kwargs):
                             - maxCells: maximum number of cells that can be requested
                               in one request
     """
+    json_data = _table_slice(request, fileid, conn, **kwargs)
+    return json_data
+
+def _table_slice(request, fileid, conn=None, **kwargs):
+    """
+    Performs a table slice
+
+    See table_slice() above for details.
+    """
 
     def parse(item):
         try:
@@ -3728,11 +3737,28 @@ def table_slice(request, fileid, conn=None, **kwargs):
             yield item
 
     source = request.POST if request.method == "POST" else request.GET
+
+    ctx = conn.createServiceOptsDict()
+    ctx.setOmeroGroup("-1")
+    resources = conn.getSharedResources()
+    table = resources.openTable(omero.model.OriginalFileI(fileid), ctx)
+    if not table:
+        return {"error": "Table %s not found" % fileid}
+    column_count = len(table.getHeaders())
+    row_count = table.getNumberOfRows()
+    # rows can come from request OR kwargs
+    rows = source.get("rows", kwargs.get("rows"))
+    if rows is None:
+        return {"error": "Must specify rows"}
+    elif rows == "*":
+        # Allow * to specify ALL rows
+        rows = "0-%d" % (row_count - 1)
+
     try:
         # Limit number of items to avoid problems when given massive ranges
         rows = list(
             limit_generator(
-                (row for item in source.get("rows").split(",") for row in parse(item)),
+                (row for item in rows.split(",") for row in parse(item)),
                 settings.MAX_TABLE_SLICE_SIZE,
             )
         )
@@ -3750,14 +3776,7 @@ def table_slice(request, fileid, conn=None, **kwargs):
         return {
             "error": f"Need comma-separated list of rows and columns ({str(error)})"
         }
-    ctx = conn.createServiceOptsDict()
-    ctx.setOmeroGroup("-1")
-    resources = conn.getSharedResources()
-    table = resources.openTable(omero.model.OriginalFileI(fileid), ctx)
-    if not table:
-        return {"error": "Table %s not found" % fileid}
-    column_count = len(table.getHeaders())
-    row_count = table.getNumberOfRows()
+
     if not all(0 <= column < column_count for column in columns):
         return {"error": "Columns out of range"}
     if not all(0 <= row < row_count for row in rows):
@@ -3781,3 +3800,72 @@ def table_slice(request, fileid, conn=None, **kwargs):
         return {"error": f"Error slicing table ({str(error)})"}
     finally:
         table.close()
+
+
+@login_required()
+@jsonp
+def table_histogram(request, fileid, conn=None, **kwargs):
+    """
+    Performs a table slice and returns histograms for the requested columns
+
+    Query arguments:
+    columns: column numbers to retrieve in comma-separated list,
+             hyphen-separated ranges allowed
+    rows: optional. Use all rows by default. But this can be used to
+          specify a subset if required, in the same format as columns.
+    bins: optional. Number of bins for the histogram, or a string to be passed
+            to numpy.histogram, e.g. "auto". Default is 10.
+
+    At most MAX_TABLE_SLICE_SIZE data points (number of rows * number of columns) can
+    be retrieved, if more are requested, an error is returned.
+
+    @param request:     http request.
+    @param fileid:      the id of the table
+    @param conn:        L{omero.gateway.BlitzGateway}
+    @param **kwargs:    unused
+    @return:            A dictionary with keys 'histograms' and 'meta' in the success
+                        case, one with key 'error' if something went wrong.
+                        'histograms' is a list of dictionaries with
+                            - column: name of column
+                            - histogram: list of counts for each bin
+                            - bin_edges: list of bin edges
+                        'meta' includes:
+                            - rowCount: total number of rows in table
+                            - columns: names of columns in same order as data arrays
+                            - columnCount: total number of columns in table
+                            - maxCells: maximum number of cells that can be requested
+                              in one request
+    """
+
+    # load the data with table_slice, then use numpy to calculate the histogram for the requested columns
+    if "rows" not in request.GET:
+        kwargs["rows"] = '*'  # default to all rows if not specified
+    slice_result = _table_slice(request, fileid, conn, **kwargs)
+    if "error" in slice_result:
+        return slice_result
+    columns = slice_result["columns"]
+    meta = slice_result["meta"]
+    bins = request.GET.get("bins", 10)
+    try:
+        bins = int(bins)
+    except ValueError:
+        # the string will be passed to numpy.histogram e.g. "auto"
+        pass
+    histograms = []
+    for i, column in enumerate(columns):
+        try:
+            hist, bin_edges = numpy.histogram(column, bins=bins)
+            histograms.append(
+                {
+                    "column": meta["columns"][i],
+                    "histogram": hist.tolist(),
+                    "bin_edges": bin_edges.tolist(),
+                }
+            )
+        except Exception as error:
+            logger.exception(
+                "Error calculating histogram for column %s in table %s"
+                % (meta["columns"][i], fileid)
+            )
+            return {"error": f"Error calculating histogram ({str(error)})"}
+    return {"histograms": histograms, "meta": meta}

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3838,7 +3838,6 @@ def table_histogram(request, fileid, conn=None, **kwargs):
                               in one request
     """
 
-    # load the data with table_slice, then use numpy to calculate the histogram for the requested columns
     if "rows" not in request.GET:
         kwargs["rows"] = "*"  # default to all rows if not specified
     slice_result = _table_slice(request, fileid, conn, **kwargs)

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3714,6 +3714,7 @@ def table_slice(request, fileid, conn=None, **kwargs):
     json_data = _table_slice(request, fileid, conn, **kwargs)
     return json_data
 
+
 def _table_slice(request, fileid, conn=None, **kwargs):
     """
     Performs a table slice
@@ -3839,7 +3840,7 @@ def table_histogram(request, fileid, conn=None, **kwargs):
 
     # load the data with table_slice, then use numpy to calculate the histogram for the requested columns
     if "rows" not in request.GET:
-        kwargs["rows"] = '*'  # default to all rows if not specified
+        kwargs["rows"] = "*"  # default to all rows if not specified
     slice_result = _table_slice(request, fileid, conn, **kwargs)
     if "error" in slice_result:
         return slice_result


### PR DESCRIPTION
We have a histogram functionality in `omero-parade` and now I also need it for `iviewer` (https://github.com/ome/omero-iviewer/pull/532), so it makes sense for this to go into `omero-web`.

This endpoint behaves similarly to the existing OMERO.table `slice` endpoint e.g. `/webgateway/table/FILE_ID/slice/?columns=0&rows=0-100` and wraps the `table_slice()` for loading the data, then generates a histogram using numpy and returns the result.

By default, we use ALL the rows to generate the histogram.
Since we don't want to have load the table twice (to get the row-count *before* passing the `rows = 0-row_count-1` to `table_slice()`, I have updated the `table_slice()` to allow `rows=*` (no change on max amount of data permitted).

So you can now do `/webgateway/table/FILE_ID/slice/?columns=0&rows=*`

Histogram supports the `bins` request parameter (int or string) - behaves as described at https://numpy.org/devdocs/reference/generated/numpy.histogram.html

Sample response to `/webgateway/table/15908/histogram/?columns=2,3` on merge-ci

```
{
  "histograms": [
    {
      "column": "x_centroid",
      "histogram": [1449, 2750, 2982, 3161, 3393, 3455, 3012, 2643, 1161, 400],
      "bin_edges": [
        3.757423210144043, 766.061197490692, 1528.36497177124,
        2290.6687460517883, 3052.9725203323364, 3815.2762946128846,
        4577.580068893432, 5339.8838431739805, 6102.187617454529,
        6864.491391735077, 7626.795166015625
      ]
    },
    {
      "column": "y_centroid",
      "histogram": [52, 142, 32, 1388, 3627, 3905, 4269, 4326, 4111, 2554],
      "bin_edges": [
        39.39493064880371, 614.6632842636108, 1189.9316378784179,
        1765.199991493225, 2340.4683451080323, 2915.7366987228393,
        3491.0050523376467, 4066.2734059524537, 4641.541759567261,
        5216.810113182068, 5792.078466796875
      ]
    }
  ],
  "meta": {
    "columns": ["x_centroid", "y_centroid"],
    "rowCount": 24406,
    "columnCount": 13,
    "maxCells": 1000000
  }
}

```