### PR TITLE
Post data save imgRdef

### DIFF
--- a/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -117,8 +117,8 @@
             }
             jQuery.ajax({
                 type: "POST",
-                url: viewport.viewport_server + '/saveImgRDef/'+viewport.loadedImg.id+'/?'+viewport.getQuery(true),
-                data: {},
+                url: viewport.viewport_server + '/saveImgRDef/'+viewport.loadedImg.id+'/',
+                data: viewport.getQuery(true),
                 success: cb(true),
                 error: cb(false),
                 dataType: "jsonp",

--- a/omeroweb/webgateway/views.py
+++ b/omeroweb/webgateway/views.py
@@ -211,6 +211,9 @@ def validate_rdef_query(func):
         r = None
         try:
             r = request.GET
+            # POST may include request params in URL (GET), so we check...
+            if "c" not in r and request.method == "POST":
+                r = request.POST
         except Exception:
             return HttpResponseServerError("Endpoint improperly configured")
 
@@ -890,6 +893,8 @@ def _get_prepared_image(
     @return:            Tuple (L{omero.gateway.ImageWrapper} image, quality)
     """
     r = request.GET
+    if "c" not in r and request.method == "POST":
+        r = request.POST
     logger.debug(
         "Preparing Image:%r saveDefs=%r "
         "retry=%r request=%r conn=%s" % (iid, saveDefs, retry, r, str(conn))


### PR DESCRIPTION
This is part of a fix for https://github.com/ome/omero-iviewer/issues/545

To avoid issues with long URL request parameters when saving rendering settings, we use the POST `data` (instead of the URL).
The `saveImgRdef` endpoint will now accept both forms.
The Preview "webgateway" viewer uses the POST `data` to handle the params. This doesn't need any change in construction of the query string or the parsing of the parameters in Django.

To test:

 - Import an image with lots of channels (either a fake file or the sample from user above - Zenodo link at https://github.com/ome/omero-iviewer/issues/542#issuecomment-4841879057)
 - Try to save new rendering settings (or a server with e.g. 4k request limit - not local dev server!)
 - Test saving without using `data` for POST params - e.g. by using iviewer (*without https://github.com/ome/omero-iviewer/pull/546*), to check that endpoint works with both forms