### PR TITLE
Relax Python<3.13 requirement for OMERO.web

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url="https://github.com/ome/omero-web/",
     license="GPLv2+",
     packages=find_packages(exclude=("test",)) + ["omero.plugins"],
-    python_requires=">=3.10",
+    python_requires=">=3.10,<3.15",
     install_requires=[
         # requires Ice (use wheel for faster installs)
         "omero-py>=5.19.0",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url="https://github.com/ome/omero-web/",
     license="GPLv2+",
     packages=find_packages(exclude=("test",)) + ["omero.plugins"],
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10",
     install_requires=[
         # requires Ice (use wheel for faster installs)
         "omero-py>=5.19.0",


### PR DESCRIPTION
As Django 5.2 is the requirement since OMERO.web 5.31.0, the package should be compatible with all versions of Python greater than 3.10