### PR TITLE
Initial support for JSON api /annotations endpoint

### DIFF
--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -410,8 +410,9 @@ GET Annotations, using omero-marshal to generate json
 """
 
 api_namedannotations = re_path(
-    r"^v(?P<api_version>%s)/m/(?P<ann_type>file|map|tag|long|timestamp|comment|boolean|double|xml|term)annotations/$"
-    % versions,
+    r"^v(?P<api_version>%s)/m/"
+    r"(?P<ann_type>file|map|tag|long|timestamp|comment|boolean|double|xml|term)"
+    r"annotations/$" % versions,
     views.AnnotationsView.as_view(),
     name="api_namedannotations",
 )

--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -400,6 +400,16 @@ api_experimenter_groups = re_path(
 GET Groups that an Experimenter is in, using omero-marshal to generate json
 """
 
+api_annotations = re_path(
+    r"^v(?P<api_version>%s)/m/annotations/$" % versions,
+    views.AnnotationsView.as_view(),
+    name="api_annotations",
+)
+"""
+GET Annotations, using omero-marshal to generate json
+"""
+
+
 urlpatterns = [
     api_versions,
     api_base,
@@ -443,4 +453,5 @@ urlpatterns = [
     api_groups,
     api_group,
     api_experimenter_groups,
+    api_annotations,
 ]

--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -410,7 +410,8 @@ GET Annotations, using omero-marshal to generate json
 """
 
 api_namedannotations = re_path(
-    r"^v(?P<api_version>%s)/m/(?P<ann_type>file|map|tag|long|timestamp|comment|boolean|double|xml|term)annotations/$" % versions,
+    r"^v(?P<api_version>%s)/m/(?P<ann_type>file|map|tag|long|timestamp|comment|boolean|double|xml|term)annotations/$"
+    % versions,
     views.AnnotationsView.as_view(),
     name="api_namedannotations",
 )

--- a/omeroweb/api/urls.py
+++ b/omeroweb/api/urls.py
@@ -409,6 +409,14 @@ api_annotations = re_path(
 GET Annotations, using omero-marshal to generate json
 """
 
+api_namedannotations = re_path(
+    r"^v(?P<api_version>%s)/m/(?P<ann_type>file|map|tag|long|timestamp|comment|boolean|double|xml|term)annotations/$" % versions,
+    views.AnnotationsView.as_view(),
+    name="api_namedannotations",
+)
+"""
+GET Annotations, using omero-marshal to generate json
+"""
 
 urlpatterns = [
     api_versions,
@@ -454,4 +462,5 @@ urlpatterns = [
     api_group,
     api_experimenter_groups,
     api_annotations,
+    api_namedannotations,
 ]

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -93,6 +93,10 @@ def api_base(request, api_version=None, **kwargs):
         "url:save": build_url(request, "api_save", v),
         "url:schema": OME_SCHEMA_URL,
     }
+    for atype in ("file", "map", "tag", "long", "timestamp", "comment",
+                  "boolean", "double", "xml", "term"):
+        rv["url:%sannotations" % atype] = build_url(
+            request, "api_namedannotations", v, ann_type=atype)
     return rv
 
 

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -474,8 +474,9 @@ class ObjectsView(ApiView):
         group = getIntOrDefault(request, "group", -1)
         normalize = request.GET.get("normalize", False) == "true"
         # Get the data
-        marshalled = query_objects(conn, self.get_omero_type(request),
-                                   group, opts, normalize)
+        marshalled = query_objects(
+            conn, self.get_omero_type(request), group, opts, normalize
+        )
         for m in marshalled["data"]:
             self.add_data(m, request, conn, self.urls, **kwargs)
         return marshalled
@@ -883,6 +884,7 @@ class AnnotationsView(ObjectsView):
         elif ann_type is not None:
             raise BadRequestError("Invalid annotation type: %s" % ann_type)
         return super(AnnotationsView, self).get(request, conn, **kwargs)
+
 
 class ExperimentersView(ObjectsView):
     """Handles GET for /experimenters/ to list Experimenters."""

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -790,25 +790,49 @@ class ShapesView(ObjectsView):
 class AnnotationsView(ObjectsView):
     """Handles GET for /annotations/ to list available Annotations."""
 
+    # OMERO_TYPE is set to "Annotation" by default, but can be changed
+    # by get_opts() to a specific annotation type.
     OMERO_TYPE = "Annotation"
 
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(AnnotationsView, self).get_opts(request, **kwargs)
 
-        # TODO: add more types?
-        for key in ["image", "dataset", "project", "screen", "plate", "well",
-                    "plateacquisition", "roi"]:
+        # All annotatable objects
+        otypes = ["Annotation", "Channel", "Dataset", "Detector", "Dichroic",
+                  "Experimenter", "ExperimenterGroup", "Fileset", "Filter",
+                  "Folder", "Image", "Instrument", "LightPath", "LightSource",
+                  "Namespace", "Node", "Objective", "OriginalFile", "PlaneInfo",
+                  "PlateAcquisition", "Plate", "Project", "Reagent", "Roi",
+                  "Screen", "Session", "Shape", "Well"]
+        request_otypes = {}
+        for key in otypes:
+            # parent_type is case-insensitive...
+            # but the JSON api expects lower-case
+            key = key.lower()
             ids = request.GET.getlist(key)
             if len(ids) > 0:
-                opts["parent_type"] = key
-                opts["parent_ids"] = [int(i) for i in ids]
-                break
+                request_otypes[key] = [int(i) for i in ids]
+        # Check that only ONE parent type is specified
+        if len(request_otypes) > 1:
+            raise BadRequestError(
+                "Can only filter by one parent type at a time. "
+                "Found: %s" % ", ".join(request_otypes.keys())
+            )
+        elif len(request_otypes) == 1:
+            opts["parent_type"] = list(request_otypes.keys())[0]
+            opts["parent_ids"] = request_otypes[opts["parent_type"]]
+
         if request.GET.get("ns") is not None:
             opts["ns"] = request.GET.get("ns")
         ann_type = request.GET.get("type")
-        if ann_type in ("file", "map", "tag", "rating", "long", "comment"):
-            opts["ann_type"] = ann_type
+
+        # Not strictly a pure function, but we need to set the OMERO_TYPE
+        if ann_type in ("file", "map", "tag", "long", "timestamp",
+                        "comment", "boolean", "double", "xml", "term"):
+            self.OMERO_TYPE = ann_type.capitalize() + "Annotation"
+        elif ann_type is not None:
+            raise BadRequestError("Invalid annotation type: %s" % ann_type)
 
         return opts
 

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -787,6 +787,7 @@ class ShapesView(ObjectsView):
 
         return marshalled
 
+
 class AnnotationsView(ObjectsView):
     """Handles GET for /annotations/ to list available Annotations."""
 
@@ -799,12 +800,36 @@ class AnnotationsView(ObjectsView):
         opts = super(AnnotationsView, self).get_opts(request, **kwargs)
 
         # All annotatable objects
-        otypes = ["Annotation", "Channel", "Dataset", "Detector", "Dichroic",
-                  "Experimenter", "ExperimenterGroup", "Fileset", "Filter",
-                  "Folder", "Image", "Instrument", "LightPath", "LightSource",
-                  "Namespace", "Node", "Objective", "OriginalFile", "PlaneInfo",
-                  "PlateAcquisition", "Plate", "Project", "Reagent", "Roi",
-                  "Screen", "Session", "Shape", "Well"]
+        otypes = [
+            "Annotation",
+            "Channel",
+            "Dataset",
+            "Detector",
+            "Dichroic",
+            "Experimenter",
+            "ExperimenterGroup",
+            "Fileset",
+            "Filter",
+            "Folder",
+            "Image",
+            "Instrument",
+            "LightPath",
+            "LightSource",
+            "Namespace",
+            "Node",
+            "Objective",
+            "OriginalFile",
+            "PlaneInfo",
+            "PlateAcquisition",
+            "Plate",
+            "Project",
+            "Reagent",
+            "Roi",
+            "Screen",
+            "Session",
+            "Shape",
+            "Well",
+        ]
         request_otypes = {}
         for key in otypes:
             # parent_type is case-insensitive...
@@ -828,8 +853,18 @@ class AnnotationsView(ObjectsView):
         ann_type = request.GET.get("type")
 
         # Not strictly a pure function, but we need to set the OMERO_TYPE
-        if ann_type in ("file", "map", "tag", "long", "timestamp",
-                        "comment", "boolean", "double", "xml", "term"):
+        if ann_type in (
+            "file",
+            "map",
+            "tag",
+            "long",
+            "timestamp",
+            "comment",
+            "boolean",
+            "double",
+            "xml",
+            "term",
+        ):
             self.OMERO_TYPE = ann_type.capitalize() + "Annotation"
         elif ann_type is not None:
             raise BadRequestError("Invalid annotation type: %s" % ann_type)

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -23,6 +23,7 @@ from django.views.generic import View
 from django.middleware import csrf
 from django.utils.decorators import method_decorator
 from django.urls import reverse
+from requests import request
 from . import api_settings
 
 import traceback
@@ -442,6 +443,10 @@ class ExperimenterGroupView(ObjectView):
 class ObjectsView(ApiView):
     """Base class for listing objects."""
 
+    def get_omero_type(self, request):
+        """Allow dynamic omero type, e.g. for AnnotationsView."""
+        return self.OMERO_TYPE
+
     def get_opts(self, request, **kwargs):
         """Return an options dict based on request parameters."""
         try:
@@ -469,7 +474,8 @@ class ObjectsView(ApiView):
         group = getIntOrDefault(request, "group", -1)
         normalize = request.GET.get("normalize", False) == "true"
         # Get the data
-        marshalled = query_objects(conn, self.OMERO_TYPE, group, opts, normalize)
+        marshalled = query_objects(conn, self.get_omero_type(request),
+                                   group, opts, normalize)
         for m in marshalled["data"]:
             self.add_data(m, request, conn, self.urls, **kwargs)
         return marshalled
@@ -791,8 +797,6 @@ class ShapesView(ObjectsView):
 class AnnotationsView(ObjectsView):
     """Handles GET for /annotations/ to list available Annotations."""
 
-    # OMERO_TYPE is set to "Annotation" by default, but can be changed
-    # by get_opts() to a specific annotation type.
     OMERO_TYPE = "Annotation"
 
     def get_opts(self, request, **kwargs):
@@ -850,9 +854,19 @@ class AnnotationsView(ObjectsView):
 
         if request.GET.get("ns") is not None:
             opts["ns"] = request.GET.get("ns")
-        ann_type = request.GET.get("type")
 
-        # Not strictly a pure function, but we need to set the OMERO_TYPE
+        return opts
+
+    def get(self, request, conn=None, **kwargs):
+        """Override get() to allow filtering by annotation type."""
+
+        # set self.OMERO_TYPE, then call super().get() to get the list of Annotations
+        # E.g. conn.getObjects("TagAnnotation") - not actually case-sensitive
+        # We support /tagannotations/
+        ann_type = kwargs.get("ann_type", None)
+        # OR /annotations/?type=tag
+        if ann_type is None:
+            ann_type = request.GET.get("type")
         if ann_type in (
             "file",
             "map",
@@ -868,9 +882,7 @@ class AnnotationsView(ObjectsView):
             self.OMERO_TYPE = ann_type.capitalize() + "Annotation"
         elif ann_type is not None:
             raise BadRequestError("Invalid annotation type: %s" % ann_type)
-
-        return opts
-
+        return super(AnnotationsView, self).get(request, conn, **kwargs)
 
 class ExperimentersView(ObjectsView):
     """Handles GET for /experimenters/ to list Experimenters."""

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -93,10 +93,21 @@ def api_base(request, api_version=None, **kwargs):
         "url:save": build_url(request, "api_save", v),
         "url:schema": OME_SCHEMA_URL,
     }
-    for atype in ("file", "map", "tag", "long", "timestamp", "comment",
-                  "boolean", "double", "xml", "term"):
+    for atype in (
+        "file",
+        "map",
+        "tag",
+        "long",
+        "timestamp",
+        "comment",
+        "boolean",
+        "double",
+        "xml",
+        "term",
+    ):
         rv["url:%sannotations" % atype] = build_url(
-            request, "api_namedannotations", v, ann_type=atype)
+            request, "api_namedannotations", v, ann_type=atype
+        )
     return rv
 
 

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -23,7 +23,6 @@ from django.views.generic import View
 from django.middleware import csrf
 from django.utils.decorators import method_decorator
 from django.urls import reverse
-from requests import request
 from . import api_settings
 
 import traceback

--- a/omeroweb/api/views.py
+++ b/omeroweb/api/views.py
@@ -86,6 +86,7 @@ def api_base(request, api_version=None, **kwargs):
         "url:screens": build_url(request, "api_screens", v),
         "url:plates": build_url(request, "api_plates", v),
         "url:rois": build_url(request, "api_rois", v),
+        "url:annotations": build_url(request, "api_annotations", v),
         "url:token": build_url(request, "api_token", v),
         "url:servers": build_url(request, "api_servers", v),
         "url:login": build_url(request, "api_login", v),
@@ -785,6 +786,31 @@ class ShapesView(ObjectsView):
             marshalled["url:roi"] = url
 
         return marshalled
+
+class AnnotationsView(ObjectsView):
+    """Handles GET for /annotations/ to list available Annotations."""
+
+    OMERO_TYPE = "Annotation"
+
+    def get_opts(self, request, **kwargs):
+        """Add extra parameters to the opts dict."""
+        opts = super(AnnotationsView, self).get_opts(request, **kwargs)
+
+        # TODO: add more types?
+        for key in ["image", "dataset", "project", "screen", "plate", "well",
+                    "plateacquisition", "roi"]:
+            ids = request.GET.getlist(key)
+            if len(ids) > 0:
+                opts["parent_type"] = key
+                opts["parent_ids"] = [int(i) for i in ids]
+                break
+        if request.GET.get("ns") is not None:
+            opts["ns"] = request.GET.get("ns")
+        ann_type = request.GET.get("type")
+        if ann_type in ("file", "map", "tag", "rating", "long", "comment"):
+            opts["ann_type"] = ann_type
+
+        return opts
 
 
 class ExperimentersView(ObjectsView):


### PR DESCRIPTION
Fixes #532 - also discussed at #635

This wraps https://github.com/ome/omero-py/pull/489 and passes query parameters to getObjects().

Adds support for `/api/v0/m/annotations/` endpoint, with various query parameters:
 - "image", "dataset", "project", "screen", "plate", "well", "plateacquisition", "roi"
 - ns
 - types of annotation, ("file", "map", "tag", "long", "comment" etc) accessed via e.g. `/api/v0/m/mapannotations/`

E.g:
 - /api/v0/m/annotations/?type=map&dataset=251&dataset=102
 - /api/v0/m/fileannotations/?project=102&limit=5&offset=1&ns=openmicroscopy.org/omero/bulk_annotations