### PR TITLE
Prepare chgrp 'update' response before chgrp submission

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -4678,6 +4678,45 @@ def chgrp(request, conn=None, **kwargs):
     """
     if not request.method == "POST":
         return JsonResponse({"Error": "Need to POST to chgrp"}, status=405)
+
+    # JSON response contains a list of images/containers that need to be
+    # updated, based on the POST info and initial state BEFORE chgrp
+
+    project_ids = request.POST.get("Project", [])
+    dataset_ids = request.POST.get("Dataset", [])
+    image_ids = request.POST.get("Image", [])
+    screen_ids = request.POST.get("Screen", [])
+    plate_ids = request.POST.get("Plate", [])
+
+    if project_ids:
+        project_ids = [int(x) for x in project_ids.split(",")]
+    if dataset_ids:
+        dataset_ids = [int(x) for x in dataset_ids.split(",")]
+    if image_ids:
+        image_ids = [int(x) for x in image_ids.split(",")]
+    if screen_ids:
+        screen_ids = [int(x) for x in screen_ids.split(",")]
+    if plate_ids:
+        plate_ids = [int(x) for x in plate_ids.split(",")]
+
+    # TODO Change this user_id to be an experimenter_id in the request as it
+    # is possible that a user is chgrping data from another user so it is
+    # that users orphaned that will need updating. Or maybe all orphaned
+    # directories could potentially need updating?
+
+    # Create a list of objects that have been changed by this operation. This
+    # can be used by the client to visually update.
+    to_be_updated = getAllObjects(
+        conn,
+        project_ids,
+        dataset_ids,
+        image_ids,
+        screen_ids,
+        plate_ids,
+        request.session.get("user_id"),
+    )
+
+    # THEN we do the actual chgrp submission...
     # Get the target group_id
     group_id = getIntOrDefault(request, "group_id", None)
     if group_id is None:
@@ -4744,45 +4783,8 @@ def chgrp(request, conn=None, **kwargs):
             }
             request.session.modified = True
 
-    # Update contains a list of images/containers that need to be
-    # updated.
-
-    project_ids = request.POST.get("Project", [])
-    dataset_ids = request.POST.get("Dataset", [])
-    image_ids = request.POST.get("Image", [])
-    screen_ids = request.POST.get("Screen", [])
-    plate_ids = request.POST.get("Plate", [])
-
-    if project_ids:
-        project_ids = [int(x) for x in project_ids.split(",")]
-    if dataset_ids:
-        dataset_ids = [int(x) for x in dataset_ids.split(",")]
-    if image_ids:
-        image_ids = [int(x) for x in image_ids.split(",")]
-    if screen_ids:
-        screen_ids = [int(x) for x in screen_ids.split(",")]
-    if plate_ids:
-        plate_ids = [int(x) for x in plate_ids.split(",")]
-
-    # TODO Change this user_id to be an experimenter_id in the request as it
-    # is possible that a user is chgrping data from another user so it is
-    # that users orphaned that will need updating. Or maybe all orphaned
-    # directories could potentially need updating?
-
-    # Create a list of objects that have been changed by this operation. This
-    # can be used by the client to visually update.
-    update = getAllObjects(
-        conn,
-        project_ids,
-        dataset_ids,
-        image_ids,
-        screen_ids,
-        plate_ids,
-        request.session.get("user_id"),
-    )
-
-    # return HttpResponse("OK")
-    return JsonResponse({"update": update})
+    print("chgrp: %s" % to_be_updated)
+    return JsonResponse({"update": to_be_updated})
 
 
 @login_required()


### PR DESCRIPTION
This should fix the intermittent failing test described at https://github.com/ome/openmicroscopy/issues/6468#issuecomment-5314214066

The `chgrp` POST action previously kicks-off the `chgrp` action first (which normally takes a while), *then*, while the chgrp is running, it builds a JSON response that represents the parents of the `chgrp` objects *BEFORE* the chgrp happend etc, so that the webclient knows which previous state to update.
Test was failing because the `chgrp` action was sometimes happening very fast, so the response actually was built *after* the chgrp completed.
To be sure that the JSON response represents the state *before* chgrp, we build that JSON before starting the chgrp.

E.g. failed at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/58/ and 
https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/55/