### PR TITLE
Allow POST requests from public user for specific URLs

### DIFF
--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -126,6 +126,15 @@ class login_required(object):
         raise an Exception since cleanup is intended to be immediate; if
         False, connection cleanup will be skipped ONLY when a
         ConnCleaningHttpResponse is returned.
+
+    allowPublicPost:
+        Makes the request available to the public user, independently of
+        any configured PUBLIC_GET_ONLY restriction. The PUBLIC_URL_FILTER
+        setting still applies.
+        Important: This should only be set to True for POST requests that
+        do not modify any data; usually this would be used for requests
+        that could be GET but require transmission of more request data
+        than allowed by usual URL length restrictions.
     """
 
     def __init__(
@@ -136,6 +145,7 @@ class login_required(object):
         doConnectionCleanup=True,
         omero_group="-1",
         allowPublic=None,
+        allowPublicPost=None,
     ):
         """
         Initialises the decorator.
@@ -146,6 +156,7 @@ class login_required(object):
         self.doConnectionCleanup = doConnectionCleanup
         self.omero_group = omero_group
         self.allowPublic = allowPublic
+        self.allowPublicPost = allowPublicPost
 
     # To make django's method_decorator work, this is required until
     # python/django sort out how argumented decorator wrapping should work
@@ -277,6 +288,8 @@ class login_required(object):
                 )
                 settings.PUBLIC_ENABLED = False
                 return False
+            if self.allowPublicPost and request.method == 'POST':
+                return settings.PUBLIC_URL_FILTER.search(request.path) is not None
             if settings.PUBLIC_GET_ONLY and (request.method != "GET"):
                 return False
             if self.allowPublic is None:

--- a/omeroweb/decorators.py
+++ b/omeroweb/decorators.py
@@ -288,7 +288,7 @@ class login_required(object):
                 )
                 settings.PUBLIC_ENABLED = False
                 return False
-            if self.allowPublicPost and request.method == 'POST':
+            if self.allowPublicPost and request.method == "POST":
                 return settings.PUBLIC_URL_FILTER.search(request.path) is not None
             if settings.PUBLIC_GET_ONLY and (request.method != "GET"):
                 return False

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -3680,7 +3680,7 @@ def table_get_where_list(request, fileid, conn=None, **kwargs):
         table.close()
 
 
-@login_required()
+@login_required(allowPublicPost=True)
 @jsonp
 def table_slice(request, fileid, conn=None, **kwargs):
     """

--- a/test/unit/test_login_required.py
+++ b/test/unit/test_login_required.py
@@ -166,8 +166,28 @@ def test_is_valid_table_slice_call(monkeypatch):
     monkeypatch.setattr(settings, "PUBLIC_PASSWORD", "password", raising=False)
     monkeypatch.setattr(settings, "PUBLIC_GET_ONLY", True)
     monkeypatch.setattr(settings, "PUBLIC_URL_FILTER", re.compile("^/api"))
-    assert decorator_allow_public_post.is_valid_public_url(1, rf.get("/webgateway/table/123/slice")) is False
-    assert decorator_allow_public_post.is_valid_public_url(1, rf.post("/webgateway/table/123/slice")) is False
+    assert (
+        decorator_allow_public_post.is_valid_public_url(
+            1, rf.get("/webgateway/table/123/slice")
+        )
+        is False
+    )
+    assert (
+        decorator_allow_public_post.is_valid_public_url(
+            1, rf.post("/webgateway/table/123/slice")
+        )
+        is False
+    )
     monkeypatch.setattr(settings, "PUBLIC_URL_FILTER", re.compile("^/api|webgateway"))
-    assert decorator_allow_public_post.is_valid_public_url(1, rf.get("/webgateway/table/123/slice")) is True
-    assert decorator_allow_public_post.is_valid_public_url(1, rf.post("/webgateway/table/123/slice")) is True
+    assert (
+        decorator_allow_public_post.is_valid_public_url(
+            1, rf.get("/webgateway/table/123/slice")
+        )
+        is True
+    )
+    assert (
+        decorator_allow_public_post.is_valid_public_url(
+            1, rf.post("/webgateway/table/123/slice")
+        )
+        is True
+    )

--- a/test/unit/test_login_required.py
+++ b/test/unit/test_login_required.py
@@ -25,6 +25,7 @@ import re
 
 rf = RequestFactory()
 decorator = login_required()
+decorator_allow_public_post = login_required(allowPublicPost=True)
 
 
 def test_is_valid_public_url_default(monkeypatch):
@@ -157,3 +158,16 @@ def test_is_valid_public_url_any_method(monkeypatch):
     assert decorator.is_valid_public_url(1, rf.post("/api/v0/login")) is True
     assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is False
     assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_table_slice_call(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    monkeypatch.setattr(settings, "PUBLIC_USER", "public.user", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_PASSWORD", "password", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_GET_ONLY", True)
+    monkeypatch.setattr(settings, "PUBLIC_URL_FILTER", re.compile("^/api"))
+    assert decorator_allow_public_post.is_valid_public_url(1, rf.get("/webgateway/table/123/slice")) is False
+    assert decorator_allow_public_post.is_valid_public_url(1, rf.post("/webgateway/table/123/slice")) is False
+    monkeypatch.setattr(settings, "PUBLIC_URL_FILTER", re.compile("^/api|webgateway"))
+    assert decorator_allow_public_post.is_valid_public_url(1, rf.get("/webgateway/table/123/slice")) is True
+    assert decorator_allow_public_post.is_valid_public_url(1, rf.post("/webgateway/table/123/slice")) is True

--- a/test/unit/test_login_required.py
+++ b/test/unit/test_login_required.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) Glencoe Software, Inc.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from django.conf import settings
+from django.test.client import RequestFactory
+from omeroweb.webclient.decorators import login_required
+import re
+
+rf = RequestFactory()
+decorator = login_required()
+
+
+def test_is_valid_public_url_default(monkeypatch):
+    assert settings.PUBLIC_ENABLED is False
+    assert not hasattr(settings, "PUBLIC_USER")
+    assert not hasattr(settings, "PUBLIC_PASSWORD")
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_public_url_enabled_no_user(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    assert settings.PUBLIC_ENABLED is True
+    assert not hasattr(settings, "PUBLIC_USER")
+    assert not hasattr(settings, "PUBLIC_PASSWORD")
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_public_url_enabled_no_password(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    monkeypatch.setattr(settings, "PUBLIC_USER", "public.user", raising=False)
+    assert settings.PUBLIC_ENABLED is True
+    assert settings.PUBLIC_USER == "public.user"
+    assert not hasattr(settings, "PUBLIC_PASSWORD")
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_public_url_nofilter(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    monkeypatch.setattr(settings, "PUBLIC_USER", "public.user", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_PASSWORD", "password", raising=False)
+    assert settings.PUBLIC_ENABLED is True
+    assert settings.PUBLIC_USER == "public.user"
+    assert settings.PUBLIC_PASSWORD == "password"
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_public_url_single_filter(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    monkeypatch.setattr(settings, "PUBLIC_USER", "public.user", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_PASSWORD", "password", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_URL_FILTER", re.compile("^/api"))
+    assert settings.PUBLIC_ENABLED is True
+    assert settings.PUBLIC_USER == "public.user"
+    assert settings.PUBLIC_PASSWORD == "password"
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_public_url_multiple_filter(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    monkeypatch.setattr(settings, "PUBLIC_USER", "public.user", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_PASSWORD", "password", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_URL_FILTER", re.compile("^/api|webgateway"))
+    assert settings.PUBLIC_ENABLED is True
+    assert settings.PUBLIC_USER == "public.user"
+    assert settings.PUBLIC_PASSWORD == "password"
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_public_url_exclude_filter(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    monkeypatch.setattr(settings, "PUBLIC_USER", "public.user", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_PASSWORD", "password", raising=False)
+    monkeypatch.setattr(
+        settings,
+        "PUBLIC_URL_FILTER",
+        re.compile("^/api|webgateway/(?!archived_files|download_as)"),
+    )
+    assert settings.PUBLIC_ENABLED is True
+    assert settings.PUBLIC_USER == "public.user"
+    assert settings.PUBLIC_PASSWORD == "password"
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is True
+    assert (
+        decorator.is_valid_public_url(1, rf.get("/webgateway/archived_files/")) is False
+    )
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/download_as/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/render_image/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_public_url_getonly(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    monkeypatch.setattr(settings, "PUBLIC_USER", "public.user", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_PASSWORD", "password", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_URL_FILTER", re.compile("^/api"))
+    assert settings.PUBLIC_ENABLED is True
+    assert settings.PUBLIC_USER == "public.user"
+    assert settings.PUBLIC_PASSWORD == "password"
+    assert settings.PUBLIC_GET_ONLY is True
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is True
+    assert decorator.is_valid_public_url(1, rf.head("/api/")) is False
+    assert decorator.is_valid_public_url(1, rf.post("/api/v0/login")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False
+
+
+def test_is_valid_public_url_any_method(monkeypatch):
+    monkeypatch.setattr(settings, "PUBLIC_ENABLED", True)
+    monkeypatch.setattr(settings, "PUBLIC_USER", "public.user", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_PASSWORD", "password", raising=False)
+    monkeypatch.setattr(settings, "PUBLIC_URL_FILTER", re.compile("^/api"))
+    monkeypatch.setattr(settings, "PUBLIC_GET_ONLY", False)
+    assert settings.PUBLIC_ENABLED is True
+    assert settings.PUBLIC_USER == "public.user"
+    assert settings.PUBLIC_PASSWORD == "password"
+    assert settings.PUBLIC_GET_ONLY is False
+    assert decorator.is_valid_public_url(1, rf.get("/api/")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/api/v0/")) is True
+    assert decorator.is_valid_public_url(1, rf.head("/api/")) is True
+    assert decorator.is_valid_public_url(1, rf.post("/api/v0/login")) is True
+    assert decorator.is_valid_public_url(1, rf.get("/webgateway/")) is False
+    assert decorator.is_valid_public_url(1, rf.get("/webclient/")) is False


### PR DESCRIPTION
### Important: The implementation approach has changed again as of July 29, 2026, relevant discussion starting at https://github.com/ome/omero-web/pull/679#issuecomment-5116214618.

---

With the introduction of the table slice call in https://github.com/ome/omero-web/pull/564, the option to use `POST` requests (in addition to `GET`) was included to allow for large number of rows to be fetched in one request. `GET` requests are limited by the maximum length of URIs.

An issue not previously considered is when `omero.web.public.enabled` is enabled in combination with `omero.web.public.get_only`.  In that case there is no way to use `POST` for the table slice call. All `POST` requests would have to be allowed.

~~This PR proposes a new setting to selectively allow `POST` for some URLs, similar to how a set of URLs can be enabled for public mode.~~

~~With the latest commits, this PR adds a new setting to allow flexible configuration of URLs per request method, without impacting the functionality of the current settings, i.e. if this new setting is not configured, the behavior remains unchanged.~~

~~Example:~~

```bash
omero config set omero.web.public.url_filter_by_method '{"POST": "^/webgateway/table/\d+/slice/"}'
```

~~This may not be the best or simplest approach, any thoughts or ideas on how else we could approach this?~~

~~Some tests for the old and new settings have been added via https://github.com/ome/openmicroscopy/pull/6460~~

cc: @will-moore @sbesson @jburel 