### PR TITLE
Preserve formatting in script activity messages

### DIFF
--- a/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -835,6 +835,14 @@ li.menu_back a {
 			    color: #666;
 			}
 
+			#activities_content tr.script .activity_title + .message {
+				clear: both;
+				display: block;
+				margin-top: 0.25rem;
+				white-space: pre-wrap;
+				font-family: ui-monospace, Consolas, "Liberation Mono", monospace;
+			}
+
 
 			#activities_panel tr.hidden {
 			    display: none;
@@ -1197,5 +1205,3 @@ li.menu_back a {
     left: 0;
     right: 0;
 }
-
-


### PR DESCRIPTION
## Summary

OMERO script `Message` outputs may contain multiline or whitespace-sensitive
content, such as reports, tracebacks, tables, and command output.

The Activities panel currently renders these messages as ordinary text,
causing newlines and repeated spaces to collapse.

This PR adds narrowly scoped styling for script result messages so that they:

- begin below the floated action buttons instead of flowing alongside them;
- preserve explicit newlines and repeated spaces while still allowing long lines to wrap;
- use a monospace font for predictable alignment;
- have a small visual separation from the script title.

The selector only targets messages in script activity rows. Other activity
types are unaffected.

I'll add it via `base_include_template`, but thought you might want it upstream too?

## Testing

Manually verified in a local OMERO.web deployment by loading the same CSS rule
through `omero.web.base_include_template`.

Tested with ordinary reports and a script that returns multiline ASCII
output through its `Message` result. Explicit whitespace is preserved, while
long output continues to wrap within the Activities panel.

A minimal test script is available at:
https://github.com/NL-BioImaging/cowscript/blob/master/Cow.py

## Screenshots

| Before | After |
| --- | --- |
| <img width="480" alt="Script output before formatting fix" src="https://github.com/user-attachments/assets/55a0b254-8ea6-4aad-9555-26c669223300"> | <img width="480" alt="Script output after formatting fix" src="https://github.com/user-attachments/assets/ed6fc251-1990-4fa5-a9a9-a7557a805447"> |
