### PR TITLE
add config "omero.web.annotation_order"

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -222,6 +222,7 @@ def check_session_engine(s):
         )
     return s
 
+
 def parse_annotation_order(value):
     try:
         parsed = json.loads(value)
@@ -231,6 +232,7 @@ def parse_annotation_order(value):
         pass
 
     return str(value)
+
 
 CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
 CUSTOM_HOST = CUSTOM_SETTINGS.get("omero.master.host", CUSTOM_HOST)
@@ -1017,7 +1019,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
             "A value of 0 or -1 pre-selects All groups."
         ),
     ],
-    "omero.web.annotation_order":[
+    "omero.web.annotation_order": [
         "ANNOTATION_ORDER",
         "namespace",
         parse_annotation_order,

--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -222,6 +222,15 @@ def check_session_engine(s):
         )
     return s
 
+def parse_annotation_order(value):
+    try:
+        parsed = json.loads(value)
+        if isinstance(parsed, list):
+            return parsed
+    except Exception:
+        pass
+
+    return str(value)
 
 CUSTOM_HOST = CUSTOM_SETTINGS.get("Ice.Default.Host", "localhost")
 CUSTOM_HOST = CUSTOM_SETTINGS.get("omero.master.host", CUSTOM_HOST)
@@ -1006,6 +1015,16 @@ CUSTOM_SETTINGS_MAPPINGS = {
         (
             "ID of the group to pre-select in search form. "
             "A value of 0 or -1 pre-selects All groups."
+        ),
+    ],
+    "omero.web.annotation_order":[
+        "ANNOTATION_ORDER",
+        "namespace",
+        parse_annotation_order,
+        (
+            "Controls annotation ordering. "
+            "Allowed values are 'namespace', 'date', or a JSON list "
+            "of namespaces defining a custom order"
         ),
     ],
     "omero.web.ui.top_links": [

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -2008,20 +2008,18 @@ def marshal_annotations(
     service_opts.setOmeroGroup(group_id)
 
     # Determine annotation order
-    annotation_order = getattr(settings,"ANNOTATION_ORDER", None)
+    annotation_order = getattr(settings, "ANNOTATION_ORDER", None)
     order_by = "ch.ns"
     if annotation_order == "date":
         order_by = "ch.details.creationEvent.time"
 
     elif isinstance(annotation_order, (list, tuple)) and len(annotation_order):
-        #build a case statement to order by the configured namespaces
+        # build a case statement to order by the configured namespaces
         case_parts = []
-        
+
         for pos, namespace in enumerate(annotation_order):
-            namespace = namespace.replace("'","''")
-            case_parts.append(
-                "when ch.ns = '%s' then %d" % (namespace,pos)
-            )
+            namespace = namespace.replace("'", "''")
+            case_parts.append("when ch.ns = '%s' then %d" % (namespace, pos))
 
         # Sort by configured position first, then namespace
         order_by = """
@@ -2031,7 +2029,6 @@ def marshal_annotations(
             end,
             ch.ns
         """ % "\n".join(case_parts)
-
 
     where_clause = ["pa.id in (:ids)"]
     # if experimenter_id is not None and experimenter_id != -1:
@@ -2102,9 +2099,8 @@ def marshal_annotations(
             dtype,
             "join fetch pa.plate" if dtype == "Well" else "",
             " and ".join(where_clause),
-            order_by
+            order_by,
         )
-
 
         for link in qs.findAllByQuery(q, params, service_opts):
             ann = link.child

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -2093,8 +2093,7 @@ def marshal_annotations(
             left outer join fetch oal.child as ch
             left outer join fetch oal.parent as pa
             join fetch ch.details.creationEvent
-            join fetch ch.details.owner 
-            %s
+            join fetch ch.details.owner %s
             left outer join fetch ch.file as file
             where %s
             order by %s

--- a/omeroweb/webclient/tree.py
+++ b/omeroweb/webclient/tree.py
@@ -2007,6 +2007,32 @@ def marshal_annotations(
         group_id = -1
     service_opts.setOmeroGroup(group_id)
 
+    # Determine annotation order
+    annotation_order = getattr(settings,"ANNOTATION_ORDER", None)
+    order_by = "ch.ns"
+    if annotation_order == "date":
+        order_by = "ch.details.creationEvent.time"
+
+    elif isinstance(annotation_order, (list, tuple)) and len(annotation_order):
+        #build a case statement to order by the configured namespaces
+        case_parts = []
+        
+        for pos, namespace in enumerate(annotation_order):
+            namespace = namespace.replace("'","''")
+            case_parts.append(
+                "when ch.ns = '%s' then %d" % (namespace,pos)
+            )
+
+        # Sort by configured position first, then namespace
+        order_by = """
+            case
+                %s
+                else 999999
+            end,
+            ch.ns
+        """ % "\n".join(case_parts)
+
+
     where_clause = ["pa.id in (:ids)"]
     # if experimenter_id is not None and experimenter_id != -1:
     #     params.addId('eid', rlong(experimenter_id))
@@ -2067,14 +2093,18 @@ def marshal_annotations(
             left outer join fetch oal.child as ch
             left outer join fetch oal.parent as pa
             join fetch ch.details.creationEvent
-            join fetch ch.details.owner %s
+            join fetch ch.details.owner 
+            %s
             left outer join fetch ch.file as file
-            where %s order by ch.ns
+            where %s
+            order by %s
             """ % (
             dtype,
             "join fetch pa.plate" if dtype == "Well" else "",
             " and ".join(where_clause),
+            order_by
         )
+
 
         for link in qs.findAllByQuery(q, params, service_opts):
             ann = link.child


### PR DESCRIPTION
This accepts values of 'namespace', 'date', or a list JSON list of namespaces.

This affects the order of the annotation groups (namespaces) in the right pane of the webclient. Currently the code hardcodes based on the namespace name. This allows to specify order based on the namespace name (default), date (of creation), or a JSON list. For the JSON list, it will order based on the list, and then default to the namespace name. 

This allows flexibility from system administrators on how they want to display the data to ensure the most relevant annotations are at the top without having to resort to ascii-ordered naming conventions.

**Examples:**
omero config set omero.web.annotation_order namespace
omero config set omero.web.annotation_order date
omero config set omero.web.annotation_order '["my_annotation/space/group4","my_annotation/space/sample2","my_annotation/space/group2"]'